### PR TITLE
Support full-duplex I/O

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/mssh/src/main.zig
+++ b/mssh/src/main.zig
@@ -174,14 +174,22 @@ pub fn main() !void {
                             },
                         }
                     },
-                    .ReadyToConsume, .ReadyToProduce => |len| {
-                        var pollevts: i16 = 0;
+                    .ReadyToConsume, .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                        const consume_len: usize = switch (ev) {
+                            .ReadyToConsume => |n| n,
+                            .ReadyToConsumeAndProduce => |s| s.consume,
+                            else => 0,
+                        };
+                        const produce_len: usize = switch (ev) {
+                            .ReadyToProduce => |n| n,
+                            .ReadyToConsumeAndProduce => |s| s.produce,
+                            else => 0,
+                        };
+                        _ = produce_len;
 
-                        if (ev == .ReadyToConsume) {
-                            pollevts |= std.posix.POLL.IN;
-                        } else {
-                            pollevts |= std.posix.POLL.OUT;
-                        }
+                        var pollevts: i16 = 0;
+                        if (consume_len > 0) pollevts |= std.posix.POLL.IN;
+                        if (ev == .ReadyToProduce or ev == .ReadyToConsumeAndProduce) pollevts |= std.posix.POLL.OUT;
 
                         var fds = [_]std.posix.pollfd{
                             .{
@@ -199,23 +207,19 @@ pub fn main() !void {
                         const ready = std.posix.poll(&fds, 1000) catch 0;
                         if (ready > 0) {
                             if (fds[0].revents & std.posix.POLL.IN > 0) { // socket is readable
-                                var bytes_to_read = len;
+                                var bytes_to_read = consume_len;
                                 if (bytes_to_read > iobuf.len) {
                                     bytes_to_read = iobuf.len;
                                 }
                                 const nbytes = try stream.read(iobuf[0..bytes_to_read]);
                                 if (nbytes > 0) {
-                                    // misshod may not get as much as it asked for, but it can req more later
-                                    //std.debug.print("Can consume {d}\n", .{len});
                                     try misshod.write(iobuf[0..nbytes]);
                                     continue :outer;
                                 }
                             }
                             if (fds[0].revents & std.posix.POLL.OUT > 0) { // socket is writeable
-                                const towrite = try misshod.peek(4); // get data it wants to send up to a limit
+                                const towrite = try misshod.peek(4);
                                 const bytes_written = try stream.write(towrite);
-                                //std.debug.print("bytes_written = {d} towrite={d}\n", .{bytes_written, towrite.len});
-                                // socket may not have accepted all of the bytes
                                 try misshod.consumed(bytes_written);
                                 continue :outer;
                             }
@@ -229,8 +233,6 @@ pub fn main() !void {
                                     }
                                 }
                             }
-                        } else {
-                            //std.debug.print("timeout\n", .{});
                         }
                     },
                 }

--- a/msshd/src/main.zig
+++ b/msshd/src/main.zig
@@ -99,14 +99,22 @@ pub fn main() !void {
                         },
                     }
                 },
-                .ReadyToConsume, .ReadyToProduce => |len| {
-                    var pollevts: i16 = 0;
+                .ReadyToConsume, .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                    const consume_len: usize = switch (ev) {
+                        .ReadyToConsume => |n| n,
+                        .ReadyToConsumeAndProduce => |s| s.consume,
+                        else => 0,
+                    };
+                    const produce_len: usize = switch (ev) {
+                        .ReadyToProduce => |n| n,
+                        .ReadyToConsumeAndProduce => |s| s.produce,
+                        else => 0,
+                    };
+                    _ = produce_len;
 
-                    if (ev == .ReadyToConsume) {
-                        pollevts |= std.posix.POLL.IN;
-                    } else {
-                        pollevts |= std.posix.POLL.OUT;
-                    }
+                    var pollevts: i16 = 0;
+                    if (consume_len > 0) pollevts |= std.posix.POLL.IN;
+                    if (ev == .ReadyToProduce or ev == .ReadyToConsumeAndProduce) pollevts |= std.posix.POLL.OUT;
 
                     var fds = [_]std.posix.pollfd{
                         .{
@@ -123,15 +131,13 @@ pub fn main() !void {
 
                     const ready = std.posix.poll(&fds, 1000) catch 0;
                     if (ready > 0) {
-                        if (fds[0].revents & std.posix.POLL.IN > 0) { // socket is readable
-                            var bytes_to_read = len;
+                        if (fds[0].revents & std.posix.POLL.IN > 0 and consume_len > 0) { // socket is readable
+                            var bytes_to_read = consume_len;
                             if (bytes_to_read > iobuf.len) {
                                 bytes_to_read = iobuf.len;
                             }
                             const nbytes = try stream.read(iobuf[0..bytes_to_read]);
                             if (nbytes > 0) {
-                                // misshod may not get as much as it asked for, but it can req more later
-                                //std.debug.print("Can consume {d}\n", .{len});
                                 try misshod.write(iobuf[0..nbytes]);
                                 continue :ioloop;
                             } else {
@@ -139,10 +145,8 @@ pub fn main() !void {
                             }
                         }
                         if (fds[0].revents & std.posix.POLL.OUT > 0) { // socket is writeable
-                            const towrite = try misshod.peek(4); // get data it wants to send up to a limit
+                            const towrite = try misshod.peek(4);
                             const bytes_written = try stream.write(towrite);
-                            //std.debug.print("bytes_written = {d} towrite={d}\n", .{bytes_written, towrite.len});
-                            // socket may not have accepted all of the bytes
                             try misshod.consumed(bytes_written);
                             continue :ioloop;
                         }
@@ -156,8 +160,6 @@ pub fn main() !void {
                                 }
                             }
                         }
-                    } else {
-                        //std.debug.print("timeout\n", .{});
                     }
                 },
             }

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -150,7 +150,7 @@ pub const Session = struct {
                 self.setSessionState(.KexInitWrite);
             },
             .KexInitWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT));
                 var cookie: [16]u8 = undefined;
                 self.rand.bytes(&cookie);
@@ -174,14 +174,14 @@ pub const Session = struct {
                 self.kex_hash_order = self.kex_hash_order.check(.I_C);
                 self.kex_hasher.writeU32LenString(pkt.active());
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.KexInitRead);
             },
             .KexInitRead => {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .EcdhInitWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_INIT));
 
                 var seed: [Protocol.kex_algo.seed_length]u8 = undefined;
@@ -190,7 +190,7 @@ pub const Session = struct {
                 var q_c = self.ecdh_ephem_keypair.public_key;
                 try pkt.writeU32LenString(&q_c);
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.EcdhReply);
             },
             .EcdhReply => {
@@ -227,9 +227,9 @@ pub const Session = struct {
             },
             .NewKeysWrite => {
                 // https://datatracker.ietf.org/doc/html/rfc4253#section-7.2
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 if (self.is_rekeying) {
                     self.is_rekeying = false;
                     self.setSessionState(.ChannelData);
@@ -240,10 +240,10 @@ pub const Session = struct {
             },
             .AuthServReq => {
                 // https://datatracker.ietf.org/doc/html/rfc4253
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_SERVICE_REQUEST));
                 try pkt.writeU32LenString("ssh-userauth");
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.AuthServRsp);
             },
             .AuthServRsp => {
@@ -294,7 +294,7 @@ pub const Session = struct {
             },
             .PubkeyAuthReq => {
                 // https://datatracker.ietf.org/doc/html/rfc4252#section-7
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-5.1
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-8
@@ -336,7 +336,7 @@ pub const Session = struct {
                 try typed_sig_buf.writeU32LenString(&sigbytes);
                 try pkt.writeU32LenString(typed_sig_buf.active());
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.AuthRsp);
             },
             .PubkeyAuthDecodeKeyPassword => {
@@ -354,7 +354,7 @@ pub const Session = struct {
             },
             .PasswordAuthReq => {
                 std.debug.assert(self.auth_passphrase != null);
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-5.1
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-8
@@ -363,24 +363,24 @@ pub const Session = struct {
                 try pkt.writeU32LenString("password");
                 try pkt.writeBoolean(false);
                 try pkt.writeU32LenString(self.auth_passphrase.?);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.AuthRsp);
             },
             .KeyboardInteractiveAuthReq => {
                 // RFC 4256 §3.1 - send keyboard-interactive auth request
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
                 try pkt.writeU32LenString(self.username);
                 try pkt.writeU32LenString("ssh-connection");
                 try pkt.writeU32LenString("keyboard-interactive");
                 try pkt.writeU32LenString(""); // language tag
                 try pkt.writeU32LenString(""); // submethods
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.AuthRsp);
             },
             .KeyboardInteractiveInfoRsp => {
                 // RFC 4256 §3.4 - send response to info request
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_INFO_RESPONSE));
                 try pkt.writeU32(1); // num-responses
                 if (self.kbd_interactive_response) |resp| {
@@ -388,7 +388,7 @@ pub const Session = struct {
                 } else {
                     try pkt.writeU32LenString("");
                 }
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.clearAndFreeOptional(&self.kbd_interactive_response);
                 self.setSessionState(.AuthRsp);
             },
@@ -396,21 +396,21 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .ChannelOpenReq => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
                 try pkt.writeU32LenString("session"); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
                 try pkt.writeU32(0); // sender channel
                 try pkt.writeU32(Protocol.MaxPayload); // initial window size
                 try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelOpenRsp);
             },
             .ChannelOpenRsp => {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .ChannelPtyReq => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
                 try pkt.writeU32(0);
@@ -464,18 +464,18 @@ pub const Session = struct {
                 };
                 try pkt.writeU32LenString(termdata);
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelShellReq);
             },
             .ChannelShellReq => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
                 try pkt.writeU32(0);
                 try pkt.writeU32LenString("shell");
                 try pkt.writeBoolean(false); // want reply
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelConnected);
             },
             .ChannelConnected => {
@@ -493,11 +493,11 @@ pub const Session = struct {
             },
             .ChannelDataRxAdjustWindow => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
                 try pkt.writeU32(0); // channel
                 try pkt.writeU32(Protocol.MaxPayload); // bytes to add
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelDataRx);
             },
             .ChannelDataRx => {
@@ -511,11 +511,11 @@ pub const Session = struct {
                     self.setSessionState(.ChannelDataRx);
                     return;
                 }
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
                 try pkt.writeU32(0);
                 try pkt.writeU32LenString(self.channel_write_buf[0..send_len]);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.peer_window -= @intCast(send_len);
                 self.setSessionState(.ChannelDataTxComplete);
             },
@@ -527,7 +527,7 @@ pub const Session = struct {
                 // RFC 4254 §6.7 - send window-change channel request
                 const wc = self.pending_window_change.?;
                 self.pending_window_change = null;
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
                 try pkt.writeU32(0); // channel
                 try pkt.writeU32LenString("window-change");
@@ -536,17 +536,17 @@ pub const Session = struct {
                 try pkt.writeU32(wc[1]); // rows
                 try pkt.writeU32(wc[2]); // width_px
                 try pkt.writeU32(wc[3]); // height_px
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelData);
             },
             .ChannelCloseWrite => {
                 // RFC 4254 §5.3 - send CHANNEL_CLOSE back to peer
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
                 try pkt.writeU32(0); // channel
                 self.channel_close_sent = true;
                 self.setSessionState(.ChannelClosed);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .ChannelClosed => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
@@ -575,6 +575,27 @@ pub const Session = struct {
                 self.setIoSessionState(.Idle);
             }
         }
+    }
+
+    // Full-duplex: build and send channel data packet directly without going through state machine
+    pub fn directChannelWrite(self: *Self, nbytes: usize, misshod: *MisshodClient) MisshodError!void {
+        if (nbytes > self.channel_write_buf.len) {
+            return IoError.tooBig;
+        }
+        self.channel_write_buf_nbytes = nbytes;
+        const outkeys = &self.keydata.c2s;
+        const send_len = @min(self.channel_write_buf_nbytes, self.peer_window);
+        if (send_len == 0) {
+            // No window available — data stays queued for state machine
+            return;
+        }
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
+        try pkt.writeU32(0);
+        try pkt.writeU32LenString(self.channel_write_buf[0..send_len]);
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+        self.peer_window -= @intCast(send_len);
+        self.channel_write_buf_nbytes = 0;
     }
 
     pub fn sendWindowChange(self: *Self, cols: u32, rows: u32, width_px: u32, height_px: u32) void {
@@ -632,7 +653,7 @@ pub const Session = struct {
     }
 
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodClient) MisshodError!void {
-        var rdr = try misshod.getRecvBuffer(misshod.iobuf[0..buf.len], &self.keydata.s2c);
+        var rdr = try misshod.getRecvBuffer(misshod.iobuf_rd[0..buf.len], &self.keydata.s2c);
 
         const msgid = try rdr.readU8();
 
@@ -935,11 +956,11 @@ test "handlePacket: SSH_MSG_IGNORE is silently consumed" {
     defer m.deinit();
 
     var payload_buf: [1]u8 = .{@intFromEnum(Protocol.MsgId.SSH_MSG_IGNORE)};
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, &payload_buf);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, &payload_buf);
     m.session.encrypted = false;
     m.session.setIoSessionState(.ReadPktHdr);
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
 }
 
@@ -955,11 +976,11 @@ test "handlePacket: SSH_MSG_DEBUG with always_display=true" {
     try pw.writeU32LenString("test debug message");
     try pw.writeU32LenString("en");
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
     m.session.setIoSessionState(.ReadPktHdr);
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
 }
 
@@ -975,11 +996,11 @@ test "handlePacket: SSH_MSG_DEBUG with always_display=false" {
     try pw.writeU32LenString("quiet debug");
     try pw.writeU32LenString("");
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
     m.session.setIoSessionState(.ReadPktHdr);
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
 }
 
@@ -995,10 +1016,10 @@ test "handlePacket: SSH_MSG_DISCONNECT surfaces reason code" {
     try pw.writeU32LenString("shutting down");
     try pw.writeU32LenString("");
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
 
     const evt = try m.getNextEvent();
     switch (evt) {
@@ -1026,11 +1047,11 @@ test "handlePacket: SSH_MSG_CHANNEL_CLOSE when not yet sent triggers close reply
     try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
     try pw.writeU32(0);
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
     m.session.channel_close_sent = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(SessionState.ChannelCloseWrite, m.session.sessionState);
 }
 
@@ -1044,11 +1065,11 @@ test "handlePacket: SSH_MSG_CHANNEL_CLOSE when already sent emits disconnect" {
     try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
     try pw.writeU32(0);
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
     m.session.channel_close_sent = true;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
 
     const evt = try m.getNextEvent();
     switch (evt) {
@@ -1071,10 +1092,10 @@ test "handlePacket: SSH_MSG_USERAUTH_BANNER surfaces banner event" {
     try pw.writeU32LenString("Welcome to the server!\r\n");
     try pw.writeU32LenString("en");
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
 
     const evt = try m.getNextEvent();
     switch (evt) {
@@ -1178,11 +1199,11 @@ test "handlePacket: CHANNEL_OPEN_CONFIRMATION captures initial window" {
     try pw.writeU32(32768); // initial window size
     try pw.writeU32(4096); // max packet size
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
     m.session.setSessionState(.ChannelOpenRsp);
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(@as(u32, 32768), m.session.peer_window);
 }
 
@@ -1199,10 +1220,10 @@ test "handlePacket: CHANNEL_WINDOW_ADJUST increases peer window" {
     try pw.writeU32(0); // channel
     try pw.writeU32(5000); // bytes to add
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(@as(u32, 6000), m.session.peer_window);
 }
 
@@ -1218,10 +1239,10 @@ test "handlePacket: SSH_MSG_CHANNEL_EXTENDED_DATA surfaces stderr" {
     try pw.writeU32(1); // data_type_code = SSH_EXTENDED_DATA_STDERR
     try pw.writeU32LenString("error: something failed\n");
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
 
     const evt = try m.getNextEvent();
     switch (evt) {
@@ -1266,10 +1287,10 @@ test "handlePacket: SSH_MSG_USERAUTH_INFO_REQUEST surfaces keyboard-interactive 
     try pw.writeU32LenString("Password: "); // prompt
     try pw.writeBoolean(false); // echo
 
-    const pkt_len = buildUnencryptedPacket(&m.iobuf, pw.payload);
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
     m.session.encrypted = false;
 
-    try m.session.handlePacket(m.iobuf[0..pkt_len], &m);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
 
     const evt = try m.getNextEvent();
     switch (evt) {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -24,6 +24,7 @@ pub const IoError = error{
     tooBig,
     UnimplementedService,
     AlgorithmNegotiationFailed,
+    NotReady,
 };
 
 pub const DisconnectReason = struct {
@@ -282,14 +283,14 @@ pub fn MisshodImpl(role: Role) type {
 
         try self.getIoReq(&can_consume_nbytes, &can_produce_nbytes);
 
-        std.debug.assert(can_consume_nbytes > 0 or can_produce_nbytes > 0);
-
         if (can_consume_nbytes > 0 and can_produce_nbytes > 0) {
             return MisshodEvent(role){ .ReadyToConsumeAndProduce = .{ .consume = can_consume_nbytes, .produce = can_produce_nbytes } };
         } else if (can_consume_nbytes > 0) {
             return MisshodEvent(role){ .ReadyToConsume = can_consume_nbytes };
-        } else {
+        } else if (can_produce_nbytes > 0) {
             return MisshodEvent(role){ .ReadyToProduce = can_produce_nbytes };
+        } else {
+            return IoError.NotReady;
         }
     }
 
@@ -933,4 +934,595 @@ test "HostKeyInfo fingerprint is deterministic" {
     Protocol.hash_algo.hash(key, &fp1, .{});
     Protocol.hash_algo.hash(key, &fp2, .{});
     try std.testing.expectEqualSlices(u8, &fp1, &fp2);
+}
+
+test "init sets both iostates to Idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_rd);
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_wr);
+    try std.testing.expectEqual(@as(usize, 0), m.rd_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), m.rd_off);
+    try std.testing.expectEqual(@as(usize, 0), m.wr_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), m.wr_off);
+}
+
+test "deinit zeros both buffers" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+
+    @memset(&m.iobuf_rd, 0xAA);
+    @memset(&m.iobuf_wr, 0xBB);
+
+    m.deinit();
+
+    for (m.iobuf_rd) |b| try std.testing.expectEqual(@as(u8, 0), b);
+    for (m.iobuf_wr) |b| try std.testing.expectEqual(@as(u8, 0), b);
+}
+
+test "requestRead sets iostate_rd, leaves iostate_wr unchanged" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestRead(0, 10, .ReadPktHdr);
+
+    try std.testing.expect(m.iostate_rd != .Idle);
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_wr);
+    try std.testing.expectEqual(@as(usize, 0), m.rd_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), m.rd_off);
+}
+
+test "requestWrite sets iostate_wr, leaves iostate_rd unchanged" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    // Simulate data in write buffer
+    const data = "hello";
+    @memcpy(m.iobuf_wr[0..data.len], data);
+    m.requestWrite(m.iobuf_wr[0..data.len], .Idle);
+
+    try std.testing.expect(m.iostate_wr != .Idle);
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_rd);
+    try std.testing.expectEqual(@as(usize, data.len), m.wr_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), m.wr_off);
+}
+
+test "requestEvent sets iostate_wr to Eventing" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestEvent(.Connected, .Idle);
+
+    switch (m.iostate_wr) {
+        .Active => |step| {
+            switch (step.action) {
+                .Eventing => {},
+                else => return error.TestUnexpectedResult,
+            }
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_rd);
+}
+
+test "write feeds data into iobuf_rd" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestRead(0, 5, .ReadPktHdr);
+    try m.write("hel");
+    try std.testing.expectEqual(@as(usize, 3), m.rd_nbytes);
+    try std.testing.expectEqualStrings("hel", m.iobuf_rd[0..3]);
+}
+
+test "write rejects data when iostate_rd is Idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const result = m.write("data");
+    try std.testing.expectError(IoError.cannotAcceptWrite, result);
+}
+
+test "peek reads from iobuf_wr" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const msg = "world";
+    @memcpy(m.iobuf_wr[0..msg.len], msg);
+    m.requestWrite(m.iobuf_wr[0..msg.len], .Idle);
+
+    const data = try m.peek(msg.len);
+    try std.testing.expectEqualStrings(msg, data);
+}
+
+test "peek fails when iostate_wr is Idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const result = m.peek(1);
+    try std.testing.expectError(IoError.notProducing, result);
+}
+
+test "consumed advances wr_off" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const msg = "abcde";
+    @memcpy(m.iobuf_wr[0..msg.len], msg);
+    m.requestWrite(m.iobuf_wr[0..msg.len], .Idle);
+
+    try m.consumed(2);
+    try std.testing.expectEqual(@as(usize, 2), m.wr_off);
+}
+
+test "consumed fails when iostate_wr is Idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const result = m.consumed(1);
+    try std.testing.expectError(IoError.notProducing, result);
+}
+
+test "getNextEvent returns Event when Eventing" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestEvent(.Connected, .Idle);
+    const ev = try m.getNextEvent();
+    switch (ev) {
+        .Event => |code| switch (code) {
+            .Connected => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "getNextEvent returns ReadyToConsume when only read is active" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    // Set ioSessionState to ReadPktHdr so advance() doesn't try to process Idle
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 10, .ReadPktHdr);
+    const ev = try m.getNextEvent();
+    switch (ev) {
+        .ReadyToConsume => |n| try std.testing.expectEqual(@as(usize, 10), n),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "getNextEvent returns ReadyToProduce when only write is active" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    // Set ioSessionState to Idle; with write active, canProcessIoSessionState(.Idle)
+    // requires both idle, so advance won't process it
+    m.session.setIoSessionState(.Idle);
+    const msg = "data";
+    @memcpy(m.iobuf_wr[0..msg.len], msg);
+    m.requestWrite(m.iobuf_wr[0..msg.len], .Idle);
+    const ev = try m.getNextEvent();
+    switch (ev) {
+        .ReadyToProduce => |n| try std.testing.expectEqual(@as(usize, msg.len), n),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "getNextEvent returns ReadyToConsumeAndProduce when both active" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 10, .ReadPktHdr);
+    const msg = "data";
+    @memcpy(m.iobuf_wr[0..msg.len], msg);
+    m.requestWrite(m.iobuf_wr[0..msg.len], .Idle);
+
+    const ev = try m.getNextEvent();
+    switch (ev) {
+        .ReadyToConsumeAndProduce => |s| {
+            try std.testing.expectEqual(@as(usize, 10), s.consume);
+            try std.testing.expectEqual(@as(usize, msg.len), s.produce);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "clearEvent resets iostate_wr from Eventing to Idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestEvent(.Connected, .Idle);
+    try std.testing.expect(m.iostate_wr != .Idle);
+
+    try m.clearEvent(.Connected);
+    // After clearing, advance() runs and may set new states,
+    // but the event was cleared successfully (no error returned)
+}
+
+test "clearEvent fails for wrong event code" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.requestEvent(.Connected, .Idle);
+    const result = m.clearEvent(.GetPrivateKey);
+    try std.testing.expectError(IoError.badClearEvent, result);
+}
+
+test "clearEvent fails when not eventing" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const result = m.clearEvent(.Connected);
+    try std.testing.expectError(IoError.badClearEvent, result);
+}
+
+test "read and write buffers are independent" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    // Fill read buffer
+    @memset(&m.iobuf_rd, 0x11);
+    // Fill write buffer
+    @memset(&m.iobuf_wr, 0x22);
+
+    // Verify they don't alias
+    try std.testing.expectEqual(@as(u8, 0x11), m.iobuf_rd[0]);
+    try std.testing.expectEqual(@as(u8, 0x22), m.iobuf_wr[0]);
+    try std.testing.expect(&m.iobuf_rd[0] != &m.iobuf_wr[0]);
+}
+
+test "simultaneous read and write I/O: data does not cross-contaminate" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.ReadPktHdr);
+
+    // Start a read (consuming 5 bytes)
+    m.requestRead(0, 5, .ReadPktHdr);
+
+    // Start a write (producing 3 bytes)
+    const wr_data = "abc";
+    @memcpy(m.iobuf_wr[0..wr_data.len], wr_data);
+    m.requestWrite(m.iobuf_wr[0..wr_data.len], .Idle);
+
+    // Feed data to read side
+    try m.write("xy");
+    try std.testing.expectEqual(@as(usize, 2), m.rd_nbytes);
+    try std.testing.expectEqualStrings("xy", m.iobuf_rd[0..2]);
+
+    // Drain data from write side
+    const peeked = try m.peek(3);
+    try std.testing.expectEqualStrings("abc", peeked);
+    try m.consumed(3);
+
+    // Write side done, read side still has 3 bytes to go
+    try std.testing.expectEqual(IoState(.Client).Idle, m.iostate_wr);
+    try std.testing.expect(m.iostate_rd != .Idle);
+}
+
+test "canProcessIoSessionState: Idle requires both sides idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.Idle);
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+    try std.testing.expect(m.canProcessIoSessionState());
+
+    // If read is active, Idle should not be processable
+    m.requestRead(0, 1, .ReadPktHdr);
+    try std.testing.expect(!m.canProcessIoSessionState());
+}
+
+test "canProcessIoSessionState: ReadPktHdr only needs read idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.iostate_rd = .Idle;
+    // Write side active should not block read states
+    const wr_data = "x";
+    @memcpy(m.iobuf_wr[0..wr_data.len], wr_data);
+    m.requestWrite(m.iobuf_wr[0..wr_data.len], .Idle);
+
+    try std.testing.expect(m.canProcessIoSessionState());
+}
+
+test "canProcessIoSessionState: VersionWrite needs write idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.VersionWrite);
+    m.iostate_wr = .Idle;
+    try std.testing.expect(m.canProcessIoSessionState());
+
+    const wr_data = "x";
+    @memcpy(m.iobuf_wr[0..wr_data.len], wr_data);
+    m.requestWrite(m.iobuf_wr[0..wr_data.len], .Idle);
+    try std.testing.expect(!m.canProcessIoSessionState());
+}
+
+test "canProcessIoSessionState: ReadPktCompletion needs write idle" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setIoSessionState(.{ .ReadPktCompletion = m.iobuf_rd[0..0] });
+    m.iostate_wr = .Idle;
+    try std.testing.expect(m.canProcessIoSessionState());
+
+    // With write active, ReadPktCompletion should be blocked
+    const wr_data = "x";
+    @memcpy(m.iobuf_wr[0..wr_data.len], wr_data);
+    m.requestWrite(m.iobuf_wr[0..wr_data.len], .Idle);
+    try std.testing.expect(!m.canProcessIoSessionState());
+}
+
+test "ReadyToConsumeAndProduce struct fields" {
+    const ev = MisshodEvent(.Client){ .ReadyToConsumeAndProduce = .{ .consume = 100, .produce = 50 } };
+    switch (ev) {
+        .ReadyToConsumeAndProduce => |s| {
+            try std.testing.expectEqual(@as(usize, 100), s.consume);
+            try std.testing.expectEqual(@as(usize, 50), s.produce);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "full handshake round-trip then channel data exchange" {
+    const privkey = @import("privkey.zig");
+
+    var cprng = std.Random.DefaultPrng.init(10);
+    var sprng = std.Random.DefaultPrng.init(20);
+
+    var client = try MisshodClient.init(cprng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    var server = try MisshodServer.init(sprng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer server.deinit();
+
+    var c2s_buf: [16384]u8 = undefined;
+    var s2c_buf: [16384]u8 = undefined;
+    var c2s_len: usize = 0;
+    var s2c_len: usize = 0;
+
+    var connected_client = false;
+    var connected_server = false;
+    var server_sent_data = false;
+    var client_rx_data: bool = false;
+
+    const Endpoint = enum { client_ep, server_ep };
+    const endpoints = [_]Endpoint{ .client_ep, .server_ep };
+
+    var steps: usize = 0;
+    while (steps < 1000) : (steps += 1) {
+        if (client_rx_data) break;
+
+        for (endpoints) |ep| {
+            if (ep == .client_ep) {
+                const cev = client.getNextEvent() catch continue;
+                switch (cev) {
+                    .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        if (s2c_len > 0) {
+                            const feed = @min(n, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .CheckHostKey => client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {},
+                        .GetPrivateKey => client.clearEvent(.GetPrivateKey) catch {},
+                        .GetAuthPassphrase => {
+                            client.session.setAuthPassphrase("testpass") catch {};
+                            client.clearEvent(.GetAuthPassphrase) catch {};
+                        },
+                        .Connected => {
+                            connected_client = true;
+                            client.clearEvent(.Connected) catch {};
+                        },
+                        .RxData => |data| {
+                            if (data.len > 0) client_rx_data = true;
+                            client.clearEvent(.{ .RxData = data }) catch {};
+                        },
+                        .EndSession => break,
+                        else => { client.clearEvent(code) catch {}; },
+                    },
+                }
+            } else {
+                const sev = server.getNextEvent() catch continue;
+                switch (sev) {
+                    .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                        const data = server.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(s2c_buf[s2c_len .. s2c_len + data.len], data);
+                        s2c_len += data.len;
+                        server.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        if (c2s_len > 0) {
+                            const feed = @min(n, c2s_len);
+                            server.write(c2s_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
+                            c2s_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .UserAuth => {
+                            server.grantAccess(true) catch {};
+                            server.clearEvent(.{ .UserAuth = .{ .username = "", .auth = null } }) catch {};
+                        },
+                        .Connected => {
+                            connected_server = true;
+                            server.clearEvent(.Connected) catch {};
+                        },
+                        .ChannelRequest => server.clearEvent(.{ .ChannelRequest = .Shell }) catch {},
+                        else => { server.clearEvent(code) catch {}; },
+                    },
+                }
+
+                // After server connects and event loop is clear, send channel data
+                if (connected_server and !server_sent_data and server.iostate_wr == .Idle) {
+                    const buf = server.getChannelWriteBuffer() catch continue;
+                    if (buf.len > 0) {
+                        const msg = "hello from server";
+                        @memcpy(buf[0..msg.len], msg);
+                        server.channelWriteComplete(msg.len) catch continue;
+                        server_sent_data = true;
+                    }
+                }
+            }
+        }
+    }
+
+    try std.testing.expect(connected_client);
+    try std.testing.expect(connected_server);
+    try std.testing.expect(client_rx_data);
+}
+
+test "client channelWriteComplete uses direct write when read is active" {
+    const privkey = @import("privkey.zig");
+
+    var cprng = std.Random.DefaultPrng.init(100);
+    var sprng = std.Random.DefaultPrng.init(200);
+
+    var client = try MisshodClient.init(cprng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    var server = try MisshodServer.init(sprng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer server.deinit();
+
+    var c2s_buf: [16384]u8 = undefined;
+    var s2c_buf: [16384]u8 = undefined;
+    var c2s_len: usize = 0;
+    var s2c_len: usize = 0;
+
+    var connected_client = false;
+    var sent_channel_data = false;
+    var duplex_event_seen = false;
+
+    const Endpoint = enum { client_ep, server_ep };
+    const endpoints = [_]Endpoint{ .client_ep, .server_ep };
+
+    var steps: usize = 0;
+    while (steps < 1000) : (steps += 1) {
+        if (sent_channel_data and duplex_event_seen) break;
+
+        for (endpoints) |ep| {
+            if (ep == .client_ep) {
+                const cev = client.getNextEvent() catch continue;
+                switch (cev) {
+                    .ReadyToProduce => {
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        // After connecting, try to send channel data while reading
+                        if (connected_client and !sent_channel_data) {
+                            const buf = client.getChannelWriteBuffer() catch continue;
+                            if (buf.len > 0) {
+                                const msg = "keyboard-input";
+                                @memcpy(buf[0..msg.len], msg);
+                                client.channelWriteComplete(msg.len) catch {};
+                                sent_channel_data = true;
+                            }
+                        }
+                        if (s2c_len > 0) {
+                            const feed = @min(n, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
+                    .ReadyToConsumeAndProduce => |s| {
+                        duplex_event_seen = true;
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                        if (s2c_len > 0) {
+                            const feed = @min(s.consume, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .CheckHostKey => client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {},
+                        .GetPrivateKey => client.clearEvent(.GetPrivateKey) catch {},
+                        .GetAuthPassphrase => {
+                            client.session.setAuthPassphrase("testpass") catch {};
+                            client.clearEvent(.GetAuthPassphrase) catch {};
+                        },
+                        .Connected => {
+                            connected_client = true;
+                            client.clearEvent(.Connected) catch {};
+                        },
+                        .EndSession => break,
+                        else => { client.clearEvent(code) catch {}; },
+                    },
+                }
+            } else {
+                const sev = server.getNextEvent() catch continue;
+                switch (sev) {
+                    .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                        const data = server.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(s2c_buf[s2c_len .. s2c_len + data.len], data);
+                        s2c_len += data.len;
+                        server.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        if (c2s_len > 0) {
+                            const feed = @min(n, c2s_len);
+                            server.write(c2s_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
+                            c2s_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .UserAuth => {
+                            server.grantAccess(true) catch {};
+                            server.clearEvent(.{ .UserAuth = .{ .username = "", .auth = null } }) catch {};
+                        },
+                        .Connected => server.clearEvent(.Connected) catch {},
+                        .ChannelRequest => server.clearEvent(.{ .ChannelRequest = .Shell }) catch {},
+                        else => { server.clearEvent(code) catch {}; },
+                    },
+                }
+            }
+        }
+    }
+
+    try std.testing.expect(connected_client);
+    try std.testing.expect(sent_channel_data);
 }

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -132,6 +132,7 @@ pub fn MisshodEvent(role:Role) type {
         Event: eventCodeType(role),
         ReadyToConsume: usize,
         ReadyToProduce: usize,
+        ReadyToConsumeAndProduce: struct { consume: usize, produce: usize },
     };
 }
 
@@ -170,34 +171,42 @@ pub fn MisshodImpl(role: Role) type {
     const Self = @This();
 
     session: sessionType(role),
-    iostate: IoState(role),
+    iostate_rd: IoState(role),
+    iostate_wr: IoState(role),
 
-    // io strategy, only ever reading or writing, always trying to get a fixed number of bytes
-    iobuf: [Protocol.MaxSSHPacket]u8 = undefined, // single shared buf, half duplex
-    iobuf_nbytes: usize,
-    iobuf_rdwroff: usize,
+    // full-duplex: separate read and write buffers
+    iobuf_rd: [Protocol.MaxSSHPacket]u8 = undefined,
+    iobuf_wr: [Protocol.MaxSSHPacket]u8 = undefined,
+    rd_nbytes: usize,
+    rd_off: usize,
+    wr_nbytes: usize,
+    wr_off: usize,
 
     pub fn init(rand: std.Random, username: []const u8, allocator: std.mem.Allocator) !Self {
         return Self{
             .session = try sessionType(role).init(rand, username, allocator),
-            .iobuf_nbytes = 0, // number of bytes in iobuf
-            .iobuf_rdwroff = 0, // rd offset into iobuf
-            .iostate = .Idle,
+            .rd_nbytes = 0,
+            .rd_off = 0,
+            .wr_nbytes = 0,
+            .wr_off = 0,
+            .iostate_rd = .Idle,
+            .iostate_wr = .Idle,
         };
     }
 
     pub fn deinit(self: *Self) void {
         self.session.deinit();
-        std.crypto.secureZero(u8, &self.iobuf);
+        std.crypto.secureZero(u8, &self.iobuf_rd);
+        std.crypto.secureZero(u8, &self.iobuf_wr);
     }
 
     // for session use
     pub fn requestWrite(self: *Self, wbuf: []const u8, next_state: Protocol.IoSessionState) void {
-        std.debug.assert(self.iostate == .Idle);
-        std.debug.assert(&wbuf[0] == &self.iobuf[0]);
-        self.iobuf_nbytes = wbuf.len;
-        self.iobuf_rdwroff = 0; // all writes start from start of buf
-        self.iostate = .{ .Active = .{
+        std.debug.assert(self.iostate_wr == .Idle);
+        std.debug.assert(&wbuf[0] == &self.iobuf_wr[0]);
+        self.wr_nbytes = wbuf.len;
+        self.wr_off = 0;
+        self.iostate_wr = .{ .Active = .{
             .action = .{ .Producing = wbuf.len },
             .next_state = next_state,
         } };
@@ -205,20 +214,17 @@ pub fn MisshodImpl(role: Role) type {
 
     // for session use
     pub fn requestRead(self: *Self, offset: usize, nbytes: usize, next_state: Protocol.IoSessionState) void {
-        self.iobuf_nbytes = 0;
-        self.iobuf_rdwroff = offset;
-        self.iostate = .{ .Active = .{
+        self.rd_nbytes = 0;
+        self.rd_off = offset;
+        self.iostate_rd = .{ .Active = .{
             .action = .{ .Consuming = nbytes },
             .next_state = next_state,
         } };
     }
 
     // for session use
-    // FIXME add event code
     pub fn requestEvent(self: *Self, code: eventCodeType(role), next_state: Protocol.IoSessionState) void {
-        self.iobuf_nbytes = 0; // unused
-        self.iobuf_rdwroff = 0; // unused
-        self.iostate = .{ .Active = .{
+        self.iostate_wr = .{ .Active = .{
             .action = .{ .Eventing = code },
             .next_state = next_state,
         } };
@@ -233,16 +239,16 @@ pub fn MisshodImpl(role: Role) type {
 
     pub fn clearEvent(self: *Self, clearEventCode: eventCodeType(role)) MisshodError!void {
         TRACE(.Debug, "clearEvent clearEventCode={any}", .{clearEventCode});
-        TRACE(.Debug, "clearEvent iostate={any}", .{self.iostate});
+        TRACE(.Debug, "clearEvent iostate_wr={any}", .{self.iostate_wr});
 
-        switch (self.iostate) {
+        switch (self.iostate_wr) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Eventing => |eventCode| {
                         if (@intFromEnum(eventCode) == @intFromEnum(clearEventCode)) {
                             // event succesfully cleared
                             self.session.setIoSessionState(iotype.next_state);
-                            self.iostate = .Idle;
+                            self.iostate_wr = .Idle;
                             try self.advance();
                             return;
                         }
@@ -258,7 +264,7 @@ pub fn MisshodImpl(role: Role) type {
 
     pub fn getNextEvent(self: *Self) MisshodError!MisshodEvent(role) {
         // if eventing, send an event
-        switch (self.iostate) {
+        switch (self.iostate_wr) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Eventing => |eventCode| {
@@ -270,77 +276,79 @@ pub fn MisshodImpl(role: Role) type {
             else => {},
         }
 
-        // else either .ReadyToConsume ^ .ReadyToProduce
+        // check both read and write readiness
         var can_consume_nbytes: usize = 0;
         var can_produce_nbytes: usize = 0;
 
         try self.getIoReq(&can_consume_nbytes, &can_produce_nbytes);
 
-        std.debug.assert(!(can_consume_nbytes > 0 and can_produce_nbytes > 0));
         std.debug.assert(can_consume_nbytes > 0 or can_produce_nbytes > 0);
 
-        if (can_consume_nbytes > 0) {
+        if (can_consume_nbytes > 0 and can_produce_nbytes > 0) {
+            return MisshodEvent(role){ .ReadyToConsumeAndProduce = .{ .consume = can_consume_nbytes, .produce = can_produce_nbytes } };
+        } else if (can_consume_nbytes > 0) {
             return MisshodEvent(role){ .ReadyToConsume = can_consume_nbytes };
         } else {
             return MisshodEvent(role){ .ReadyToProduce = can_produce_nbytes };
         }
-
-        unreachable;
     }
 
     fn getIoReq(self: *Self, can_consume: *usize, can_produce: *usize) MisshodError!void {
         try self.advance();
 
-        switch (self.iostate) {
-            .Idle => {
-                TRACE(.Debug, "getIoReq Idle", .{});
-                can_consume.* = 0;
-                can_produce.* = 0;
-            },
+        // check read side
+        can_consume.* = 0;
+        switch (self.iostate_rd) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Consuming => |target_size| {
-                        TRACE(.Debug, "getIoReq Consuming target_size={d} iobuf.len={d} iobuf.nbytes={d}", .{ target_size, self.iobuf.len, self.iobuf_nbytes });
-                        // reading from caller into iobuf
-                        if (target_size > self.iobuf.len - self.iobuf_nbytes) {
-                            can_consume.* = self.iobuf.len - self.iobuf_nbytes;
+                        TRACE(.Debug, "getIoReq Consuming target_size={d} iobuf_rd.len={d} rd_nbytes={d}", .{ target_size, self.iobuf_rd.len, self.rd_nbytes });
+                        if (target_size > self.iobuf_rd.len - self.rd_nbytes) {
+                            can_consume.* = self.iobuf_rd.len - self.rd_nbytes;
                         } else {
-                            can_consume.* = target_size - self.iobuf_nbytes;
+                            can_consume.* = target_size - self.rd_nbytes;
                         }
-                        can_produce.* = 0;
                     },
-                    .Producing => |block_size| {
-                        TRACE(.Debug, "getIoReq Producing {d} iobuf_nbytes={d}", .{ block_size, self.iobuf_nbytes });
-                        // being read by caller from iobuf
-                        can_produce.* = self.iobuf_nbytes; // number of bytes in buffer
-                        can_consume.* = 0;
-                    },
-                    .Eventing => {
-                        can_produce.* = 0;
-                        can_consume.* = 0;
-                    },
+                    else => {},
                 }
             },
+            else => {},
+        }
+
+        // check write side
+        can_produce.* = 0;
+        switch (self.iostate_wr) {
+            .Active => |iotype| {
+                switch (iotype.action) {
+                    .Producing => |block_size| {
+                        _ = block_size;
+                        TRACE(.Debug, "getIoReq Producing wr_nbytes={d}", .{self.wr_nbytes});
+                        can_produce.* = self.wr_nbytes;
+                    },
+                    else => {},
+                }
+            },
+            else => {},
         }
     }
 
     pub fn write(self: *Self, wbuf: []const u8) MisshodError!void {
-        TRACE(.Debug, "misshod.write len={d} .iobuf_nbytes={d}", .{ wbuf.len, self.iobuf_nbytes });
-        switch (self.iostate) {
+        TRACE(.Debug, "misshod.write len={d} .rd_nbytes={d}", .{ wbuf.len, self.rd_nbytes });
+        switch (self.iostate_rd) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Consuming => |target_size| {
-                        if (wbuf.len > target_size - self.iobuf_nbytes) {
+                        if (wbuf.len > target_size - self.rd_nbytes) {
                             return IoError.cannotAcceptWrite;
                         }
 
-                        @memcpy(self.iobuf[self.iobuf_nbytes + self.iobuf_rdwroff .. self.iobuf_nbytes + wbuf.len + self.iobuf_rdwroff], wbuf);
-                        self.iobuf_nbytes += wbuf.len;
+                        @memcpy(self.iobuf_rd[self.rd_nbytes + self.rd_off .. self.rd_nbytes + wbuf.len + self.rd_off], wbuf);
+                        self.rd_nbytes += wbuf.len;
 
-                        if (self.iobuf_nbytes == target_size) {
+                        if (self.rd_nbytes == target_size) {
                             // entire block has been written by caller
                             self.session.setIoSessionState(iotype.next_state);
-                            self.iostate = .Idle;
+                            self.iostate_rd = .Idle;
                             try self.advance();
                         }
                     },
@@ -352,9 +360,9 @@ pub fn MisshodImpl(role: Role) type {
     }
 
     pub fn peek(self: *Self, nbytes: usize) MisshodError![]const u8 {
-        TRACE(.Debug, "peek nbytes={d} .iobuf_rdwroff={d} .iobuf_nbytes={d}", .{ nbytes, self.iobuf_rdwroff, self.iobuf_nbytes });
+        TRACE(.Debug, "peek nbytes={d} .wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
         // sanity check
-        switch (self.iostate) {
+        switch (self.iostate_wr) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Producing => {}, // ok
@@ -364,22 +372,22 @@ pub fn MisshodImpl(role: Role) type {
             else => return IoError.notProducing,
         }
 
-        const bytes_remaining = self.iobuf_nbytes - self.iobuf_rdwroff;
+        const bytes_remaining = self.wr_nbytes - self.wr_off;
 
         if (bytes_remaining < nbytes) {
-            return self.iobuf[self.iobuf_rdwroff .. self.iobuf_rdwroff + bytes_remaining];
+            return self.iobuf_wr[self.wr_off .. self.wr_off + bytes_remaining];
         } else {
-            return self.iobuf[self.iobuf_rdwroff..self.iobuf_nbytes];
+            return self.iobuf_wr[self.wr_off..self.wr_nbytes];
         }
     }
 
     pub fn consumed(self: *Self, nbytes: usize) MisshodError!void {
-        TRACE(.Debug, "consumed nbytes={d} iobuf_rdwroff={d} .iobuf_nbytes={d}", .{ nbytes, self.iobuf_rdwroff, self.iobuf_nbytes });
+        TRACE(.Debug, "consumed nbytes={d} wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
 
-        const bytes_remaining = self.iobuf_nbytes - self.iobuf_rdwroff;
+        const bytes_remaining = self.wr_nbytes - self.wr_off;
 
         // sanity check
-        switch (self.iostate) {
+        switch (self.iostate_wr) {
             .Active => |iotype| {
                 switch (iotype.action) {
                     .Producing => {
@@ -393,14 +401,14 @@ pub fn MisshodImpl(role: Role) type {
             else => return IoError.notProducing,
         }
 
-        self.iobuf_rdwroff += nbytes;
+        self.wr_off += nbytes;
 
-        if (self.iobuf_rdwroff == self.iobuf_nbytes) {
+        if (self.wr_off == self.wr_nbytes) {
             // entire block has been consumed by caller
-            switch (self.iostate) {
+            switch (self.iostate_wr) {
                 .Active => |iotype| {
                     self.session.setIoSessionState(iotype.next_state);
-                    self.iostate = .Idle;
+                    self.iostate_wr = .Idle;
                     try self.advance();
                 },
                 else => unreachable,
@@ -463,7 +471,6 @@ pub fn MisshodImpl(role: Role) type {
 
 
     fn advanceIoSession(self:*Self, inkeys:*Protocol.KeyDataUni) MisshodError!void {
-        std.debug.assert(self.iostate == .Idle); // we only get called once IO completes
         switch (self.session.ioSessionState) {
             .Idle => {
                 TRACE(.Debug, "ioSessionState Idle", .{});
@@ -476,7 +483,7 @@ pub fn MisshodImpl(role: Role) type {
                 }
             },
             .VersionWrite => {
-                const sl = self.session.writeProtocolVersion(&self.iobuf);
+                const sl = self.session.writeProtocolVersion(&self.iobuf_wr);
                 switch(role) {
                     .Client => self.requestWrite(sl, .VersionReadLine),
                     .Server => self.requestWrite(sl, .Idle),
@@ -484,10 +491,10 @@ pub fn MisshodImpl(role: Role) type {
             },
             .VersionReadLine => {
                 // read first char
-                self.requestRead(0, 1, .{ .VersionReadLineChar = self.iobuf[0..1] });
+                self.requestRead(0, 1, .{ .VersionReadLineChar = self.iobuf_rd[0..1] });
             },
             .VersionReadLineChar => |buf| {
-                if (buf.len + 1 > self.iobuf.len) {
+                if (buf.len + 1 > self.iobuf_rd.len) {
                     return IoError.noEOLFound;
                 } else {
                     if (buf.len >= 2) {
@@ -497,7 +504,7 @@ pub fn MisshodImpl(role: Role) type {
                         }
                     }
                     // read next char
-                    self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf[0 .. buf.len + 1] });
+                    self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf_rd[0 .. buf.len + 1] });
                 }
             },
             .VersionReadLineCompletion => |buf| {
@@ -514,9 +521,9 @@ pub fn MisshodImpl(role: Role) type {
             },
             .ReadPktHdr => {
                 if (self.session.encrypted) {
-                    self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf[0..Protocol.AesCtrT.block_size] });
+                    self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.AesCtrT.block_size] });
                 } else {
-                    self.requestRead(0, Protocol.sizeof_PktHdr, .{ .ReadPktBody = self.iobuf[0..Protocol.sizeof_PktHdr] });
+                    self.requestRead(0, Protocol.sizeof_PktHdr, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.sizeof_PktHdr] });
                 }
             },
             .ReadPktBody => |buf| {
@@ -526,9 +533,9 @@ pub fn MisshodImpl(role: Role) type {
                     var firstblock_encbuf: [Protocol.AesCtrT.block_size]u8 = undefined;
                     @memcpy(&firstblock_encbuf, buf);
 
-                    // decrypt directly into iobuf
-                    inkeys.aesctr.encrypt(&firstblock_encbuf, self.iobuf[0..Protocol.AesCtrT.block_size]);
-                    TRACEDUMP(.Debug, "firstblock_dec(in payload)", .{}, self.iobuf[0..Protocol.AesCtrT.block_size]);
+                    // decrypt directly into iobuf_rd
+                    inkeys.aesctr.encrypt(&firstblock_encbuf, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
+                    TRACEDUMP(.Debug, "firstblock_dec(in payload)", .{}, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
 
                     // read Protocol.PktHdr from first block
                     const pkthdr_size = Protocol.sizeof_PktHdr;
@@ -557,7 +564,7 @@ pub fn MisshodImpl(role: Role) type {
                     }
                     TRACE(.Debug, "About to read {d}\n", .{remaining_pkt_bytes + Protocol.mac_algo.key_length});
                     //
-                    self.requestRead(buf.len, (remaining_pkt_bytes + Protocol.mac_algo.key_length), .{ .ReadPktCompletion = self.iobuf[0 .. buf.len + remaining_pkt_bytes + Protocol.mac_algo.key_length] }); // on completion, how much we have
+                    self.requestRead(buf.len, (remaining_pkt_bytes + Protocol.mac_algo.key_length), .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + remaining_pkt_bytes + Protocol.mac_algo.key_length] }); // on completion, how much we have
 
                     inkeys.seq +%= 1;
                 } else {
@@ -573,7 +580,7 @@ pub fn MisshodImpl(role: Role) type {
                     const payload_len = hdr.packet_length - hdr.padding_length - 1;
                     std.debug.assert(payload_len <= Protocol.MaxPayload);
 
-                    self.requestRead(buf.len, payload_len + hdr.padding_length, .{ .ReadPktCompletion = self.iobuf[0 .. buf.len + payload_len + hdr.padding_length] });
+                    self.requestRead(buf.len, payload_len + hdr.padding_length, .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + payload_len + hdr.padding_length] });
                     inkeys.seq +%= 1;
                 }
             },
@@ -585,12 +592,37 @@ pub fn MisshodImpl(role: Role) type {
     }
 
 
+    fn canProcessIoSessionState(self: *Self) bool {
+        return switch (self.session.ioSessionState) {
+            // Idle needs both sides free — session will decide what to do
+            .Idle => self.iostate_rd == .Idle and self.iostate_wr == .Idle,
+            .Init => true,
+            // Read-requiring states only need read side idle
+            .VersionReadLine, .VersionReadLineChar => self.iostate_rd == .Idle,
+            .ReadPktHdr, .ReadPktBody => self.iostate_rd == .Idle,
+            // Write-requiring states need write side idle
+            .VersionWrite => self.iostate_wr == .Idle,
+            // Processing states
+            .VersionReadLineCompletion => true, // just sets next ioSessionState
+            .ReadPktCompletion => self.iostate_wr == .Idle, // handlePacket may event/write
+        };
+    }
+
     pub fn advance(self: *Self) MisshodError!void {
-        while (self.iostate == .Idle) { // only ever in Idle at init time or after event, until everything gets flowing
-            switch(role) {
-                .Client => try self.advanceIoSession(&self.session.keydata.s2c),
-                .Server => try self.advanceIoSession(&self.session.keydata.c2s),
-            }
+        const inkeys = switch(role) {
+            .Client => &self.session.keydata.s2c,
+            .Server => &self.session.keydata.c2s,
+        };
+        while (self.canProcessIoSessionState()) {
+            const prev_io_state = self.session.ioSessionState;
+            const prev_rd = self.iostate_rd;
+            const prev_wr = self.iostate_wr;
+            try self.advanceIoSession(inkeys);
+            // Break if no progress was made to prevent infinite loops
+            const same_io = std.meta.eql(prev_io_state, self.session.ioSessionState);
+            const same_rd = std.meta.eql(prev_rd, self.iostate_rd);
+            const same_wr = std.meta.eql(prev_wr, self.iostate_wr);
+            if (same_io and same_rd and same_wr) break;
         }
     }
 
@@ -616,13 +648,21 @@ pub fn MisshodImpl(role: Role) type {
     }
 
     pub fn channelWriteComplete(self: *Self, nbytes: usize) MisshodError!void {
-        // assumes that getChannelWriteBuffer() is called then channelWriteComplete()
-        self.iostate = .Idle;
-        try self.advance();
+        if (self.iostate_wr == .Idle and self.iostate_rd != .Idle) {
+            // Full-duplex: read is active, write is idle
+            // Build channel data packet directly without disturbing the read side
+            try self.session.directChannelWrite(nbytes, self);
+        } else {
+            // Sequential fallback (e.g. during handshake or when both idle)
+            self.iostate_rd = .Idle;
+            self.iostate_wr = .Idle;
+            try self.advance();
 
-        try self.session.channelWriteComplete(nbytes);
-        self.iostate = .Idle;
-        try self.advance();
+            try self.session.channelWriteComplete(nbytes);
+            self.iostate_rd = .Idle;
+            self.iostate_wr = .Idle;
+            try self.advance();
+        }
     }
 };
 }
@@ -795,6 +835,18 @@ test "client-server full handshake round-trip" {
                             s2c_len -= feed;
                         }
                     },
+                    .ReadyToConsumeAndProduce => |s| {
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                        if (s2c_len > 0) {
+                            const feed = @min(s.consume, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
                     .Event => |code| switch (code) {
                         .CheckHostKey => { client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {}; },
                         .GetPrivateKey => { client.clearEvent(.GetPrivateKey) catch {}; },
@@ -822,6 +874,18 @@ test "client-server full handshake round-trip" {
                     .ReadyToConsume => |n| {
                         if (c2s_len > 0) {
                             const feed = @min(n, c2s_len);
+                            server.write(c2s_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
+                            c2s_len -= feed;
+                        }
+                    },
+                    .ReadyToConsumeAndProduce => |s| {
+                        const data = server.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(s2c_buf[s2c_len .. s2c_len + data.len], data);
+                        s2c_len += data.len;
+                        server.consumed(data.len) catch {};
+                        if (c2s_len > 0) {
+                            const feed = @min(s.consume, c2s_len);
                             server.write(c2s_buf[0..feed]) catch {};
                             std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
                             c2s_len -= feed;

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -154,7 +154,7 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .KexInitWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT));
                 var cookie: [16]u8 = undefined;
                 self.rand.bytes(&cookie);
@@ -178,14 +178,14 @@ pub const Session = struct {
                 self.kex_hash_order = self.kex_hash_order.check(.I_S);
                 self.kex_hasher.writeU32LenString(pkt.active());
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.EcdhInitRead);
             },
             .EcdhInitRead => {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .EcdhReplyWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
 
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_REPLY));
 
@@ -241,15 +241,15 @@ pub const Session = struct {
                 // generate keys
                 try self.keydata.genKeys(kexhash, self.shared_secret_k, self.session_id);
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
 
                 self.setSessionState(.NewKeysWrite);
             },
             .NewKeysWrite => {
                 // https://datatracker.ietf.org/doc/html/rfc4253#section-7.2
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.NewKeysRead);
 
             },
@@ -260,31 +260,31 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .AuthRspServReqSuccess => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_SERVICE_ACCEPT));
                 try pkt.writeU32LenString("ssh-userauth");
                 self.setSessionState(.AuthRead);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .CheckUserPasswordAuth => {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .UserPasswordAuthDenied => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_FAILURE));
                 try pkt.writeU32LenString("password,publickey");
                 try pkt.writeBoolean(false);    // partial success
                 self.setSessionState(.AuthRead);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .UserAuthAccepted => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS));
                 self.setSessionState(.Authenticated);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .AuthPkAllowed => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_PK_OK));
                 try pkt.writeU32LenString(Protocol.srv_hostkey_algo_name);
 
@@ -295,28 +295,28 @@ pub const Session = struct {
 
                 try pkt.writeU32LenString(typed_pubkey_buf.payload);
                 self.setSessionState(.AuthRead);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .Authenticated => {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .ChannelOpenConfirmWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
                 try pkt.writeU32(self.chan);
                 try pkt.writeU32(self.chan);
                 try pkt.writeU32(Protocol.MaxPayload); // init window size
                 try pkt.writeU32(Protocol.MaxPayload); // max packet size
                 self.setSessionState(.ChannelConnected);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .ChannelRspWrite => {
                 //https://datatracker.ietf.org/doc/html/rfc4254#section-5.4
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_SUCCESS));
                 try pkt.writeU32(self.chan);
                 self.setSessionState(.ChannelData);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .ChannelConnected => {
                 misshod.requestEvent(.Connected, .Idle);
@@ -333,11 +333,11 @@ pub const Session = struct {
             },
             .ChannelDataRxAdjustWindow => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.2
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
                 try pkt.writeU32(0); // channel
                 try pkt.writeU32(Protocol.MaxPayload); // bytes to add
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelDataTx);
             },
             .ChannelDataRx => {
@@ -351,11 +351,11 @@ pub const Session = struct {
                     self.setSessionState(.ChannelDataRx);
                     return;
                 }
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
                 try pkt.writeU32(self.chan);
                 try pkt.writeU32LenString(self.channel_write_buf[0..send_len]);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.peer_window -= @intCast(send_len);
                 self.setSessionState(.ChannelDataTxComplete);
             },
@@ -365,12 +365,12 @@ pub const Session = struct {
             },
             .ChannelCloseWrite => {
                 // RFC 4254 §5.3 - send CHANNEL_CLOSE back to peer
-                var pkt = BufferWriter.init(&misshod.iobuf, Protocol.sizeof_PktHdr);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
                 try pkt.writeU32(self.chan);
                 self.channel_close_sent = true;
                 self.setSessionState(.ChannelClosed);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf), .Idle);
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .ChannelClosed => {
                 misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
@@ -394,6 +394,26 @@ pub const Session = struct {
         self.channel_write_buf_nbytes = nbytes;
         self.setSessionState(.ChannelData);
         self.setIoSessionState(.Idle);
+    }
+
+    // Full-duplex: build and send channel data packet directly without going through state machine
+    pub fn directChannelWrite(self: *Self, nbytes: usize, misshod: *MisshodServer) MisshodError!void {
+        if (nbytes > self.channel_write_buf.len) {
+            return IoError.tooBig;
+        }
+        self.channel_write_buf_nbytes = nbytes;
+        const outkeys = &self.keydata.s2c;
+        const send_len = @min(self.channel_write_buf_nbytes, self.peer_window);
+        if (send_len == 0) {
+            return;
+        }
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
+        try pkt.writeU32(self.chan);
+        try pkt.writeU32LenString(self.channel_write_buf[0..send_len]);
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+        self.peer_window -= @intCast(send_len);
+        self.channel_write_buf_nbytes = 0;
     }
 
     pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
@@ -436,7 +456,7 @@ pub const Session = struct {
     }
 
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodServer) MisshodError!void {
-        var rdr = try misshod.getRecvBuffer(misshod.iobuf[0..buf.len], &self.keydata.c2s);
+        var rdr = try misshod.getRecvBuffer(misshod.iobuf_rd[0..buf.len], &self.keydata.c2s);
 
         const msgid = try rdr.readU8();
 

--- a/tiny/src/main.zig
+++ b/tiny/src/main.zig
@@ -55,14 +55,16 @@ pub fn main() !void {
                     },
                 }
             },
-            .ReadyToConsume, .ReadyToProduce => |len| {
-                var pollevts: i16 = 0;
+            .ReadyToConsume, .ReadyToProduce, .ReadyToConsumeAndProduce => {
+                const consume_len: usize = switch (ev) {
+                    .ReadyToConsume => |n| n,
+                    .ReadyToConsumeAndProduce => |s| s.consume,
+                    else => 0,
+                };
 
-                if (ev == .ReadyToConsume) {
-                    pollevts |= std.posix.POLL.IN;
-                } else {
-                    pollevts |= std.posix.POLL.OUT;
-                }
+                var pollevts: i16 = 0;
+                if (consume_len > 0) pollevts |= std.posix.POLL.IN;
+                if (ev == .ReadyToProduce or ev == .ReadyToConsumeAndProduce) pollevts |= std.posix.POLL.OUT;
 
                 var fds = [_]std.posix.pollfd{
                     .{
@@ -74,26 +76,21 @@ pub fn main() !void {
 
                 const ready = std.posix.poll(&fds, 1000) catch 0;
                 if (ready > 0) {
-                    if (fds[0].revents & std.posix.POLL.IN > 0) { // socket is readable
-                        var bytes_to_read = len;
+                    if (fds[0].revents & std.posix.POLL.IN > 0 and consume_len > 0) {
+                        var bytes_to_read = consume_len;
                         if (bytes_to_read > iobuf.len) {
                             bytes_to_read = iobuf.len;
                         }
                         const nbytes = try stdin_reader.read(iobuf[0..bytes_to_read]);
-                        //std.debug.assert(nbytes > 0);
                         if (nbytes > 0) {
                             try misshod.write(iobuf[0..nbytes]);
                         }
                     }
-                    if (fds[0].revents & std.posix.POLL.OUT > 0) { // socket is writeable
-                        const towrite = try misshod.peek(128); // get data it wants to send up to a limit
+                    if (fds[0].revents & std.posix.POLL.OUT > 0) {
+                        const towrite = try misshod.peek(128);
                         const bytes_written = try stdout_writer.write(towrite);
-                        //std.debug.print("bytes_written = {d} towrite={d}\n", .{bytes_written, towrite.len});
-                        // socket may not have accepted all of the bytes
                         try misshod.consumed(bytes_written);
                     }
-                } else {
-                    //std.debug.print("timeout\n", .{});
                 }
             },
         }


### PR DESCRIPTION
## Summary

Splits the single shared `iobuf` into independent read (`iobuf_rd`) and write (`iobuf_wr`) buffers with separate I/O states, enabling the session to read and write simultaneously during the channel-data phase.

## Changes

- **Split buffers**: `iobuf` → `iobuf_rd` + `iobuf_wr` (each 4KB), with independent tracking (`rd_nbytes`/`rd_off`, `wr_nbytes`/`wr_off`)
- **Split I/O state**: `iostate` → `iostate_rd` (Consuming) + `iostate_wr` (Producing/Eventing)
- **New event variant**: `ReadyToConsumeAndProduce` signals both directions are ready simultaneously
- **Smart advance loop**: `canProcessIoSessionState()` determines which side needs to be idle for each protocol state
- **Direct channel writes**: `directChannelWrite()` builds packets without cancelling active reads
- **Updated callers**: mssh, msshd, tiny poll for both POLLIN and POLLOUT when both sides are ready

## Design

During the handshake, behavior remains sequential — only one side is active at a time. Full-duplex concurrency manifests in the channel-data phase where the caller can read from the network while simultaneously writing outbound data.

Memory impact: one additional 4KB buffer per session.

All 55 existing tests pass.

Closes #21