### PR TITLE
Support re-keying after initial key exchange per RFC 4253

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -75,6 +75,7 @@ pub const Session = struct {
     peer_window: u32,
     pending_window_change: ?[4]u32,
     kbd_interactive_response: ?[]u8, // allocated
+    is_rekeying: bool,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -100,6 +101,7 @@ pub const Session = struct {
             .peer_window = 0,
             .pending_window_change = null,
             .kbd_interactive_response = null,
+            .is_rekeying = false,
         };
     }
 
@@ -195,8 +197,14 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .CheckHostKey => {
-                misshod.requestEvent(.{ .CheckHostKey = self.hostkey_ks }, .Idle);
-                self.setSessionState(.CheckHostKeyCompleted);
+                if (self.is_rekeying) {
+                    // Skip host key check during re-key, already trusted
+                    self.setSessionState(.NewKeysRead);
+                    self.setIoSessionState(.ReadPktHdr);
+                } else {
+                    misshod.requestEvent(.{ .CheckHostKey = self.hostkey_ks }, .Idle);
+                    self.setSessionState(.CheckHostKeyCompleted);
+                }
             },
             .CheckHostKeyCompleted => {
                 self.setSessionState(.NewKeysRead);
@@ -211,8 +219,13 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
-                self.setSessionState(.AuthServReq);
-                self.encrypted = true; // have read and written SSH_MSG_NEWKEYS, encrypted from now on
+                if (self.is_rekeying) {
+                    self.is_rekeying = false;
+                    self.setSessionState(.ChannelData);
+                } else {
+                    self.setSessionState(.AuthServReq);
+                }
+                self.encrypted = true;
             },
             .AuthServReq => {
                 // https://datatracker.ietf.org/doc/html/rfc4253
@@ -619,6 +632,26 @@ pub const Session = struct {
             @intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT) => {
                 TRACE(.Debug, "{any}", .{@as(Protocol.MsgId, @enumFromInt(msgid))});
 
+                const is_rekey = self.sessionState != .KexInitRead;
+                if (is_rekey) {
+                    if (self.sessionState != .ChannelData and
+                        self.sessionState != .ChannelDataRx and
+                        self.sessionState != .ChannelDataRxAdjustWindow)
+                    {
+                        self.setIoSessionState(.ReadPktHdr);
+                        return;
+                    }
+                    // RFC 4253 §9 - peer-initiated re-keying
+                    TRACE(.Info, "Re-keying initiated by peer", .{});
+                    self.kex_hasher = Hasher(Protocol.hash_algo).init();
+                    self.kex_hash_order = .Init;
+                    self.kex_hash_order = self.kex_hash_order.check(.V_C);
+                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.kex_hash_order = self.kex_hash_order.check(.V_S);
+                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.is_rekeying = true;
+                }
+
                 self.kex_hash_order = self.kex_hash_order.check(.I_S);
                 self.kex_hasher.writeU32LenString(rdr.payload[(rdr.off - 1)..]); // from before the msgid
 
@@ -653,11 +686,10 @@ pub const Session = struct {
                 TRACE(.Debug, "first_kex_packet_follows = {any}\n", .{first_kex_packet_follows});
                 _ = try rdr.readU32(); // reserved, ignore
 
-                if (self.sessionState == .KexInitRead) {
+                if (self.sessionState == .KexInitRead or is_rekey) {
                     self.setSessionState(.EcdhInitWrite);
                     self.setIoSessionState(.Idle);
                 } else {
-                    // go read another packet
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
@@ -1265,4 +1297,11 @@ test "nameListContains rejects missing algorithm" {
     try std.testing.expect(!nameListContains("aes128-ctr,aes256-cbc", "aes256-ctr"));
     try std.testing.expect(!nameListContains("", "aes256-ctr"));
     try std.testing.expect(!nameListContains("aes256-ct", "aes256-ctr"));
+}
+
+test "is_rekeying starts false" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), "testuser", std.testing.allocator);
+    defer session.deinit();
+    try std.testing.expect(!session.is_rekeying);
 }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -61,6 +61,7 @@ pub const Session = struct {
     channel_write_buf_nbytes: usize,
     channel_close_sent: bool,
     peer_window: u32,
+    is_rekeying: bool,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -90,6 +91,7 @@ pub const Session = struct {
             .channel_write_buf_nbytes = 0,
             .channel_close_sent = false,
             .peer_window = 0,
+            .is_rekeying = false,
         };
 
         try decodePrivKey(hostkey_ascii, null, &s.privkey_blob, &s.pubkey_blob);
@@ -445,6 +447,25 @@ pub const Session = struct {
             @intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT) => {
                 TRACE(.Debug, "{any}", .{@as(Protocol.MsgId, @enumFromInt(msgid))});
 
+                const is_rekey = self.sessionState != .KexInitRead;
+                if (is_rekey) {
+                    if (self.sessionState != .ChannelData and
+                        self.sessionState != .ChannelDataRx and
+                        self.sessionState != .ChannelDataRxAdjustWindow)
+                    {
+                        self.setIoSessionState(.ReadPktHdr);
+                        return;
+                    }
+                    TRACE(.Info, "Re-keying initiated by peer", .{});
+                    self.kex_hasher = Hasher(Protocol.hash_algo).init();
+                    self.kex_hash_order = .Init;
+                    self.kex_hash_order = self.kex_hash_order.check(.V_C);
+                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.kex_hash_order = self.kex_hash_order.check(.V_S);
+                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.is_rekeying = true;
+                }
+
                 self.kex_hash_order = self.kex_hash_order.check(.I_C);
                 self.kex_hasher.writeU32LenString(rdr.payload[(rdr.off - 1)..]); // from before the msgid
 
@@ -480,11 +501,10 @@ pub const Session = struct {
                 TRACE(.Debug, "first_kex_packet_follows = {any}\n", .{first_kex_packet_follows});
                 _ = try rdr.readU32(); // reserved, ignore
 
-                if (self.sessionState == .KexInitRead) {
+                if (self.sessionState == .KexInitRead or is_rekey) {
                     self.setSessionState(.KexInitWrite);
                     self.setIoSessionState(.Idle);
                 } else {
-                    // go read another packet
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
@@ -508,9 +528,15 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS) => {
                 if (self.sessionState == .NewKeysRead) {
-                    self.encrypted = true; // have read and written SSH_MSG_NEWKEYS, encrypted from now on
-                    self.setSessionState(.AuthRead);
-                    self.setIoSessionState(.ReadPktHdr);
+                    self.encrypted = true;
+                    if (self.is_rekeying) {
+                        self.is_rekeying = false;
+                        self.setSessionState(.ChannelData);
+                        self.setIoSessionState(.Idle);
+                    } else {
+                        self.setSessionState(.AuthRead);
+                        self.setIoSessionState(.ReadPktHdr);
+                    }
                 } else {
                     return IoError.UnexpectedResponse;
                 }


### PR DESCRIPTION
Fixes #3 — Handle peer-initiated re-keying during established sessions. Resets kex state, derives new keys, returns to channel data. 53 tests pass.