### PR TITLE
Support terminal resize and signal forwarding per RFC 4254

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -44,6 +44,7 @@ pub const SessionState = enum {
     ChannelDataRx,
     ChannelDataTx,
     ChannelDataTxComplete,
+    ChannelWindowChangeWrite,
     ChannelCloseWrite,
     ChannelClosed,
 };
@@ -70,6 +71,7 @@ pub const Session = struct {
     channel_write_buf_nbytes: usize,
     channel_close_sent: bool,
     peer_window: u32,
+    pending_window_change: ?[4]u32,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -93,6 +95,7 @@ pub const Session = struct {
             .channel_write_buf_nbytes = 0,
             .channel_close_sent = false,
             .peer_window = 0,
+            .pending_window_change = null,
         };
     }
 
@@ -425,7 +428,9 @@ pub const Session = struct {
                 self.setSessionState(.ChannelData);
             },
             .ChannelData => {
-                if (self.channel_write_buf_nbytes > 0) { // something to send
+                if (self.pending_window_change != null) {
+                    self.setSessionState(.ChannelWindowChangeWrite);
+                } else if (self.channel_write_buf_nbytes > 0) { // something to send
                     self.setSessionState(.ChannelDataTx);
                 } else { // wait for incoming
                     self.setSessionState(.ChannelDataRxAdjustWindow);
@@ -463,6 +468,22 @@ pub const Session = struct {
                 self.channel_write_buf_nbytes = 0;
                 self.setSessionState(.ChannelData);
             },
+            .ChannelWindowChangeWrite => {
+                // RFC 4254 §6.7 - send window-change channel request
+                const wc = self.pending_window_change.?;
+                self.pending_window_change = null;
+                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
+                try pkt.writeU32(0); // channel
+                try pkt.writeU32LenString("window-change");
+                try pkt.writeBoolean(false); // want reply
+                try pkt.writeU32(wc[0]); // cols
+                try pkt.writeU32(wc[1]); // rows
+                try pkt.writeU32(wc[2]); // width_px
+                try pkt.writeU32(wc[3]); // height_px
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                self.setSessionState(.ChannelData);
+            },
             .ChannelCloseWrite => {
                 // RFC 4254 §5.3 - send CHANNEL_CLOSE back to peer
                 var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
@@ -496,6 +517,16 @@ pub const Session = struct {
         if (self.sessionState == .ChannelDataRx) { // waiting to receive
             if (self.ioSessionState == .ReadPktHdr) { // nothing actually happening
                 self.setSessionState(.ChannelDataTx);
+                self.setIoSessionState(.Idle);
+            }
+        }
+    }
+
+    pub fn sendWindowChange(self: *Self, cols: u32, rows: u32, width_px: u32, height_px: u32) void {
+        self.pending_window_change = .{ cols, rows, width_px, height_px };
+        if (self.sessionState == .ChannelDataRx) {
+            if (self.ioSessionState == .ReadPktHdr) {
+                self.setSessionState(.ChannelWindowChangeWrite);
                 self.setIoSessionState(.Idle);
             }
         }
@@ -1093,4 +1124,19 @@ test "handlePacket: SSH_MSG_CHANNEL_EXTENDED_DATA surfaces stderr" {
         },
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "sendWindowChange queues pending change" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), "testuser", std.testing.allocator);
+    defer session.deinit();
+
+    try std.testing.expect(session.pending_window_change == null);
+    session.sendWindowChange(120, 40, 960, 640);
+    try std.testing.expect(session.pending_window_change != null);
+    const wc = session.pending_window_change.?;
+    try std.testing.expectEqual(@as(u32, 120), wc[0]);
+    try std.testing.expectEqual(@as(u32, 40), wc[1]);
+    try std.testing.expectEqual(@as(u32, 960), wc[2]);
+    try std.testing.expectEqual(@as(u32, 640), wc[3]);
 }

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -82,6 +82,13 @@ pub const UserCredentials = struct {
     auth: ?UserCredentialsPasswordOrPubkey, // null for "none" auth
 };
 
+pub const WindowSize = struct {
+    cols: u32,
+    rows: u32,
+    width_px: u32,
+    height_px: u32,
+};
+
 pub const MisshodServerEventCodes = union(enum) {
     EndSession: EndSessionReason,
     UserAuth: UserCredentials,
@@ -89,6 +96,8 @@ pub const MisshodServerEventCodes = union(enum) {
     Connected,
     RxData: []const u8,
     RxExtendedData: ExtendedData,
+    WindowChange: WindowSize,
+    Signal: []const u8,
 };
 
 pub fn MisshodEvent(role:Role) type {
@@ -632,4 +641,30 @@ test "ExtendedData struct" {
     const ext: ExtendedData = .{ .data_type = 1, .data = "stderr output" };
     try std.testing.expectEqual(@as(u32, 1), ext.data_type);
     try std.testing.expectEqualStrings("stderr output", ext.data);
+}
+
+test "WindowSize struct" {
+    const ws: WindowSize = .{ .cols = 120, .rows = 40, .width_px = 960, .height_px = 640 };
+    try std.testing.expectEqual(@as(u32, 120), ws.cols);
+    try std.testing.expectEqual(@as(u32, 40), ws.rows);
+}
+
+test "MisshodServerEventCodes WindowChange variant" {
+    const evt: MisshodServerEventCodes = .{ .WindowChange = .{ .cols = 80, .rows = 24, .width_px = 640, .height_px = 480 } };
+    switch (evt) {
+        .WindowChange => |ws| {
+            try std.testing.expectEqual(@as(u32, 80), ws.cols);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "MisshodServerEventCodes Signal variant" {
+    const evt: MisshodServerEventCodes = .{ .Signal = "INT" };
+    switch (evt) {
+        .Signal => |sig| {
+            try std.testing.expectEqualStrings("INT", sig);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -667,7 +667,25 @@ pub const Session = struct {
                     _ = widthpx;
                     _ = heightpx;
                 } else if (std.mem.eql(u8, typ, "shell")) {
-                    // FIXME, any special shell behaviour here
+                    // shell request — no additional data
+                } else if (std.mem.eql(u8, typ, "window-change")) {
+                    // RFC 4254 §6.7
+                    const cols = try rdr.readU32();
+                    const rows = try rdr.readU32();
+                    const widthpx = try rdr.readU32();
+                    const heightpx = try rdr.readU32();
+                    misshod.requestEvent(.{ .WindowChange = .{
+                        .cols = cols,
+                        .rows = rows,
+                        .width_px = widthpx,
+                        .height_px = heightpx,
+                    } }, .Idle);
+                    return;
+                } else if (std.mem.eql(u8, typ, "signal")) {
+                    // RFC 4254 §6.9
+                    const signal_name = try rdr.readU32LenString();
+                    misshod.requestEvent(.{ .Signal = signal_name }, .Idle);
+                    return;
                 } else {
                     TRACE(.Debug, "channel req '{s}'", .{typ});
                     if (wantreply) {    // can't do this


### PR DESCRIPTION
Fixes #14 — Handle window-change (§6.7) and signal (§6.9) channel requests. Client can send resize via sendWindowChange(). 4 tests added.