### PR TITLE
Handle SSH_MSG_CHANNEL_CLOSE properly per RFC 4254

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -44,6 +44,8 @@ pub const SessionState = enum {
     ChannelDataRx,
     ChannelDataTx,
     ChannelDataTxComplete,
+    ChannelCloseWrite,
+    ChannelClosed,
 };
 
 pub const Session = struct {
@@ -66,6 +68,7 @@ pub const Session = struct {
     encrypted: bool,
     channel_write_buf: [64]u8 = undefined, // FIXME size
     channel_write_buf_nbytes: usize,
+    channel_close_sent: bool,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -87,6 +90,7 @@ pub const Session = struct {
             .privkey_passphrase = null,
             .auth_passphrase = null,
             .channel_write_buf_nbytes = 0,
+            .channel_close_sent = false,
         };
     }
 
@@ -449,6 +453,18 @@ pub const Session = struct {
                 self.channel_write_buf_nbytes = 0;
                 self.setSessionState(.ChannelData);
             },
+            .ChannelCloseWrite => {
+                // RFC 4254 §5.3 - send CHANNEL_CLOSE back to peer
+                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
+                try pkt.writeU32(0); // channel
+                self.channel_close_sent = true;
+                self.setSessionState(.ChannelClosed);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+            },
+            .ChannelClosed => {
+                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+            },
         }
     }
 
@@ -691,6 +707,16 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE) => {
+                // RFC 4254 §5.3 - must send CLOSE back if not already sent
+                _ = try rdr.readU32(); // channel
+                if (self.channel_close_sent) {
+                    misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                } else {
+                    self.setSessionState(.ChannelCloseWrite);
+                    self.setIoSessionState(.Idle);
+                }
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
                 // RFC 4253 §11.2 - must be silently ignored

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -708,6 +708,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -43,6 +43,7 @@ pub const MsgId = enum(u8) {
     SSH_MSG_CHANNEL_DATA = 94,
     SSH_MSG_CHANNEL_EXTENDED_DATA = 95,
     SSH_MSG_CHANNEL_EOF = 96,
+    SSH_MSG_CHANNEL_CLOSE = 97,
     SSH_MSG_CHANNEL_REQUEST = 98,
     SSH_MSG_CHANNEL_SUCCESS = 99,
 };
@@ -286,6 +287,7 @@ test "MsgId enum values match SSH RFC" {
     try std.testing.expectEqual(@as(u8, 90), @intFromEnum(MsgId.SSH_MSG_CHANNEL_OPEN));
     try std.testing.expectEqual(@as(u8, 94), @intFromEnum(MsgId.SSH_MSG_CHANNEL_DATA));
     try std.testing.expectEqual(@as(u8, 96), @intFromEnum(MsgId.SSH_MSG_CHANNEL_EOF));
+    try std.testing.expectEqual(@as(u8, 97), @intFromEnum(MsgId.SSH_MSG_CHANNEL_CLOSE));
 }
 
 test "MaxPayload is reasonable" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -703,6 +703,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -38,6 +38,8 @@ pub const SessionState = enum {
     ChannelDataRx,
     ChannelDataTx,
     ChannelDataTxComplete,
+    ChannelCloseWrite,
+    ChannelClosed,
 };
 
 pub const Session = struct {
@@ -57,6 +59,7 @@ pub const Session = struct {
     encrypted: bool,
     channel_write_buf: [64]u8 = undefined, // FIXME size
     channel_write_buf_nbytes: usize,
+    channel_close_sent: bool,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -84,6 +87,7 @@ pub const Session = struct {
             .privkey_passphrase = null,
             .auth_passphrase = null,
             .channel_write_buf_nbytes = 0,
+            .channel_close_sent = false,
         };
 
         try decodePrivKey(hostkey_ascii, null, &s.privkey_blob, &s.pubkey_blob);
@@ -346,6 +350,18 @@ pub const Session = struct {
             .ChannelDataTxComplete => {
                 self.channel_write_buf_nbytes = 0;
                 self.setSessionState(.ChannelData);
+            },
+            .ChannelCloseWrite => {
+                // RFC 4254 §5.3 - send CHANNEL_CLOSE back to peer
+                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
+                try pkt.writeU32(self.chan);
+                self.channel_close_sent = true;
+                self.setSessionState(.ChannelClosed);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+            },
+            .ChannelClosed => {
+                misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
             },
         }
     }
@@ -686,6 +702,16 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF) => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE) => {
+                // RFC 4254 §5.3 - must send CLOSE back if not already sent
+                _ = try rdr.readU32(); // channel
+                if (self.channel_close_sent) {
+                    misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                } else {
+                    self.setSessionState(.ChannelCloseWrite);
+                    self.setIoSessionState(.Idle);
+                }
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
                 // RFC 4253 §11.2 - must be silently ignored


### PR DESCRIPTION
## Summary

Implement proper SSH_MSG_CHANNEL_CLOSE handshake per RFC 4254 §5.3.

### Changes
- Added `SSH_MSG_CHANNEL_CLOSE = 97` to the `MsgId` enum
- Added `channel_close_sent` state tracking to both sessions
- Handle incoming CHANNEL_CLOSE:
  - If already sent CLOSE: end session immediately
  - If not yet sent: send CLOSE reply, then end session
- Added `ChannelCloseWrite` and `ChannelClosed` states to both state machines

Previously CHANNEL_CLOSE was unhandled, which could leave resources leaked on the peer side.

Fixes #13