### PR TITLE
Enlarge channel write buffer to MaxChannelDataLen

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -66,7 +66,7 @@ pub const Session = struct {
     username: []const u8,
     rand: std.Random = undefined,
     encrypted: bool,
-    channel_write_buf: [64]u8 = undefined, // FIXME size
+    channel_write_buf: [Protocol.MaxChannelDataLen]u8 = undefined,
     channel_write_buf_nbytes: usize,
     channel_close_sent: bool,
 

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -750,6 +750,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -84,6 +84,8 @@ pub const KexHashOrder = enum { // https://datatracker.ietf.org/doc/html/rfc5656
 
 pub const MaxSSHPacket = 4096; // Can be smaller https://datatracker.ietf.org/doc/html/rfc4253#section-5.3
 pub const MaxPayload = (MaxSSHPacket - (sizeof_PktHdr + 255 + mac_algo.key_length));
+// Max channel data: MaxPayload minus channel data framing (msgid:1 + channel:4 + string_len:4)
+pub const MaxChannelDataLen = MaxPayload - 9;
 pub const MaxIVLen = 20; // number of bytes to generate for IVs
 pub const MaxKeyLen = 64; // number of bytes to generate for keys
 
@@ -293,6 +295,13 @@ test "MsgId enum values match SSH RFC" {
 test "MaxPayload is reasonable" {
     try std.testing.expect(MaxPayload > 0);
     try std.testing.expect(MaxPayload < MaxSSHPacket);
+}
+
+test "MaxChannelDataLen accounts for framing overhead" {
+    // Channel data framing: msgid(1) + channel(4) + string_len(4) = 9 bytes
+    try std.testing.expectEqual(MaxPayload - 9, MaxChannelDataLen);
+    try std.testing.expect(MaxChannelDataLen > 0);
+    try std.testing.expect(MaxChannelDataLen > 64); // must be larger than old hardcoded value
 }
 
 test "KeyDataBi.clear zeros all key material" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -57,7 +57,7 @@ pub const Session = struct {
     keydata: Protocol.KeyDataBi,
     rand: std.Random = undefined,
     encrypted: bool,
-    channel_write_buf: [64]u8 = undefined, // FIXME size
+    channel_write_buf: [Protocol.MaxChannelDataLen]u8 = undefined,
     channel_write_buf_nbytes: usize,
     channel_close_sent: bool,
 

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -745,6 +745,22 @@ pub const Session = struct {
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE) => {
+                // RFC 4253 §11.2 - must be silently ignored
+                self.setIoSessionState(.ReadPktHdr);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_DEBUG) => {
+                // RFC 4253 §11.3 - may be logged, must not cause protocol failure
+                const always_display = try rdr.readBoolean();
+                const message = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+                if (always_display) {
+                    TRACE(.Info, "SSH_MSG_DEBUG: '{s}'", .{message});
+                } else {
+                    TRACE(.Debug, "SSH_MSG_DEBUG: '{s}'", .{message});
+                }
+                self.setIoSessionState(.ReadPktHdr);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST) => {
                 // TBD
                 self.setIoSessionState(.ReadPktHdr); // read again


### PR DESCRIPTION
## Summary

Increase the channel write buffer from 64 bytes to `MaxChannelDataLen` (3795 bytes) to support real terminal I/O and data transfer.

### Changes
- Added `MaxChannelDataLen` constant to `protocol.zig` = `MaxPayload - 9` (accounting for channel data framing)
- Updated `channel_write_buf` in both `client_session.zig` and `server_session.zig`

The 64-byte buffer was far too small — any write larger than 64 bytes would error with `IoError.tooBig`.

Fixes #10