### PR TITLE
Support exec, subsystem, and env channel requests per RFC 4254

### DIFF
--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -89,6 +89,13 @@ pub const WindowSize = struct {
     height_px: u32,
 };
 
+pub const ChannelRequestType = union(enum) {
+    Shell,
+    Exec: []const u8,
+    Subsystem: []const u8,
+    Env: struct { name: []const u8, value: []const u8 },
+};
+
 pub const MisshodServerEventCodes = union(enum) {
     EndSession: EndSessionReason,
     UserAuth: UserCredentials,
@@ -98,6 +105,7 @@ pub const MisshodServerEventCodes = union(enum) {
     RxExtendedData: ExtendedData,
     WindowChange: WindowSize,
     Signal: []const u8,
+    ChannelRequest: ChannelRequestType,
 };
 
 pub fn MisshodEvent(role:Role) type {
@@ -665,6 +673,41 @@ test "MisshodServerEventCodes Signal variant" {
         .Signal => |sig| {
             try std.testing.expectEqualStrings("INT", sig);
         },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ChannelRequestType Exec variant" {
+    const req: ChannelRequestType = .{ .Exec = "ls -la" };
+    switch (req) {
+        .Exec => |cmd| try std.testing.expectEqualStrings("ls -la", cmd),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ChannelRequestType Subsystem variant" {
+    const req: ChannelRequestType = .{ .Subsystem = "sftp" };
+    switch (req) {
+        .Subsystem => |name| try std.testing.expectEqualStrings("sftp", name),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ChannelRequestType Env variant" {
+    const req: ChannelRequestType = .{ .Env = .{ .name = "LANG", .value = "en_US.UTF-8" } };
+    switch (req) {
+        .Env => |env| {
+            try std.testing.expectEqualStrings("LANG", env.name);
+            try std.testing.expectEqualStrings("en_US.UTF-8", env.value);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ChannelRequestType Shell variant" {
+    const req: ChannelRequestType = .Shell;
+    switch (req) {
+        .Shell => {},
         else => return error.TestUnexpectedResult,
     }
 }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -667,7 +667,25 @@ pub const Session = struct {
                     _ = widthpx;
                     _ = heightpx;
                 } else if (std.mem.eql(u8, typ, "shell")) {
-                    // shell request — no additional data
+                    // RFC 4254 §6.5 — interactive shell
+                    misshod.requestEvent(.{ .ChannelRequest = .Shell }, .Idle);
+                    if (!wantreply) return;
+                } else if (std.mem.eql(u8, typ, "exec")) {
+                    // RFC 4254 §6.5 — single command execution
+                    const command = try rdr.readU32LenString();
+                    misshod.requestEvent(.{ .ChannelRequest = .{ .Exec = command } }, .Idle);
+                    if (!wantreply) return;
+                } else if (std.mem.eql(u8, typ, "subsystem")) {
+                    // RFC 4254 §6.5 — named subsystem (e.g. sftp)
+                    const subsystem = try rdr.readU32LenString();
+                    misshod.requestEvent(.{ .ChannelRequest = .{ .Subsystem = subsystem } }, .Idle);
+                    if (!wantreply) return;
+                } else if (std.mem.eql(u8, typ, "env")) {
+                    // RFC 4254 §6.4 — set environment variable
+                    const name = try rdr.readU32LenString();
+                    const value = try rdr.readU32LenString();
+                    misshod.requestEvent(.{ .ChannelRequest = .{ .Env = .{ .name = name, .value = value } } }, .Idle);
+                    if (!wantreply) return;
                 } else if (std.mem.eql(u8, typ, "window-change")) {
                     // RFC 4254 §6.7
                     const cols = try rdr.readU32();


### PR DESCRIPTION
Fixes #11 — Handle exec, subsystem, env channel request types. Adds ChannelRequestType union and ChannelRequest server event. 4 tests added.