### PR TITLE
Clear sensitive data from memory on deinit

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -67,7 +67,7 @@ pub const Session = struct {
     channel_write_buf: [64]u8 = undefined, // FIXME size
     channel_write_buf_nbytes: usize,
 
-    privkey_ascii: ?[]u8, // allocated  // FIXME deinit properly and clear
+    privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
     privkey_blob: [Protocol.srv_hostkey_algo.SecretKey.encoded_length]u8 = undefined,
@@ -88,6 +88,31 @@ pub const Session = struct {
             .auth_passphrase = null,
             .channel_write_buf_nbytes = 0,
         };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.clearAndFreeOptional(&self.privkey_ascii);
+        self.clearAndFreeOptional(&self.privkey_passphrase);
+        self.clearAndFreeOptional(&self.auth_passphrase);
+        if (self.hostkey_ks) |ks| {
+            std.crypto.secureZero(u8, ks);
+            self.allocator.free(ks);
+            self.hostkey_ks = null;
+        }
+        std.crypto.secureZero(u8, &self.shared_secret_k);
+        std.crypto.secureZero(u8, &self.session_id);
+        std.crypto.secureZero(u8, &self.privkey_blob);
+        std.crypto.secureZero(u8, &self.pubkey_blob);
+        std.crypto.secureZero(u8, &self.channel_write_buf);
+        self.keydata.clear();
+    }
+
+    fn clearAndFreeOptional(self: *Self, field: *?[]u8) void {
+        if (field.*) |slice| {
+            std.crypto.secureZero(u8, slice);
+            self.allocator.free(slice);
+            field.* = null;
+        }
     }
 
     pub fn setIoSessionState(self: *Self, newState: Protocol.IoSessionState) void {
@@ -455,6 +480,7 @@ pub const Session = struct {
 
     pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
         if (self.privkey_ascii) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.privkey_ascii = null;
         }
@@ -464,6 +490,7 @@ pub const Session = struct {
 
     pub fn setPrivateKeyPassphrase(self: *Self, data: []const u8) MisshodError!void {
         if (self.privkey_passphrase) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.privkey_passphrase = null;
         }
@@ -473,6 +500,7 @@ pub const Session = struct {
 
     pub fn setAuthPassphrase(self: *Self, data: []const u8) MisshodError!void {
         if (self.auth_passphrase) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.auth_passphrase = null;
         }

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -136,9 +136,9 @@ pub fn MisshodImpl(role: Role) type {
         };
     }
 
-    pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
-        _ = self;
-        _ = allocator;
+    pub fn deinit(self: *Self) void {
+        self.session.deinit();
+        std.crypto.secureZero(u8, &self.iobuf);
     }
 
     // for session use

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -139,6 +139,15 @@ pub const KeyDataBi = struct {
         };
     }
 
+    pub fn clear(self: *Self) void {
+        std.crypto.secureZero(u8, &self.c2s.iv);
+        std.crypto.secureZero(u8, &self.c2s.key);
+        std.crypto.secureZero(u8, &self.c2s.mackey);
+        std.crypto.secureZero(u8, &self.s2c.iv);
+        std.crypto.secureZero(u8, &self.s2c.key);
+        std.crypto.secureZero(u8, &self.s2c.mackey);
+    }
+
     // generate session keys from shared secret
     pub fn genKeys(self:* Self, H: [hash_algo.digest_length]u8, shared_secret_k:[kex_algo.shared_length]u8, session_id: [hash_algo.digest_length]u8) !void {
 
@@ -282,4 +291,26 @@ test "MsgId enum values match SSH RFC" {
 test "MaxPayload is reasonable" {
     try std.testing.expect(MaxPayload > 0);
     try std.testing.expect(MaxPayload < MaxSSHPacket);
+}
+
+test "KeyDataBi.clear zeros all key material" {
+    var kd = KeyDataBi.init();
+    // fill with non-zero data
+    @memset(&kd.c2s.iv, 0xAA);
+    @memset(&kd.c2s.key, 0xBB);
+    @memset(&kd.c2s.mackey, 0xCC);
+    @memset(&kd.s2c.iv, 0xDD);
+    @memset(&kd.s2c.key, 0xEE);
+    @memset(&kd.s2c.mackey, 0xFF);
+
+    kd.clear();
+
+    const zero_iv: [MaxIVLen]u8 = .{0} ** MaxIVLen;
+    const zero_key: [MaxKeyLen]u8 = .{0} ** MaxKeyLen;
+    try std.testing.expectEqualSlices(u8, &zero_iv, &kd.c2s.iv);
+    try std.testing.expectEqualSlices(u8, &zero_key, &kd.c2s.key);
+    try std.testing.expectEqualSlices(u8, &zero_key, &kd.c2s.mackey);
+    try std.testing.expectEqualSlices(u8, &zero_iv, &kd.s2c.iv);
+    try std.testing.expectEqualSlices(u8, &zero_key, &kd.s2c.key);
+    try std.testing.expectEqualSlices(u8, &zero_key, &kd.s2c.mackey);
 }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -58,7 +58,7 @@ pub const Session = struct {
     channel_write_buf: [64]u8 = undefined, // FIXME size
     channel_write_buf_nbytes: usize,
 
-    privkey_ascii: ?[]u8, // allocated  // FIXME deinit properly and clear
+    privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
 
@@ -89,6 +89,28 @@ pub const Session = struct {
         try decodePrivKey(hostkey_ascii, null, &s.privkey_blob, &s.pubkey_blob);
 
         return s;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.clearAndFreeOptional(&self.privkey_ascii);
+        self.clearAndFreeOptional(&self.privkey_passphrase);
+        self.clearAndFreeOptional(&self.auth_passphrase);
+        std.crypto.secureZero(u8, &self.shared_secret_k);
+        std.crypto.secureZero(u8, &self.session_id);
+        std.crypto.secureZero(u8, &self.privkey_blob);
+        std.crypto.secureZero(u8, &self.pubkey_blob);
+        std.crypto.secureZero(u8, &self.auth_pubkey_attempted);
+        std.crypto.secureZero(u8, &self.q_c);
+        std.crypto.secureZero(u8, &self.channel_write_buf);
+        self.keydata.clear();
+    }
+
+    fn clearAndFreeOptional(self: *Self, field: *?[]u8) void {
+        if (field.*) |slice| {
+            std.crypto.secureZero(u8, slice);
+            self.allocator.free(slice);
+            field.* = null;
+        }
     }
 
     pub fn setIoSessionState(self: *Self, newState: Protocol.IoSessionState) void {
@@ -349,6 +371,7 @@ pub const Session = struct {
 
     pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
         if (self.privkey_ascii) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.privkey_ascii = null;
         }
@@ -358,6 +381,7 @@ pub const Session = struct {
 
     pub fn setPrivateKeyPassphrase(self: *Self, data: []const u8) MisshodError!void {
         if (self.privkey_passphrase) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.privkey_passphrase = null;
         }
@@ -367,6 +391,7 @@ pub const Session = struct {
 
     pub fn setAuthPassphrase(self: *Self, data: []const u8) MisshodError!void {
         if (self.auth_passphrase) |old| {
+            std.crypto.secureZero(u8, old);
             self.allocator.free(old);
             self.auth_passphrase = null;
         }


### PR DESCRIPTION
## Summary

Securely clear private keys, passphrases, and session keys from memory after use to limit exposure in memory dumps or core files.

### Changes
- Added `deinit()` to both client and server `Session` structs
- Zeros all sensitive fields: private key blobs, shared secret, session ID, key material
- Frees and zeros allocated buffers: `privkey_ascii`, `privkey_passphrase`, `auth_passphrase`
- Added `KeyDataBi.clear()` to zero IVs, encryption keys, and MAC keys
- Updated `MisshodImpl.deinit` to call session deinit and zero the I/O buffer
- Zero-before-free in setter functions to prevent data lingering after key replacement
- Uses `std.crypto.secureZero` to prevent compiler optimization of zeroing

Fixes #17