### PR TITLE
Per-channel receive-window accounting

### DIFF
--- a/src/channel.zig
+++ b/src/channel.zig
@@ -9,7 +9,6 @@ pub const ChannelState = enum {
     RspWrite,
     Connected,
     Data,
-    DataRxAdjustWindow,
     DataRx,
     DataTx,
     DataTxComplete,
@@ -52,6 +51,21 @@ pub const Channel = struct {
 
     pub fn secureZero(self: *Self) void {
         std.crypto.secureZero(u8, &self.write_buf);
+    }
+
+    /// Decrement local_window by the amount of data received.
+    pub fn consumeLocalWindow(self: *Self, len: u32) void {
+        self.local_window -|= len; // saturating subtract
+    }
+
+    /// Returns true if local_window has dropped below the replenish threshold.
+    pub fn needsWindowAdjust(self: *const Self) bool {
+        return self.local_window < Protocol.MaxPayload / 2;
+    }
+
+    /// Returns the number of bytes to add to bring local_window back to MaxPayload.
+    pub fn windowAdjustAmount(self: *const Self) u32 {
+        return Protocol.MaxPayload - self.local_window;
     }
 };
 
@@ -126,7 +140,7 @@ pub const ChannelTable = struct {
             .ConfirmWrite, .RspWrite, .CloseWrite, .OpenFailureWrite => true,
             .Connected => true,
             .Data => true,
-            .DataRxAdjustWindow, .DataTx, .DataTxComplete => true,
+            .DataTx, .DataTxComplete => true,
             .DataRx, .Open, .Closed => false,
         };
     }
@@ -332,4 +346,43 @@ test "findNextRunnable returns null when no channels runnable" {
     const ch1 = table.allocChannel(20, 32768, 32768).?;
     ch1.state = .DataRx;
     try std.testing.expect(table.findNextRunnable() == null);
+}
+
+test "consumeLocalWindow decrements local_window" {
+    var ch = Channel.init(0, 1, 32768, 32768);
+    const initial = ch.local_window;
+    ch.consumeLocalWindow(100);
+    try std.testing.expectEqual(initial - 100, ch.local_window);
+}
+
+test "consumeLocalWindow saturates at zero" {
+    var ch = Channel.init(0, 1, 32768, 32768);
+    ch.local_window = 50;
+    ch.consumeLocalWindow(200);
+    try std.testing.expectEqual(@as(u32, 0), ch.local_window);
+}
+
+test "needsWindowAdjust triggers below half MaxPayload" {
+    var ch = Channel.init(0, 1, 32768, 32768);
+    // At full window — no adjust needed
+    try std.testing.expect(!ch.needsWindowAdjust());
+
+    // Just above threshold — no adjust
+    ch.local_window = Protocol.MaxPayload / 2;
+    try std.testing.expect(!ch.needsWindowAdjust());
+
+    // Below threshold — adjust needed
+    ch.local_window = Protocol.MaxPayload / 2 - 1;
+    try std.testing.expect(ch.needsWindowAdjust());
+}
+
+test "windowAdjustAmount replenishes to MaxPayload" {
+    var ch = Channel.init(0, 1, 32768, 32768);
+    ch.local_window = 100;
+    const adjust = ch.windowAdjustAmount();
+    try std.testing.expectEqual(Protocol.MaxPayload - 100, adjust);
+
+    // After applying the adjust, window should be MaxPayload
+    ch.local_window += adjust;
+    try std.testing.expectEqual(Protocol.MaxPayload, ch.local_window);
 }

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -511,7 +511,18 @@ pub const Session = struct {
                     try pkt.writeU32(wc[3]); // height_px
                     misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 } else if (chan.write_buf_nbytes > 0) {
-                    chan.state = .DataRxAdjustWindow;
+                    chan.state = .DataTx;
+                } else if (chan.needsWindowAdjust()) {
+                    // RFC 4254 §5.2 — replenish receive window
+                    var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                    try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
+                    try pkt.writeU32(chan.remote_id);
+                    const adjust = chan.windowAdjustAmount();
+                    try pkt.writeU32(adjust);
+                    chan.local_window += adjust;
+                    misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                    chan.state = .DataRx;
+                    self.active_channel_id = null;
                 } else {
                     chan.state = .DataRx;
                     self.active_channel_id = null;
@@ -519,14 +530,6 @@ pub const Session = struct {
                 if (self.channel_table.findNextRunnable()) |_| {} else {
                     self.setIoSessionState(.ReadPktHdr);
                 }
-            },
-            .DataRxAdjustWindow => {
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
-                try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32(Protocol.MaxPayload);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                chan.state = .DataTx;
             },
             .DataRx => {
                 self.active_channel_id = null;
@@ -896,6 +899,7 @@ pub const Session = struct {
                     return IoError.UnexpectedResponse;
                 }
                 const s = try rdr.readU32LenString();
+                chan.consumeLocalWindow(@intCast(s.len));
                 misshod.requestEvent(.{ .RxData = s }, .Idle);
                 chan.state = .Data;
                 self.active_channel_id = chan.local_id;
@@ -912,6 +916,7 @@ pub const Session = struct {
                 }
                 const data_type = try rdr.readU32();
                 const s = try rdr.readU32LenString();
+                chan.consumeLocalWindow(@intCast(s.len));
                 misshod.requestEvent(.{ .RxExtendedData = .{ .data_type = data_type, .data = s } }, .Idle);
                 chan.state = .Data;
                 self.active_channel_id = chan.local_id;

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -343,7 +343,18 @@ pub const Session = struct {
             },
             .Data => {
                 if (chan.write_buf_nbytes > 0) {
-                    chan.state = .DataRxAdjustWindow;
+                    chan.state = .DataTx;
+                } else if (chan.needsWindowAdjust()) {
+                    // RFC 4254 §5.2 — replenish receive window
+                    var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                    try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
+                    try pkt.writeU32(chan.remote_id);
+                    const adjust = chan.windowAdjustAmount();
+                    try pkt.writeU32(adjust);
+                    chan.local_window += adjust;
+                    misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                    chan.state = .DataRx;
+                    self.active_channel_id = null;
                 } else {
                     chan.state = .DataRx;
                     self.active_channel_id = null;
@@ -351,14 +362,6 @@ pub const Session = struct {
                 if (self.channel_table.findNextRunnable()) |_| {} else {
                     self.setIoSessionState(.ReadPktHdr);
                 }
-            },
-            .DataRxAdjustWindow => {
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
-                try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32(Protocol.MaxPayload);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                chan.state = .DataTx;
             },
             .DataRx => {
                 self.active_channel_id = null;
@@ -841,6 +844,7 @@ pub const Session = struct {
                     return IoError.UnexpectedResponse;
                 }
                 const s = try rdr.readU32LenString();
+                chan.consumeLocalWindow(@intCast(s.len));
                 misshod.requestEvent(.{ .RxData = .{ .channel = chan.local_id, .data = s } }, .Idle);
                 chan.state = .Data;
                 self.active_channel_id = chan.local_id;
@@ -857,6 +861,7 @@ pub const Session = struct {
                 }
                 const data_type = try rdr.readU32();
                 const s = try rdr.readU32LenString();
+                chan.consumeLocalWindow(@intCast(s.len));
                 misshod.requestEvent(.{ .RxExtendedData = .{ .channel = chan.local_id, .data_type = data_type, .data = s } }, .Idle);
                 chan.state = .Data;
                 self.active_channel_id = chan.local_id;


### PR DESCRIPTION
Fixes #40

## Summary

Implements proper per-channel receive-window tracking per RFC 4254 §5.2. Previously, `WINDOW_ADJUST` was sent unconditionally before every outbound data send. Now the receiver tracks consumed window space and only sends `WINDOW_ADJUST` when the window drops below a threshold.

### Changes
- **`src/channel.zig`**: Added `consumeLocalWindow()`, `needsWindowAdjust()`, `windowAdjustAmount()` helpers. Removed `DataRxAdjustWindow` from `ChannelState` enum.
- **`src/server_session.zig`**: Decrements `local_window` on inbound `CHANNEL_DATA`/`CHANNEL_EXTENDED_DATA`. Sends `WINDOW_ADJUST` in `Data` state when threshold is crossed. Outbound data path goes directly to `DataTx`.
- **`src/client_session.zig`**: Same pattern as server.

### Threshold
Window adjust is sent when `local_window < MaxPayload / 2`, replenishing back to `MaxPayload`.

### Testing
99 tests pass including 4 new window-accounting tests:
- `consumeLocalWindow` decrements correctly / saturates at zero
- `needsWindowAdjust` triggers below half MaxPayload
- `windowAdjustAmount` replenishes to MaxPayload