### PR TITLE
Surface SSH_MSG_USERAUTH_BANNER to caller

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -647,13 +647,11 @@ pub const Session = struct {
                 }
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_BANNER) => {
-                TRACE(.Debug, "Protocol.MsgId.SSH_MSG_USERAUTH_BANNER", .{});
+                // RFC 4252 §5.4 - banner message before auth completes
                 const banner = try rdr.readU32LenString();
-                TRACE(.Info, "Server banner '{s}'", .{util.chomp(banner)});
-                const lang = try rdr.readU32LenString();
-                TRACE(.Debug, "Server banner language '{s}'", .{lang});
-                // do another read
-                self.setIoSessionState(.ReadPktHdr);
+                TRACE(.Debug, "Server banner '{s}'", .{util.chomp(banner)});
+                _ = try rdr.readU32LenString(); // language tag
+                misshod.requestEvent(.{ .Banner = banner }, .ReadPktHdr);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS) => {
                 // don't care what state we were in, we've been let in

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -710,6 +710,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -710,22 +710,6 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
-                // RFC 4253 §11.2 - must be silently ignored
-                self.setIoSessionState(.ReadPktHdr);
-            },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
-                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
-                const always_display = try rdr.readBoolean();
-                const message = try rdr.readU32LenString();
-                _ = try rdr.readU32LenString(); // language tag
-                if (always_display) {
-                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
-                } else {
-                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
-                }
-                self.setIoSessionState(.ReadPktHdr);
-            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -63,6 +63,7 @@ pub const MisshodClientEventCodes = union(enum) {
     EndSession: EndSessionReason,
     Connected,
     RxData: []const u8,
+    Banner: []const u8,
 };
 
 pub const UserCredentialsPasswordOrPubkey = union(enum) {
@@ -605,6 +606,16 @@ test "EndSessionReason tagged union" {
         .ServerDisconnect => |r| {
             try std.testing.expectEqual(@as(u32, 11), r.code);
             try std.testing.expectEqualStrings("test disconnect", r.description);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "MisshodClientEventCodes Banner variant" {
+    const banner: MisshodClientEventCodes = .{ .Banner = "Welcome to the server" };
+    switch (banner) {
+        .Banner => |text| {
+            try std.testing.expectEqualStrings("Welcome to the server", text);
         },
         else => return error.TestUnexpectedResult,
     }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -703,6 +703,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -703,22 +703,6 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
-                // RFC 4253 §11.2 - must be silently ignored
-                self.setIoSessionState(.ReadPktHdr);
-            },
-            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
-                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
-                const always_display = try rdr.readBoolean();
-                const message = try rdr.readU32LenString();
-                _ = try rdr.readU32LenString(); // language tag
-                if (always_display) {
-                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
-                } else {
-                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
-                }
-                self.setIoSessionState(.ReadPktHdr);
-            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again


### PR DESCRIPTION
## Summary

Surface SSH_MSG_USERAUTH_BANNER (RFC 4252 §5.4) to the application via the event system instead of just logging it internally.

### Changes
- Added `Banner: []const u8` to `MisshodClientEventCodes`
- Updated the USERAUTH_BANNER handler in `client_session.zig` to emit a `Banner` event
- After the caller processes and clears the event, reading resumes automatically

The banner text is a borrowed slice into the I/O buffer and must be consumed before calling `clearEvent`.

Fixes #20