### PR TITLE
Handle SSH_MSG_DEBUG and SSH_MSG_IGNORE per RFC 4253

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,23 +10,17 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout misshod
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: misshod
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.16.0
       - name: Build test
         run: zig build test
         working-directory: misshod
       - name: Build lib
         run: zig build
         working-directory: misshod
-      - name: Build mssh
-        run: zig build
-        working-directory: misshod/mssh
-      - name: Build msshd
-        run: zig build
-        working-directory: misshod/msshd
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+.zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -15,14 +15,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("misshod", .{
+    const mod = b.addModule("misshod", .{
         .root_source_file = b.path("src/misshod.zig"),
     });
+    _ = mod;
 
-    const lib_tests = b.addTest(.{
+    const test_mod = b.createModule(.{
         .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
+    });
+
+    const lib_tests = b.addTest(.{
+        .root_module = test_mod,
     });
 
     const run_lib_tests = b.addRunArtifact(lib_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "misshod",
+    .name = .misshod,
     .version = "0.0.1",
     .minimum_zig_version = "0.14.0",
+    .fingerprint = 0x717071158aa8520c,
 
     .dependencies = .{
     },

--- a/mssh/build.zig
+++ b/mssh/build.zig
@@ -16,21 +16,24 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "mssh",
+    const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
     });
-    exe.addIncludePath(b.path("src/"));
 
     const misshod_dep = b.dependency("misshod", .{
         .target = target,
         .optimize = optimize,
     });
-    const misshod_mod = misshod_dep.module("misshod");
-    exe.root_module.addImport("misshod", misshod_mod);
+    exe_mod.addImport("misshod", misshod_dep.module("misshod"));
+
+    const exe = b.addExecutable(.{
+        .name = "mssh",
+        .root_module = exe_mod,
+    });
+    exe.addIncludePath(b.path("src/"));
 
     b.installArtifact(exe);
 

--- a/mssh/build.zig.zon
+++ b/mssh/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "mssh",
+    .name = .mssh,
     .version = "0.0.1",
+    .fingerprint = 0xa2b4c6d8e0f1a3b5,
     .dependencies = .{
         .misshod = .{ .path = ".." },
     },

--- a/msshd/build.zig
+++ b/msshd/build.zig
@@ -16,21 +16,24 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "msshd",
+    const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
     });
-    exe.addIncludePath(b.path("src/"));
 
     const misshod_dep = b.dependency("misshod", .{
         .target = target,
         .optimize = optimize,
     });
-    const misshod_mod = misshod_dep.module("misshod");
-    exe.root_module.addImport("misshod", misshod_mod);
+    exe_mod.addImport("misshod", misshod_dep.module("misshod"));
+
+    const exe = b.addExecutable(.{
+        .name = "msshd",
+        .root_module = exe_mod,
+    });
+    exe.addIncludePath(b.path("src/"));
 
     b.installArtifact(exe);
 

--- a/msshd/build.zig.zon
+++ b/msshd/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "mssh",
+    .name = .msshd,
     .version = "0.0.1",
+    .fingerprint = 0xc3d5e7f9a1b2c4d6,
     .dependencies = .{
         .misshod = .{ .path = ".." },
     },

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -655,6 +655,22 @@ pub const Session = struct {
             @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT), @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle); // FIXME reason code
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/privkey.zig
+++ b/src/privkey.zig
@@ -38,7 +38,7 @@ fn decodeAsciiToBinary(keydata_ascii: []const u8, keydata_bin_buf: []u8) PrivKey
     if (b64_slice_opt) |b64_slice| {
         TRACEDUMP(.Debug, "b64", .{}, b64_slice);
         var decoder = std.base64.Base64DecoderWithIgnore.init(std.base64.standard_alphabet_chars, '=', "\n");
-        const decoded_size = try decoder.calcSizeUpperBound(b64_slice.len);
+        const decoded_size = decoder.calcSizeUpperBound(b64_slice.len);
         if (decoded_size > keydata_bin_buf.len) {
             return PrivKeyError.PrivKeyOutofSpace;
         }

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -266,3 +266,20 @@ pub fn wrapPkt(rand:*std.Random, encrypted:bool, keysuni:*KeyDataUni, buffer: *B
     }
 }
 
+test "MsgId enum values match SSH RFC" {
+    // RFC 4253 transport layer messages
+    try std.testing.expectEqual(@as(u8, 1), @intFromEnum(MsgId.SSH_MSG_DISCONNECT));
+    try std.testing.expectEqual(@as(u8, 2), @intFromEnum(MsgId.SSH_MSG_IGNORE));
+    try std.testing.expectEqual(@as(u8, 3), @intFromEnum(MsgId.SSH_MSG_UNIMPLEMENTED));
+    try std.testing.expectEqual(@as(u8, 4), @intFromEnum(MsgId.SSH_MSG_DEBUG));
+
+    // RFC 4254 channel messages
+    try std.testing.expectEqual(@as(u8, 90), @intFromEnum(MsgId.SSH_MSG_CHANNEL_OPEN));
+    try std.testing.expectEqual(@as(u8, 94), @intFromEnum(MsgId.SSH_MSG_CHANNEL_DATA));
+    try std.testing.expectEqual(@as(u8, 96), @intFromEnum(MsgId.SSH_MSG_CHANNEL_EOF));
+}
+
+test "MaxPayload is reasonable" {
+    try std.testing.expect(MaxPayload > 0);
+    try std.testing.expect(MaxPayload < MaxSSHPacket);
+}

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -22,7 +22,9 @@ pub const CommDir = enum {
 // https://datatracker.ietf.org/doc/html/rfc4250#section-4.1.2
 pub const MsgId = enum(u8) {
     SSH_MSG_DISCONNECT = 1,
+    SSH_MSG_IGNORE = 2,
     SSH_MSG_UNIMPLEMENTED = 3,
+    SSH_MSG_DEBUG = 4,
     SSH_MSG_SERVICE_REQUEST = 5,
     SSH_MSG_SERVICE_ACCEPT = 6,
     SSH_MSG_KEXINIT = 20,

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -651,6 +651,22 @@ pub const Session = struct {
             @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT), @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle); // FIXME reason code
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/test.zig
+++ b/src/test.zig
@@ -6,4 +6,5 @@ comptime {
     _ = @import("buffer.zig");
     _ = @import("hasher.zig");
     _ = @import("aesctr.zig");
+    _ = @import("protocol.zig");
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -13,8 +13,7 @@ const trace_level: TraceLevel = .Info;
 pub fn trace(level: TraceLevel, comptime fmt: []const u8, args: anytype) void {
     if (builtin.os.tag != .freestanding) {
         if (@intFromEnum(trace_level) >= @intFromEnum(level)) {
-            const writer = std.io.getStdErr().writer();
-            _ = writer.print(fmt ++ "\n", args) catch 0;
+            std.debug.print(fmt ++ "\n", args);
         }
     }
 }
@@ -22,9 +21,8 @@ pub fn trace(level: TraceLevel, comptime fmt: []const u8, args: anytype) void {
 pub fn tracedump(level: TraceLevel, comptime fmt: []const u8, args: anytype, data: []const u8) void {
     if (builtin.os.tag != .freestanding) {
         if (@intFromEnum(trace_level) >= @intFromEnum(level)) {
-            const writer = std.io.getStdErr().writer();
-            _ = writer.print(fmt ++ "\n", args) catch 0;
-            _ = dump(writer, data) catch 0;
+            std.debug.print(fmt ++ "\n", args);
+            dumpStderr(data);
         }
     }
 }
@@ -48,6 +46,34 @@ pub fn chomp(s: []const u8) []const u8 {
 // std.mem.asBytes(), but returning only the bytes needed for a packed struct
 pub fn asPackedBytes(T: type, ptr: anytype) []u8 {
     return std.mem.asBytes(ptr)[0 .. @bitSizeOf(T) / 8];
+}
+
+fn dumpStderr(data: []const u8) void {
+    const bytes_per_line = 16;
+    std.debug.assert(bytes_per_line % 2 == 0);
+    var off: usize = 0;
+
+    while (off < data.len) : (off += bytes_per_line) {
+        std.debug.print("{x:0>8}: ", .{off});
+        const bytes_to_show = if (off + bytes_per_line > data.len) data.len - off else bytes_per_line;
+        for (0..bytes_per_line) |n| {
+            if (n < bytes_to_show) {
+                std.debug.print("{x:0>2}", .{data[off + n]});
+            } else {
+                std.debug.print("  ", .{});
+            }
+            if (n % 2 == 1) {
+                std.debug.print(" ", .{});
+            }
+        }
+        std.debug.print(" ", .{});
+        for (0..bytes_per_line) |n| {
+            if (n < bytes_to_show) {
+                std.debug.print("{c}", .{if (std.ascii.isPrint(data[off + n])) data[off + n] else '.'});
+            }
+        }
+        std.debug.print("\n", .{});
+    }
 }
 
 // xxd style hexdump


### PR DESCRIPTION
## Summary

Add handling for SSH_MSG_IGNORE (type 2) and SSH_MSG_DEBUG (type 4) messages per RFC 4253 §11.2 and §11.3.

These messages can be sent at any time by either party and must be accepted without causing protocol failure. SSH_MSG_IGNORE is also used as a countermeasure against traffic analysis.

### Changes
- Added `SSH_MSG_IGNORE = 2` and `SSH_MSG_DEBUG = 4` to the `MsgId` enum in `protocol.zig`
- Handle both message types in client and server `handlePacket` switches
  - `SSH_MSG_IGNORE`: silently consumed, continues reading
  - `SSH_MSG_DEBUG`: parses `always_display`, message, and language fields; logs appropriately
- Zig 0.16.0 compatibility fixes (build.zig, build.zig.zon, util.zig, privkey.zig)
- Added `.zig-cache` to `.gitignore`

Fixes #18