### PR TITLE
Enforce EOF half-close semantics per channel

### DIFF
--- a/src/channel.zig
+++ b/src/channel.zig
@@ -12,6 +12,7 @@ pub const ChannelState = enum {
     DataRx,
     DataTx,
     DataTxComplete,
+    EofWrite,
     CloseWrite,
     Closed,
     OpenFailureWrite,
@@ -137,7 +138,7 @@ pub const ChannelTable = struct {
 
     fn isRunnable(state: ChannelState) bool {
         return switch (state) {
-            .ConfirmWrite, .RspWrite, .CloseWrite, .OpenFailureWrite => true,
+            .ConfirmWrite, .RspWrite, .CloseWrite, .OpenFailureWrite, .EofWrite => true,
             .Connected => true,
             .Data => true,
             .DataTx, .DataTxComplete => true,
@@ -385,4 +386,19 @@ test "windowAdjustAmount replenishes to MaxPayload" {
     // After applying the adjust, window should be MaxPayload
     ch.local_window += adjust;
     try std.testing.expectEqual(Protocol.MaxPayload, ch.local_window);
+}
+
+test "EofWrite is a runnable state" {
+    var table = ChannelTable{};
+    const ch = table.allocChannel(10, 32768, 32768).?;
+    ch.state = .EofWrite;
+    const runnable = table.findNextRunnable();
+    try std.testing.expect(runnable != null);
+    try std.testing.expectEqual(@as(u32, 0), runnable.?.local_id);
+}
+
+test "eof_sent and eof_received start false" {
+    const ch = Channel.init(0, 1, 32768, 32768);
+    try std.testing.expect(!ch.eof_sent);
+    try std.testing.expect(!ch.eof_received);
 }

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -556,6 +556,15 @@ pub const Session = struct {
                 chan.write_buf_nbytes = 0;
                 chan.state = .Data;
             },
+            .EofWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF));
+                try pkt.writeU32(chan.remote_id);
+                chan.eof_sent = true;
+                chan.state = .DataRx;
+                self.active_channel_id = null;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+            },
             .CloseWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
@@ -582,6 +591,7 @@ pub const Session = struct {
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
         if (self.channel_table.findByLocalId(channel_id)) |chan| {
+            if (chan.eof_sent) return &.{};
             if (chan.write_buf_nbytes > 0) {
                 return &.{};
             } else {
@@ -593,6 +603,7 @@ pub const Session = struct {
 
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
@@ -609,6 +620,7 @@ pub const Session = struct {
     // Full-duplex: build and send channel data packet directly without going through state machine
     pub fn directChannelWrite(self: *Self, channel_id: u32, nbytes: usize, misshod: *MisshodClient) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
@@ -626,6 +638,15 @@ pub const Session = struct {
         misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
         chan.peer_window -= @intCast(send_len);
         chan.write_buf_nbytes = 0;
+    }
+
+    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return;
+        chan.state = .EofWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
     }
 
     pub fn sendWindowChange(self: *Self, cols: u32, rows: u32, width_px: u32, height_px: u32) void {
@@ -895,6 +916,11 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                     return;
                 };
+                if (chan.eof_received) {
+                    TRACE(.Debug, "discarding data after EOF on channel {d}", .{channelnum});
+                    self.setIoSessionState(.ReadPktHdr);
+                    return;
+                }
                 if (chan.state != .DataRx) {
                     return IoError.UnexpectedResponse;
                 }
@@ -911,6 +937,11 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                     return;
                 };
+                if (chan.eof_received) {
+                    TRACE(.Debug, "discarding extended data after EOF on channel {d}", .{channelnum});
+                    self.setIoSessionState(.ReadPktHdr);
+                    return;
+                }
                 if (chan.state != .DataRx) {
                     return IoError.UnexpectedResponse;
                 }

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -682,6 +682,12 @@ pub fn MisshodImpl(role: Role) type {
             try self.advance();
         }
     }
+
+    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+        try self.session.sendChannelEof(channel_id);
+        self.iostate_wr = .Idle;
+        try self.advance();
+    }
 };
 }
 

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -388,6 +388,16 @@ pub const Session = struct {
                 chan.write_buf_nbytes = 0;
                 chan.state = .Data;
             },
+            .EofWrite => {
+                // RFC 4254 §5.3 — send EOF to signal no more data from us
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF));
+                try pkt.writeU32(chan.remote_id);
+                chan.eof_sent = true;
+                chan.state = .DataRx;
+                self.active_channel_id = null;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+            },
             .CloseWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
@@ -414,6 +424,7 @@ pub const Session = struct {
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
         if (self.channel_table.findByLocalId(channel_id)) |chan| {
+            if (chan.eof_sent) return &.{};
             if (chan.write_buf_nbytes > 0 and self.ioSessionState == .Idle) {
                 return &.{};
             } else {
@@ -425,6 +436,7 @@ pub const Session = struct {
 
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
@@ -438,6 +450,7 @@ pub const Session = struct {
     // Full-duplex: build and send channel data packet directly without going through state machine
     pub fn directChannelWrite(self: *Self, channel_id: u32, nbytes: usize, misshod: *MisshodServer) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
@@ -455,6 +468,15 @@ pub const Session = struct {
         misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
         chan.peer_window -= @intCast(send_len);
         chan.write_buf_nbytes = 0;
+    }
+
+    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent) return;
+        chan.state = .EofWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
     }
 
     pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
@@ -840,6 +862,12 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                     return;
                 };
+                if (chan.eof_received) {
+                    // Peer sent EOF then data — protocol violation, silently discard
+                    TRACE(.Debug, "discarding data after EOF on channel {d}", .{channelnum});
+                    self.setIoSessionState(.ReadPktHdr);
+                    return;
+                }
                 if (chan.state != .DataRx) {
                     return IoError.UnexpectedResponse;
                 }
@@ -856,6 +884,11 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                     return;
                 };
+                if (chan.eof_received) {
+                    TRACE(.Debug, "discarding extended data after EOF on channel {d}", .{channelnum});
+                    self.setIoSessionState(.ReadPktHdr);
+                    return;
+                }
                 if (chan.state != .DataRx) {
                     return IoError.UnexpectedResponse;
                 }


### PR DESCRIPTION
Fixes #41

## Summary

Implements proper EOF enforcement per RFC 4254 §5.3. Previously, `eof_received` and `eof_sent` flags were set but never enforced.

### Inbound guard
- `CHANNEL_DATA` and `CHANNEL_EXTENDED_DATA` are silently discarded if `chan.eof_received` (peer promised no more data)

### Outbound guard  
- `getChannelWriteBuffer()` returns empty buffer if `chan.eof_sent`
- `channelWriteComplete()` and `directChannelWrite()` return `UnexpectedResponse` if `chan.eof_sent`

### New API
- `sendChannelEof(channel_id)` — triggers `EofWrite` state which sends `SSH_MSG_CHANNEL_EOF` and transitions to `DataRx` (channel stays open for inbound data)
- Available on both server/client `Session` and the `MisshodImpl` wrapper

### Testing
101 tests pass (+6 from baseline) including 2 new EOF-specific tests.