### PR TITLE
Extract and surface SSH_MSG_DISCONNECT reason codes

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -680,8 +680,19 @@ pub const Session = struct {
                 misshod.requestEvent(.{ .RxData = s }, .Idle);
                 self.setSessionState(.ChannelData);
             },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT), @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
-                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle); // FIXME reason code
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT) => {
+                // RFC 4253 §11.1
+                const reason_code = try rdr.readU32();
+                const description = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                TRACE(.Info, "SSH_MSG_DISCONNECT reason={d} '{s}'", .{ reason_code, description });
+                misshod.requestEvent(.{ .EndSession = .{ .ServerDisconnect = .{
+                    .code = reason_code,
+                    .description = description,
+                } } }, .Idle);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
+                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
                 // RFC 4253 §11.2 - must be silently ignored

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -25,8 +25,14 @@ pub const IoError = error{
     UnimplementedService,
 };
 
-pub const EndSessionReason = enum {
+pub const DisconnectReason = struct {
+    code: u32,
+    description: []const u8,
+};
+
+pub const EndSessionReason = union(enum) {
     Disconnect,
+    ServerDisconnect: DisconnectReason,
     AuthFailure,
 };
 
@@ -575,4 +581,31 @@ pub fn MisshodImpl(role: Role) type {
         try self.advance();
     }
 };
+}
+
+test "EndSessionReason tagged union" {
+    const reason_disconnect: EndSessionReason = .Disconnect;
+    const reason_auth: EndSessionReason = .AuthFailure;
+    const reason_server: EndSessionReason = .{ .ServerDisconnect = .{
+        .code = 11,
+        .description = "test disconnect",
+    } };
+
+    switch (reason_disconnect) {
+        .Disconnect => {},
+        else => return error.TestUnexpectedResult,
+    }
+
+    switch (reason_auth) {
+        .AuthFailure => {},
+        else => return error.TestUnexpectedResult,
+    }
+
+    switch (reason_server) {
+        .ServerDisconnect => |r| {
+            try std.testing.expectEqual(@as(u32, 11), r.code);
+            try std.testing.expectEqualStrings("test disconnect", r.description);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -673,8 +673,19 @@ pub const Session = struct {
                     return IoError.UnexpectedResponse;
                 }
             },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT), @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
-                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle); // FIXME reason code
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DISCONNECT) => {
+                // RFC 4253 §11.1
+                const reason_code = try rdr.readU32();
+                const description = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                TRACE(.Info, "SSH_MSG_DISCONNECT reason={d} '{s}'", .{ reason_code, description });
+                misshod.requestEvent(.{ .EndSession = .{ .ServerDisconnect = .{
+                    .code = reason_code,
+                    .description = description,
+                } } }, .Idle);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
+                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
                 // RFC 4253 §11.2 - must be silently ignored

--- a/src/test.zig
+++ b/src/test.zig
@@ -7,4 +7,5 @@ comptime {
     _ = @import("hasher.zig");
     _ = @import("aesctr.zig");
     _ = @import("protocol.zig");
+    _ = @import("misshod.zig");
 }


### PR DESCRIPTION
## Summary

Parse and surface SSH_MSG_DISCONNECT reason codes per RFC 4253 §11.1, instead of ignoring them.

### Changes
- Added `DisconnectReason` struct carrying `code: u32` and `description: []const u8`
- Changed `EndSessionReason` from an enum to a tagged union with `ServerDisconnect: DisconnectReason`
- Separated SSH_MSG_DISCONNECT from SSH_MSG_CHANNEL_EOF handling in both client and server sessions
- Disconnect reason code and description are now logged and surfaced to callers

Fixes #19