### PR TITLE
Add client API for opening session channels

### DIFF
--- a/src/channel.zig
+++ b/src/channel.zig
@@ -3,7 +3,13 @@ const Protocol = @import("protocol.zig");
 
 pub const MaxChannels = 4;
 
+pub const ClientChannelOpenMode = enum {
+    AutoShell,
+    RawSession,
+};
+
 pub const ChannelState = enum {
+    OpenWrite,
     Open,
     ConfirmWrite,
     RspWrite,
@@ -32,6 +38,7 @@ pub const Channel = struct {
     eof_received: bool,
     close_sent: bool,
     close_received: bool,
+    client_open_mode: ClientChannelOpenMode,
     state: ChannelState,
 
     pub fn init(local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
@@ -46,6 +53,7 @@ pub const Channel = struct {
             .eof_received = false,
             .close_sent = false,
             .close_received = false,
+            .client_open_mode = .RawSession,
             .state = .Open,
         };
     }
@@ -138,7 +146,7 @@ pub const ChannelTable = struct {
 
     fn isRunnable(state: ChannelState) bool {
         return switch (state) {
-            .ConfirmWrite, .RspWrite, .CloseWrite, .OpenFailureWrite, .EofWrite => true,
+            .OpenWrite, .ConfirmWrite, .RspWrite, .CloseWrite, .OpenFailureWrite, .EofWrite => true,
             .Connected => true,
             .Data => true,
             .DataTx, .DataTxComplete => true,
@@ -228,6 +236,7 @@ test "Channel init sets default values" {
     try std.testing.expect(!ch.eof_received);
     try std.testing.expect(!ch.close_sent);
     try std.testing.expect(!ch.close_received);
+    try std.testing.expectEqual(ClientChannelOpenMode.RawSession, ch.client_open_mode);
     try std.testing.expectEqual(ChannelState.Open, ch.state);
 }
 
@@ -347,6 +356,15 @@ test "findNextRunnable returns null when no channels runnable" {
     const ch1 = table.allocChannel(20, 32768, 32768).?;
     ch1.state = .DataRx;
     try std.testing.expect(table.findNextRunnable() == null);
+}
+
+test "OpenWrite channel state is runnable" {
+    var table = ChannelTable{};
+    const ch = table.allocChannel(10, 32768, 32768).?;
+    ch.state = .OpenWrite;
+
+    const runnable = table.findNextRunnable().?;
+    try std.testing.expectEqual(ch.local_id, runnable.local_id);
 }
 
 test "consumeLocalWindow decrements local_window" {

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -17,6 +17,7 @@ const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
 const ChannelTable = @import("channel.zig").ChannelTable;
 const ChannelState = @import("channel.zig").ChannelState;
+const ClientChannelOpenMode = @import("channel.zig").ClientChannelOpenMode;
 
 pub const SessionState = enum {
     Init,
@@ -131,6 +132,12 @@ pub const Session = struct {
         self.sessionState = newState;
     }
 
+    fn allocateClientSessionChannel(self: *Self, mode: ClientChannelOpenMode) MisshodError!*Channel {
+        const chan = self.channel_table.allocChannel(0, 0, 0) orelse return IoError.tooManyChannels;
+        chan.client_open_mode = mode;
+        chan.state = .OpenWrite;
+        return chan;
+    }
 
     pub fn advanceSession(self: *Self, misshod: *MisshodClient) MisshodError!void {
         const outkeys = &self.keydata.c2s;
@@ -386,19 +393,9 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .ChannelOpenReq => {
-                const chan = self.channel_table.allocChannel(0, 0, 0) orelse {
-                    return IoError.UnexpectedResponse;
-                };
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
-                // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
-                try pkt.writeU32LenString("session"); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
-                try pkt.writeU32(chan.local_id); // sender channel
-                try pkt.writeU32(Protocol.MaxPayload); // initial window size
-                try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                const chan = try self.allocateClientSessionChannel(.AutoShell);
                 self.active_channel_id = chan.local_id;
-                self.setSessionState(.ChannelOpenRsp);
+                self.setSessionState(.ChannelActive);
             },
             .ChannelOpenRsp => {
                 self.setIoSessionState(.ReadPktHdr);
@@ -424,6 +421,17 @@ pub const Session = struct {
         self.active_channel_id = chan.local_id;
 
         switch (chan.state) {
+            .OpenWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+                // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
+                try pkt.writeU32LenString("session"); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
+                try pkt.writeU32(chan.local_id); // sender channel
+                try pkt.writeU32(Protocol.MaxPayload); // initial window size
+                try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                self.setSessionState(.ChannelOpenRsp);
+            },
             .Open => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
@@ -601,6 +609,21 @@ pub const Session = struct {
         return &.{};
     }
 
+    pub fn openSessionChannel(self: *Self, misshod: *MisshodClient) MisshodError!u32 {
+        if (misshod.iostate_wr != .Idle or self.active_channel_id != null) {
+            return IoError.cannotAcceptWrite;
+        }
+        if (self.sessionState != .ChannelActive) {
+            return IoError.NotReady;
+        }
+
+        const chan = try self.allocateClientSessionChannel(.RawSession);
+        self.active_channel_id = chan.local_id;
+        self.setIoSessionState(.Idle);
+        try self.advanceChannel(misshod, &self.keydata.c2s);
+        return chan.local_id;
+    }
+
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
         if (chan.eof_sent) return IoError.UnexpectedResponse;
@@ -722,8 +745,7 @@ pub const Session = struct {
 
                 const is_rekey = self.sessionState != .KexInitRead;
                 if (is_rekey) {
-                    if (self.sessionState != .ChannelActive)
-                    {
+                    if (self.sessionState != .ChannelActive) {
                         self.setIoSessionState(.ReadPktHdr);
                         return;
                     }
@@ -902,10 +924,41 @@ pub const Session = struct {
                     chan.remote_id = sender;
                     chan.peer_window = peer_window;
                     chan.remote_max_packet_size = max_packet_size;
-                    chan.state = .Open;
-                    self.active_channel_id = chan.local_id;
+                    switch (chan.client_open_mode) {
+                        .AutoShell => {
+                            chan.state = .Open;
+                            self.active_channel_id = chan.local_id;
+                            self.setSessionState(.ChannelActive);
+                            self.setIoSessionState(.Idle);
+                        },
+                        .RawSession => {
+                            chan.state = .Data;
+                            self.active_channel_id = chan.local_id;
+                            self.setSessionState(.ChannelActive);
+                            misshod.requestEvent(.{ .ChannelOpened = chan.local_id }, .Idle);
+                        },
+                    }
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE) => {
+                // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
+                const recipient = try rdr.readU32(); // recipient channel
+                const reason_code = try rdr.readU32();
+                const description = try rdr.readU32LenString();
+                _ = try rdr.readU32LenString(); // language tag
+
+                if (self.channel_table.findByLocalId(recipient)) |chan| {
+                    const local_id = chan.local_id;
+                    self.channel_table.freeChannel(local_id);
+                    self.active_channel_id = null;
                     self.setSessionState(.ChannelActive);
-                    self.setIoSessionState(.Idle);
+                    misshod.requestEvent(.{ .ChannelOpenFailure = .{
+                        .channel = local_id,
+                        .reason_code = reason_code,
+                        .description = description,
+                    } }, .Idle);
                 } else {
                     self.setIoSessionState(.ReadPktHdr);
                 }
@@ -1027,7 +1080,6 @@ pub const Session = struct {
             },
         }
     }
-
 };
 
 fn nameListContains(namelist: []const u8, target: []const u8) bool {
@@ -1037,7 +1089,6 @@ fn nameListContains(namelist: []const u8, target: []const u8) bool {
     }
     return false;
 }
-
 
 // Helper: build an unencrypted SSH packet in the provided buffer.
 // Returns the total packet length (header + payload + padding).
@@ -1058,6 +1109,23 @@ fn buildUnencryptedPacket(buf: []u8, payload: []const u8) usize {
     return Protocol.sizeof_PktHdr + payload.len + padding_length;
 }
 
+fn unencryptedPayload(packet: []const u8) []const u8 {
+    var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, packet[0..Protocol.sizeof_PktHdr]).*;
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+    }
+    const payload_len = hdr.packet_length - hdr.padding_length - 1;
+    return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
+}
+
+fn expectProducedChannelRequest(m: *MisshodClient, expected_type: []const u8) !void {
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST), try rdr.readU8());
+    _ = try rdr.readU32(); // recipient channel
+    try std.testing.expectEqualStrings(expected_type, try rdr.readU32LenString());
+}
+
 test "handlePacket: SSH_MSG_IGNORE is silently consumed" {
     var prng = std.Random.DefaultPrng.init(42);
     var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
@@ -1070,6 +1138,77 @@ test "handlePacket: SSH_MSG_IGNORE is silently consumed" {
 
     try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+}
+
+test "openSessionChannel writes channel open for new raw session channel" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    const channel_id = try m.openSessionChannel();
+    try std.testing.expectEqual(@as(u32, 0), channel_id);
+    try std.testing.expectEqual(SessionState.ChannelOpenRsp, m.session.sessionState);
+
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(ClientChannelOpenMode.RawSession, chan.client_open_mode);
+    try std.testing.expectEqual(ChannelState.OpenWrite, chan.state);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
+    try std.testing.expectEqualStrings("session", try rdr.readU32LenString());
+    try std.testing.expectEqual(channel_id, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+}
+
+test "openSessionChannel rejects another open while one is pending" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    _ = try m.openSessionChannel();
+    try std.testing.expectError(IoError.cannotAcceptWrite, m.openSessionChannel());
+}
+
+test "openSessionChannel can open another raw channel after confirmation" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    const first_id = try m.openSessionChannel();
+    try m.consumed(m.wr_nbytes);
+
+    var payload_backing: [32]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try pw.writeU32(first_id); // recipient channel
+    try pw.writeU32(42); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.iostate_rd = .Idle;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try m.clearEvent(.{ .ChannelOpened = first_id });
+
+    const second_id = try m.openSessionChannel();
+    try std.testing.expectEqual(@as(u32, 1), second_id);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
+    try std.testing.expectEqualStrings("session", try rdr.readU32LenString());
+    try std.testing.expectEqual(second_id, try rdr.readU32());
 }
 
 test "handlePacket: SSH_MSG_DEBUG with always_display=true" {
@@ -1313,7 +1452,8 @@ test "handlePacket: CHANNEL_OPEN_CONFIRMATION captures initial window" {
     defer m.deinit();
 
     // Allocate a channel so findByLocalId(0) works
-    _ = m.session.channel_table.allocChannel(0, 0, 0);
+    const chan = m.session.channel_table.allocChannel(0, 0, 0).?;
+    chan.client_open_mode = .AutoShell;
 
     var payload_backing: [32]u8 = undefined;
     var pw = BufferWriter.init(&payload_backing, 0);
@@ -1328,8 +1468,126 @@ test "handlePacket: CHANNEL_OPEN_CONFIRMATION captures initial window" {
     m.session.setSessionState(.ChannelOpenRsp);
 
     try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
-    const chan = m.session.channel_table.findByLocalId(0).?;
-    try std.testing.expectEqual(@as(u32, 32768), chan.peer_window);
+    const confirmed = m.session.channel_table.findByLocalId(0).?;
+    try std.testing.expectEqual(@as(u32, 32768), confirmed.peer_window);
+}
+
+test "handlePacket: raw channel confirmation emits ChannelOpened without shell setup" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(0, 0, 0).?;
+    chan.client_open_mode = .RawSession;
+    chan.state = .OpenWrite;
+
+    var payload_backing: [32]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try pw.writeU32(chan.local_id); // recipient channel
+    try pw.writeU32(42); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelOpenRsp);
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try std.testing.expectEqual(@as(u32, 42), chan.remote_id);
+    try std.testing.expectEqual(ChannelState.Data, chan.state);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpened => |channel_id| try std.testing.expectEqual(chan.local_id, channel_id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    try m.clearEvent(.{ .ChannelOpened = chan.local_id });
+    try std.testing.expect(std.meta.eql(m.iostate_wr, .Idle));
+}
+
+test "handlePacket: auto-shell confirmation still emits Connected" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(0, 0, 0).?;
+    chan.client_open_mode = .AutoShell;
+    chan.state = .OpenWrite;
+
+    var payload_backing: [32]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try pw.writeU32(chan.local_id); // recipient channel
+    try pw.writeU32(42); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelOpenRsp);
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try std.testing.expectEqual(ChannelState.Open, chan.state);
+
+    try m.advance();
+    try expectProducedChannelRequest(&m, "pty-req");
+    try m.consumed(m.wr_nbytes);
+    try expectProducedChannelRequest(&m, "shell");
+    try m.consumed(m.wr_nbytes);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .Connected => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "handlePacket: channel open failure frees channel and emits event" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(0, 0, 0).?;
+    chan.client_open_mode = .RawSession;
+    chan.state = .OpenWrite;
+    const local_id = chan.local_id;
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+    try pw.writeU32(local_id); // recipient channel
+    try pw.writeU32(4); // SSH_OPEN_RESOURCE_SHORTAGE
+    try pw.writeU32LenString("too many channels");
+    try pw.writeU32LenString("");
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelOpenRsp);
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try std.testing.expect(m.session.channel_table.findByLocalId(local_id) == null);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpenFailure => |failure| {
+                try std.testing.expectEqual(local_id, failure.channel);
+                try std.testing.expectEqual(@as(u32, 4), failure.reason_code);
+                try std.testing.expectEqualStrings("too many channels", failure.description);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "handlePacket: CHANNEL_WINDOW_ADJUST increases peer window" {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -25,6 +25,7 @@ pub const IoError = error{
     UnimplementedService,
     AlgorithmNegotiationFailed,
     NotReady,
+    tooManyChannels,
 };
 
 pub const DisconnectReason = struct {
@@ -43,15 +44,15 @@ pub const Role = enum {
     Server,
 };
 
-fn sessionType(role:Role) type {
-    return switch(role) {
+fn sessionType(role: Role) type {
+    return switch (role) {
         .Client => ClientSession,
         .Server => ServerSession,
     };
 }
 
-fn eventCodeType(role:Role) type {
-    return switch(role) {
+fn eventCodeType(role: Role) type {
+    return switch (role) {
         .Client => MisshodClientEventCodes,
         .Server => MisshodServerEventCodes,
     };
@@ -80,10 +81,18 @@ pub const MisshodClientEventCodes = union(enum) {
     GetAuthPassphrase,
     EndSession: EndSessionReason,
     Connected,
+    ChannelOpened: u32,
+    ChannelOpenFailure: ChannelOpenFailure,
     RxData: []const u8,
     RxExtendedData: ExtendedData,
     Banner: []const u8,
     KeyboardInteractive: KeyboardInteractivePrompt,
+};
+
+pub const ChannelOpenFailure = struct {
+    channel: u32,
+    reason_code: u32,
+    description: []const u8,
 };
 
 pub const ExtendedData = struct {
@@ -150,7 +159,7 @@ pub const MisshodServerEventCodes = union(enum) {
     ChannelRequest: ChannelRequestEvent,
 };
 
-pub fn MisshodEvent(role:Role) type {
+pub fn MisshodEvent(role: Role) type {
     return union(enum) {
         Event: eventCodeType(role),
         ReadyToConsume: usize,
@@ -160,7 +169,7 @@ pub fn MisshodEvent(role:Role) type {
 }
 
 // Producing a block, or consuming a block
-pub fn IoAction(role:Role) type {
+pub fn IoAction(role: Role) type {
     return union(enum) {
         Producing: usize,
         Consuming: usize,
@@ -169,7 +178,7 @@ pub fn IoAction(role:Role) type {
 }
 
 // An IoAction, followed by state to move Session to on completion
-pub fn IoStep(role:Role) type {
+pub fn IoStep(role: Role) type {
     return struct {
         action: IoAction(role),
         next_state: Protocol.IoSessionState,
@@ -177,518 +186,520 @@ pub fn IoStep(role:Role) type {
 }
 
 // Either Idle, or Active (Producing or Consuming) with a next IoSessionState on completion
-pub fn IoState(role:Role) type {
+pub fn IoState(role: Role) type {
     return union(enum) {
         Idle,
         Active: IoStep(role),
     };
 }
 
-
 pub const MisshodClient = MisshodImpl(.Client);
 pub const MisshodServer = MisshodImpl(.Server);
 
-
 pub fn MisshodImpl(role: Role) type {
     return struct {
-    const Self = @This();
+        const Self = @This();
 
-    session: sessionType(role),
-    iostate_rd: IoState(role),
-    iostate_wr: IoState(role),
+        session: sessionType(role),
+        iostate_rd: IoState(role),
+        iostate_wr: IoState(role),
 
-    // full-duplex: separate read and write buffers
-    iobuf_rd: [Protocol.MaxSSHPacket]u8 = undefined,
-    iobuf_wr: [Protocol.MaxSSHPacket]u8 = undefined,
-    rd_nbytes: usize,
-    rd_off: usize,
-    wr_nbytes: usize,
-    wr_off: usize,
+        // full-duplex: separate read and write buffers
+        iobuf_rd: [Protocol.MaxSSHPacket]u8 = undefined,
+        iobuf_wr: [Protocol.MaxSSHPacket]u8 = undefined,
+        rd_nbytes: usize,
+        rd_off: usize,
+        wr_nbytes: usize,
+        wr_off: usize,
 
-    pub fn init(rand: std.Random, username: []const u8, allocator: std.mem.Allocator) !Self {
-        return Self{
-            .session = try sessionType(role).init(rand, username, allocator),
-            .rd_nbytes = 0,
-            .rd_off = 0,
-            .wr_nbytes = 0,
-            .wr_off = 0,
-            .iostate_rd = .Idle,
-            .iostate_wr = .Idle,
-        };
-    }
-
-    pub fn deinit(self: *Self) void {
-        self.session.deinit();
-        std.crypto.secureZero(u8, &self.iobuf_rd);
-        std.crypto.secureZero(u8, &self.iobuf_wr);
-    }
-
-    // for session use
-    pub fn requestWrite(self: *Self, wbuf: []const u8, next_state: Protocol.IoSessionState) void {
-        std.debug.assert(self.iostate_wr == .Idle);
-        std.debug.assert(&wbuf[0] == &self.iobuf_wr[0]);
-        self.wr_nbytes = wbuf.len;
-        self.wr_off = 0;
-        self.iostate_wr = .{ .Active = .{
-            .action = .{ .Producing = wbuf.len },
-            .next_state = next_state,
-        } };
-    }
-
-    // for session use
-    pub fn requestRead(self: *Self, offset: usize, nbytes: usize, next_state: Protocol.IoSessionState) void {
-        self.rd_nbytes = 0;
-        self.rd_off = offset;
-        self.iostate_rd = .{ .Active = .{
-            .action = .{ .Consuming = nbytes },
-            .next_state = next_state,
-        } };
-    }
-
-    // for session use
-    pub fn requestEvent(self: *Self, code: eventCodeType(role), next_state: Protocol.IoSessionState) void {
-        self.iostate_wr = .{ .Active = .{
-            .action = .{ .Eventing = code },
-            .next_state = next_state,
-        } };
-    }
-
-    pub fn grantAccess(self: *Self, allow:bool) MisshodError!void {
-        switch(role) {
-            .Client => return IoError.UnimplementedService, // FIXME something more tailored
-            .Server => return try self.session.grantAccess(allow),
-        }
-    }
-
-    pub fn clearEvent(self: *Self, clearEventCode: eventCodeType(role)) MisshodError!void {
-        TRACE(.Debug, "clearEvent clearEventCode={any}", .{clearEventCode});
-        TRACE(.Debug, "clearEvent iostate_wr={any}", .{self.iostate_wr});
-
-        switch (self.iostate_wr) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Eventing => |eventCode| {
-                        if (@intFromEnum(eventCode) == @intFromEnum(clearEventCode)) {
-                            // event succesfully cleared
-                            self.session.setIoSessionState(iotype.next_state);
-                            self.iostate_wr = .Idle;
-                            try self.advance();
-                            return;
-                        }
-                    },
-                    else => {},
-                }
-            },
-            else => {},
+        pub fn init(rand: std.Random, username: []const u8, allocator: std.mem.Allocator) !Self {
+            return Self{
+                .session = try sessionType(role).init(rand, username, allocator),
+                .rd_nbytes = 0,
+                .rd_off = 0,
+                .wr_nbytes = 0,
+                .wr_off = 0,
+                .iostate_rd = .Idle,
+                .iostate_wr = .Idle,
+            };
         }
 
-        return IoError.badClearEvent;
-    }
-
-    pub fn getNextEvent(self: *Self) MisshodError!MisshodEvent(role) {
-        // if eventing, send an event
-        switch (self.iostate_wr) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Eventing => |eventCode| {
-                        return MisshodEvent(role){ .Event = eventCode };
-                    },
-                    else => {},
-                }
-            },
-            else => {},
+        pub fn deinit(self: *Self) void {
+            self.session.deinit();
+            std.crypto.secureZero(u8, &self.iobuf_rd);
+            std.crypto.secureZero(u8, &self.iobuf_wr);
         }
 
-        // check both read and write readiness
-        var can_consume_nbytes: usize = 0;
-        var can_produce_nbytes: usize = 0;
-
-        try self.getIoReq(&can_consume_nbytes, &can_produce_nbytes);
-
-        if (can_consume_nbytes > 0 and can_produce_nbytes > 0) {
-            return MisshodEvent(role){ .ReadyToConsumeAndProduce = .{ .consume = can_consume_nbytes, .produce = can_produce_nbytes } };
-        } else if (can_consume_nbytes > 0) {
-            return MisshodEvent(role){ .ReadyToConsume = can_consume_nbytes };
-        } else if (can_produce_nbytes > 0) {
-            return MisshodEvent(role){ .ReadyToProduce = can_produce_nbytes };
-        } else {
-            return IoError.NotReady;
-        }
-    }
-
-    fn getIoReq(self: *Self, can_consume: *usize, can_produce: *usize) MisshodError!void {
-        try self.advance();
-
-        // check read side
-        can_consume.* = 0;
-        switch (self.iostate_rd) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Consuming => |target_size| {
-                        TRACE(.Debug, "getIoReq Consuming target_size={d} iobuf_rd.len={d} rd_nbytes={d}", .{ target_size, self.iobuf_rd.len, self.rd_nbytes });
-                        if (target_size > self.iobuf_rd.len - self.rd_nbytes) {
-                            can_consume.* = self.iobuf_rd.len - self.rd_nbytes;
-                        } else {
-                            can_consume.* = target_size - self.rd_nbytes;
-                        }
-                    },
-                    else => {},
-                }
-            },
-            else => {},
+        // for session use
+        pub fn requestWrite(self: *Self, wbuf: []const u8, next_state: Protocol.IoSessionState) void {
+            std.debug.assert(self.iostate_wr == .Idle);
+            std.debug.assert(&wbuf[0] == &self.iobuf_wr[0]);
+            self.wr_nbytes = wbuf.len;
+            self.wr_off = 0;
+            self.iostate_wr = .{ .Active = .{
+                .action = .{ .Producing = wbuf.len },
+                .next_state = next_state,
+            } };
         }
 
-        // check write side
-        can_produce.* = 0;
-        switch (self.iostate_wr) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Producing => |block_size| {
-                        _ = block_size;
-                        TRACE(.Debug, "getIoReq Producing wr_nbytes={d}", .{self.wr_nbytes});
-                        can_produce.* = self.wr_nbytes;
-                    },
-                    else => {},
-                }
-            },
-            else => {},
-        }
-    }
-
-    pub fn write(self: *Self, wbuf: []const u8) MisshodError!void {
-        TRACE(.Debug, "misshod.write len={d} .rd_nbytes={d}", .{ wbuf.len, self.rd_nbytes });
-        switch (self.iostate_rd) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Consuming => |target_size| {
-                        if (wbuf.len > target_size - self.rd_nbytes) {
-                            return IoError.cannotAcceptWrite;
-                        }
-
-                        @memcpy(self.iobuf_rd[self.rd_nbytes + self.rd_off .. self.rd_nbytes + wbuf.len + self.rd_off], wbuf);
-                        self.rd_nbytes += wbuf.len;
-
-                        if (self.rd_nbytes == target_size) {
-                            // entire block has been written by caller
-                            self.session.setIoSessionState(iotype.next_state);
-                            self.iostate_rd = .Idle;
-                            try self.advance();
-                        }
-                    },
-                    else => {},
-                }
-            },
-            else => return IoError.cannotAcceptWrite,
-        }
-    }
-
-    pub fn peek(self: *Self, nbytes: usize) MisshodError![]const u8 {
-        TRACE(.Debug, "peek nbytes={d} .wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
-        // sanity check
-        switch (self.iostate_wr) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Producing => {}, // ok
-                    else => return IoError.notProducing,
-                }
-            },
-            else => return IoError.notProducing,
+        // for session use
+        pub fn requestRead(self: *Self, offset: usize, nbytes: usize, next_state: Protocol.IoSessionState) void {
+            self.rd_nbytes = 0;
+            self.rd_off = offset;
+            self.iostate_rd = .{ .Active = .{
+                .action = .{ .Consuming = nbytes },
+                .next_state = next_state,
+            } };
         }
 
-        const bytes_remaining = self.wr_nbytes - self.wr_off;
-
-        if (bytes_remaining < nbytes) {
-            return self.iobuf_wr[self.wr_off .. self.wr_off + bytes_remaining];
-        } else {
-            return self.iobuf_wr[self.wr_off..self.wr_nbytes];
-        }
-    }
-
-    pub fn consumed(self: *Self, nbytes: usize) MisshodError!void {
-        TRACE(.Debug, "consumed nbytes={d} wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
-
-        const bytes_remaining = self.wr_nbytes - self.wr_off;
-
-        // sanity check
-        switch (self.iostate_wr) {
-            .Active => |iotype| {
-                switch (iotype.action) {
-                    .Producing => {
-                        if (nbytes > bytes_remaining) {
-                            return IoError.notEnoughData;
-                        }
-                    },
-                    else => return IoError.notProducing,
-                }
-            },
-            else => return IoError.notProducing,
+        // for session use
+        pub fn requestEvent(self: *Self, code: eventCodeType(role), next_state: Protocol.IoSessionState) void {
+            self.iostate_wr = .{ .Active = .{
+                .action = .{ .Eventing = code },
+                .next_state = next_state,
+            } };
         }
 
-        self.wr_off += nbytes;
+        pub fn grantAccess(self: *Self, allow: bool) MisshodError!void {
+            switch (role) {
+                .Client => return IoError.UnimplementedService, // FIXME something more tailored
+                .Server => return try self.session.grantAccess(allow),
+            }
+        }
 
-        if (self.wr_off == self.wr_nbytes) {
-            // entire block has been consumed by caller
+        pub fn clearEvent(self: *Self, clearEventCode: eventCodeType(role)) MisshodError!void {
+            TRACE(.Debug, "clearEvent clearEventCode={any}", .{clearEventCode});
+            TRACE(.Debug, "clearEvent iostate_wr={any}", .{self.iostate_wr});
+
             switch (self.iostate_wr) {
                 .Active => |iotype| {
-                    self.session.setIoSessionState(iotype.next_state);
-                    self.iostate_wr = .Idle;
-                    try self.advance();
+                    switch (iotype.action) {
+                        .Eventing => |eventCode| {
+                            if (@intFromEnum(eventCode) == @intFromEnum(clearEventCode)) {
+                                // event succesfully cleared
+                                self.session.setIoSessionState(iotype.next_state);
+                                self.iostate_wr = .Idle;
+                                try self.advance();
+                                return;
+                            }
+                        },
+                        else => {},
+                    }
                 },
-                else => unreachable,
+                else => {},
+            }
+
+            return IoError.badClearEvent;
+        }
+
+        pub fn getNextEvent(self: *Self) MisshodError!MisshodEvent(role) {
+            // if eventing, send an event
+            switch (self.iostate_wr) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Eventing => |eventCode| {
+                            return MisshodEvent(role){ .Event = eventCode };
+                        },
+                        else => {},
+                    }
+                },
+                else => {},
+            }
+
+            // check both read and write readiness
+            var can_consume_nbytes: usize = 0;
+            var can_produce_nbytes: usize = 0;
+
+            try self.getIoReq(&can_consume_nbytes, &can_produce_nbytes);
+
+            if (can_consume_nbytes > 0 and can_produce_nbytes > 0) {
+                return MisshodEvent(role){ .ReadyToConsumeAndProduce = .{ .consume = can_consume_nbytes, .produce = can_produce_nbytes } };
+            } else if (can_consume_nbytes > 0) {
+                return MisshodEvent(role){ .ReadyToConsume = can_consume_nbytes };
+            } else if (can_produce_nbytes > 0) {
+                return MisshodEvent(role){ .ReadyToProduce = can_produce_nbytes };
+            } else {
+                return IoError.NotReady;
             }
         }
-    }
 
-    pub fn getRecvBuffer(self: *Self, iobuf: []u8, inkeys: *Protocol.KeyDataUni) MisshodError!BufferReader {
+        fn getIoReq(self: *Self, can_consume: *usize, can_produce: *usize) MisshodError!void {
+            try self.advance();
 
-        var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, iobuf[0..Protocol.sizeof_PktHdr]).*;
-        if (native_endian != .big) {
-            // flip bytes
-            std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+            // check read side
+            can_consume.* = 0;
+            switch (self.iostate_rd) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Consuming => |target_size| {
+                            TRACE(.Debug, "getIoReq Consuming target_size={d} iobuf_rd.len={d} rd_nbytes={d}", .{ target_size, self.iobuf_rd.len, self.rd_nbytes });
+                            if (target_size > self.iobuf_rd.len - self.rd_nbytes) {
+                                can_consume.* = self.iobuf_rd.len - self.rd_nbytes;
+                            } else {
+                                can_consume.* = target_size - self.rd_nbytes;
+                            }
+                        },
+                        else => {},
+                    }
+                },
+                else => {},
+            }
+
+            // check write side
+            can_produce.* = 0;
+            switch (self.iostate_wr) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Producing => |block_size| {
+                            _ = block_size;
+                            TRACE(.Debug, "getIoReq Producing wr_nbytes={d}", .{self.wr_nbytes});
+                            can_produce.* = self.wr_nbytes;
+                        },
+                        else => {},
+                    }
+                },
+                else => {},
+            }
         }
-        const payload_len = hdr.packet_length - hdr.padding_length - 1;
-        const payload = iobuf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 
-        if (!self.session.encrypted) {
-            return BufferReader.init(payload);
-        } else {
-            TRACEDUMP(.Debug, "all buf", .{}, iobuf);
-            const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
-            if (pkt_len > Protocol.AesCtrT.block_size) { // if there's more to be decrypted after first block
-                const remaining_pkt_bytes = pkt_len - Protocol.AesCtrT.block_size;
-                var dec: [Protocol.MaxSSHPacket]u8 = undefined;
-                inkeys.aesctr.encrypt(iobuf[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes], dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]); // use same offset into dec for simplicity
+        pub fn write(self: *Self, wbuf: []const u8) MisshodError!void {
+            TRACE(.Debug, "misshod.write len={d} .rd_nbytes={d}", .{ wbuf.len, self.rd_nbytes });
+            switch (self.iostate_rd) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Consuming => |target_size| {
+                            if (wbuf.len > target_size - self.rd_nbytes) {
+                                return IoError.cannotAcceptWrite;
+                            }
 
-                TRACEDUMP(.Debug, "dec", .{}, dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]);
-                // copy decrypted back into writebuf
-                @memcpy(iobuf[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes], dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]);
-                TRACEDUMP(.Debug, "writebuf", .{}, iobuf[0..pkt_len]);
+                            @memcpy(self.iobuf_rd[self.rd_nbytes + self.rd_off .. self.rd_nbytes + wbuf.len + self.rd_off], wbuf);
+                            self.rd_nbytes += wbuf.len;
+
+                            if (self.rd_nbytes == target_size) {
+                                // entire block has been written by caller
+                                self.session.setIoSessionState(iotype.next_state);
+                                self.iostate_rd = .Idle;
+                                try self.advance();
+                            }
+                        },
+                        else => {},
+                    }
+                },
+                else => return IoError.cannotAcceptWrite,
             }
-
-            // verify mac
-            if (iobuf.len < Protocol.mac_algo.key_length) {
-                return error.InvalidPacketSize; // too small to have a mac
-            }
-            const rxmac = iobuf[pkt_len..iobuf.len]; // at the end
-            var calcmac: [Protocol.mac_algo.key_length]u8 = undefined;
-            var m = Protocol.mac_algo.init(inkeys.mackey[0..Protocol.mac_algo.key_length]);
-            const seq = std.mem.nativeTo(u32, inkeys.seq - 1, .big); // seq has already been incremented
-            m.update(std.mem.asBytes(&seq));
-            m.update(iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]); // plaintext
-            m.final(&calcmac);
-
-            TRACEDUMP(.Debug, "rxmac", .{}, rxmac);
-            TRACEDUMP(.Debug, "mackey", .{}, inkeys.mackey[0..Protocol.mac_algo.key_length]);
-            TRACEDUMP(.Debug, "macseq", .{}, std.mem.asBytes(&seq));
-            TRACEDUMP(.Debug, "macdata", .{}, iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]);
-            TRACEDUMP(.Debug, "calcmac", .{}, std.mem.asBytes(&calcmac));
-
-            if (!std.mem.eql(u8, &calcmac, rxmac)) {
-                return IoError.InvalidMac;
-            }
-
-            // remove mac and return buffer containing just plaintext payload
-            return BufferReader.init(iobuf[Protocol.sizeof_PktHdr .. iobuf.len - Protocol.mac_algo.key_length]);
         }
-    }
 
+        pub fn peek(self: *Self, nbytes: usize) MisshodError![]const u8 {
+            TRACE(.Debug, "peek nbytes={d} .wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
+            // sanity check
+            switch (self.iostate_wr) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Producing => {}, // ok
+                        else => return IoError.notProducing,
+                    }
+                },
+                else => return IoError.notProducing,
+            }
 
-    fn advanceIoSession(self:*Self, inkeys:*Protocol.KeyDataUni) MisshodError!void {
-        switch (self.session.ioSessionState) {
-            .Idle => {
-                TRACE(.Debug, "ioSessionState Idle", .{});
-                try self.session.advanceSession(self);
-            },
-            .Init => {
-                switch(role) {
-                    .Client => self.session.setIoSessionState(.VersionWrite),
-                    .Server => self.session.setIoSessionState(.VersionReadLine),
+            const bytes_remaining = self.wr_nbytes - self.wr_off;
+
+            if (bytes_remaining < nbytes) {
+                return self.iobuf_wr[self.wr_off .. self.wr_off + bytes_remaining];
+            } else {
+                return self.iobuf_wr[self.wr_off..self.wr_nbytes];
+            }
+        }
+
+        pub fn consumed(self: *Self, nbytes: usize) MisshodError!void {
+            TRACE(.Debug, "consumed nbytes={d} wr_off={d} .wr_nbytes={d}", .{ nbytes, self.wr_off, self.wr_nbytes });
+
+            const bytes_remaining = self.wr_nbytes - self.wr_off;
+
+            // sanity check
+            switch (self.iostate_wr) {
+                .Active => |iotype| {
+                    switch (iotype.action) {
+                        .Producing => {
+                            if (nbytes > bytes_remaining) {
+                                return IoError.notEnoughData;
+                            }
+                        },
+                        else => return IoError.notProducing,
+                    }
+                },
+                else => return IoError.notProducing,
+            }
+
+            self.wr_off += nbytes;
+
+            if (self.wr_off == self.wr_nbytes) {
+                // entire block has been consumed by caller
+                switch (self.iostate_wr) {
+                    .Active => |iotype| {
+                        self.session.setIoSessionState(iotype.next_state);
+                        self.iostate_wr = .Idle;
+                        try self.advance();
+                    },
+                    else => unreachable,
                 }
-            },
-            .VersionWrite => {
-                const sl = self.session.writeProtocolVersion(&self.iobuf_wr);
-                switch(role) {
-                    .Client => self.requestWrite(sl, .VersionReadLine),
-                    .Server => self.requestWrite(sl, .Idle),
+            }
+        }
+
+        pub fn getRecvBuffer(self: *Self, iobuf: []u8, inkeys: *Protocol.KeyDataUni) MisshodError!BufferReader {
+            var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, iobuf[0..Protocol.sizeof_PktHdr]).*;
+            if (native_endian != .big) {
+                // flip bytes
+                std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+            }
+            const payload_len = hdr.packet_length - hdr.padding_length - 1;
+            const payload = iobuf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
+
+            if (!self.session.encrypted) {
+                return BufferReader.init(payload);
+            } else {
+                TRACEDUMP(.Debug, "all buf", .{}, iobuf);
+                const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
+                if (pkt_len > Protocol.AesCtrT.block_size) { // if there's more to be decrypted after first block
+                    const remaining_pkt_bytes = pkt_len - Protocol.AesCtrT.block_size;
+                    var dec: [Protocol.MaxSSHPacket]u8 = undefined;
+                    inkeys.aesctr.encrypt(iobuf[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes], dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]); // use same offset into dec for simplicity
+
+                    TRACEDUMP(.Debug, "dec", .{}, dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]);
+                    // copy decrypted back into writebuf
+                    @memcpy(iobuf[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes], dec[Protocol.AesCtrT.block_size .. Protocol.AesCtrT.block_size + remaining_pkt_bytes]);
+                    TRACEDUMP(.Debug, "writebuf", .{}, iobuf[0..pkt_len]);
                 }
-            },
-            .VersionReadLine => {
-                // read first char
-                self.requestRead(0, 1, .{ .VersionReadLineChar = self.iobuf_rd[0..1] });
-            },
-            .VersionReadLineChar => |buf| {
-                if (buf.len + 1 > self.iobuf_rd.len) {
-                    return IoError.noEOLFound;
-                } else {
-                    if (buf.len >= 2) {
-                        if (buf[buf.len - 2] == '\r' and buf[buf.len - 1] == '\n') {
-                            self.session.setIoSessionState(.{ .VersionReadLineCompletion = buf });
-                            return;
+
+                // verify mac
+                if (iobuf.len < Protocol.mac_algo.key_length) {
+                    return error.InvalidPacketSize; // too small to have a mac
+                }
+                const rxmac = iobuf[pkt_len..iobuf.len]; // at the end
+                var calcmac: [Protocol.mac_algo.key_length]u8 = undefined;
+                var m = Protocol.mac_algo.init(inkeys.mackey[0..Protocol.mac_algo.key_length]);
+                const seq = std.mem.nativeTo(u32, inkeys.seq - 1, .big); // seq has already been incremented
+                m.update(std.mem.asBytes(&seq));
+                m.update(iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]); // plaintext
+                m.final(&calcmac);
+
+                TRACEDUMP(.Debug, "rxmac", .{}, rxmac);
+                TRACEDUMP(.Debug, "mackey", .{}, inkeys.mackey[0..Protocol.mac_algo.key_length]);
+                TRACEDUMP(.Debug, "macseq", .{}, std.mem.asBytes(&seq));
+                TRACEDUMP(.Debug, "macdata", .{}, iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]);
+                TRACEDUMP(.Debug, "calcmac", .{}, std.mem.asBytes(&calcmac));
+
+                if (!std.mem.eql(u8, &calcmac, rxmac)) {
+                    return IoError.InvalidMac;
+                }
+
+                // remove mac and return buffer containing just plaintext payload
+                return BufferReader.init(iobuf[Protocol.sizeof_PktHdr .. iobuf.len - Protocol.mac_algo.key_length]);
+            }
+        }
+
+        fn advanceIoSession(self: *Self, inkeys: *Protocol.KeyDataUni) MisshodError!void {
+            switch (self.session.ioSessionState) {
+                .Idle => {
+                    TRACE(.Debug, "ioSessionState Idle", .{});
+                    try self.session.advanceSession(self);
+                },
+                .Init => {
+                    switch (role) {
+                        .Client => self.session.setIoSessionState(.VersionWrite),
+                        .Server => self.session.setIoSessionState(.VersionReadLine),
+                    }
+                },
+                .VersionWrite => {
+                    const sl = self.session.writeProtocolVersion(&self.iobuf_wr);
+                    switch (role) {
+                        .Client => self.requestWrite(sl, .VersionReadLine),
+                        .Server => self.requestWrite(sl, .Idle),
+                    }
+                },
+                .VersionReadLine => {
+                    // read first char
+                    self.requestRead(0, 1, .{ .VersionReadLineChar = self.iobuf_rd[0..1] });
+                },
+                .VersionReadLineChar => |buf| {
+                    if (buf.len + 1 > self.iobuf_rd.len) {
+                        return IoError.noEOLFound;
+                    } else {
+                        if (buf.len >= 2) {
+                            if (buf[buf.len - 2] == '\r' and buf[buf.len - 1] == '\n') {
+                                self.session.setIoSessionState(.{ .VersionReadLineCompletion = buf });
+                                return;
+                            }
                         }
+                        // read next char
+                        self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf_rd[0 .. buf.len + 1] });
                     }
-                    // read next char
-                    self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf_rd[0 .. buf.len + 1] });
-                }
-            },
-            .VersionReadLineCompletion => |buf| {
-                TRACE(.Debug, "RX: version '{s}'", .{util.chomp(buf)});
-                switch(role) {
-                    .Client => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_S),
-                    .Server => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_C)
-                }
-                self.session.kex_hasher.writeU32LenString(util.chomp(buf));
-                switch(role) {
-                    .Client => self.session.setIoSessionState(.Idle),
-                    .Server => self.session.setIoSessionState(.VersionWrite),
-                }
-            },
-            .ReadPktHdr => {
-                if (self.session.encrypted) {
-                    self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.AesCtrT.block_size] });
-                } else {
-                    self.requestRead(0, Protocol.sizeof_PktHdr, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.sizeof_PktHdr] });
-                }
-            },
-            .ReadPktBody => |buf| {
-                if (self.session.encrypted) {
-                    // https://datatracker.ietf.org/doc/html/rfc4253#section-6
-                    // grab first encrypted block from writebuf
-                    var firstblock_encbuf: [Protocol.AesCtrT.block_size]u8 = undefined;
-                    @memcpy(&firstblock_encbuf, buf);
-
-                    // decrypt directly into iobuf_rd
-                    inkeys.aesctr.encrypt(&firstblock_encbuf, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
-                    TRACEDUMP(.Debug, "firstblock_dec(in payload)", .{}, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
-
-                    // read Protocol.PktHdr from first block
-                    const pkthdr_size = Protocol.sizeof_PktHdr;
-                    var hdr: Protocol.PktHdr = undefined;
-                    hdr = std.mem.bytesToValue(Protocol.PktHdr, buf[0..pkthdr_size]);
-                    if (native_endian != .big) {
-                        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+                },
+                .VersionReadLineCompletion => |buf| {
+                    TRACE(.Debug, "RX: version '{s}'", .{util.chomp(buf)});
+                    switch (role) {
+                        .Client => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_S),
+                        .Server => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_C),
                     }
-
-                    // padding len is such that payload_len + sizeof(hdr) + padding = block size
-                    const payload_len = hdr.packet_length - (hdr.padding_length + 1);
-                    if (hdr.padding_length < 4) {
-                        return IoError.InvalidPacketSize;
+                    self.session.kex_hasher.writeU32LenString(util.chomp(buf));
+                    switch (role) {
+                        .Client => self.session.setIoSessionState(.Idle),
+                        .Server => self.session.setIoSessionState(.VersionWrite),
                     }
-                    const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
-                    // avoid reading obviously bad packet sizes
-                    if (pkt_len < 8 or pkt_len > Protocol.MaxSSHPacket) {
-                        TRACE(.Info, "Bad pkt size {d}\n", .{pkt_len});
-                        return IoError.InvalidPacketSize;
+                },
+                .ReadPktHdr => {
+                    if (self.session.encrypted) {
+                        self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.AesCtrT.block_size] });
+                    } else {
+                        self.requestRead(0, Protocol.sizeof_PktHdr, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.sizeof_PktHdr] });
                     }
+                },
+                .ReadPktBody => |buf| {
+                    if (self.session.encrypted) {
+                        // https://datatracker.ietf.org/doc/html/rfc4253#section-6
+                        // grab first encrypted block from writebuf
+                        var firstblock_encbuf: [Protocol.AesCtrT.block_size]u8 = undefined;
+                        @memcpy(&firstblock_encbuf, buf);
 
-                    // calc number of remaining bytes + mac, read from network
-                    var remaining_pkt_bytes: usize = 0;
-                    if (pkt_len > Protocol.AesCtrT.block_size) {
-                        remaining_pkt_bytes = pkt_len - Protocol.AesCtrT.block_size;
+                        // decrypt directly into iobuf_rd
+                        inkeys.aesctr.encrypt(&firstblock_encbuf, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
+                        TRACEDUMP(.Debug, "firstblock_dec(in payload)", .{}, self.iobuf_rd[0..Protocol.AesCtrT.block_size]);
+
+                        // read Protocol.PktHdr from first block
+                        const pkthdr_size = Protocol.sizeof_PktHdr;
+                        var hdr: Protocol.PktHdr = undefined;
+                        hdr = std.mem.bytesToValue(Protocol.PktHdr, buf[0..pkthdr_size]);
+                        if (native_endian != .big) {
+                            std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+                        }
+
+                        // padding len is such that payload_len + sizeof(hdr) + padding = block size
+                        const payload_len = hdr.packet_length - (hdr.padding_length + 1);
+                        if (hdr.padding_length < 4) {
+                            return IoError.InvalidPacketSize;
+                        }
+                        const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
+                        // avoid reading obviously bad packet sizes
+                        if (pkt_len < 8 or pkt_len > Protocol.MaxSSHPacket) {
+                            TRACE(.Info, "Bad pkt size {d}\n", .{pkt_len});
+                            return IoError.InvalidPacketSize;
+                        }
+
+                        // calc number of remaining bytes + mac, read from network
+                        var remaining_pkt_bytes: usize = 0;
+                        if (pkt_len > Protocol.AesCtrT.block_size) {
+                            remaining_pkt_bytes = pkt_len - Protocol.AesCtrT.block_size;
+                        }
+                        TRACE(.Debug, "About to read {d}\n", .{remaining_pkt_bytes + Protocol.mac_algo.key_length});
+                        //
+                        self.requestRead(buf.len, (remaining_pkt_bytes + Protocol.mac_algo.key_length), .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + remaining_pkt_bytes + Protocol.mac_algo.key_length] }); // on completion, how much we have
+
+                        inkeys.seq +%= 1;
+                    } else {
+                        // copy header
+                        var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, buf[0..Protocol.sizeof_PktHdr]).*;
+                        if (native_endian != .big) {
+                            // flip bytes
+                            std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+                        }
+
+                        TRACE(.Debug, ".ReadPktBody hdr={any}", .{hdr});
+                        // read in payload
+                        const payload_len = hdr.packet_length - hdr.padding_length - 1;
+                        std.debug.assert(payload_len <= Protocol.MaxPayload);
+
+                        self.requestRead(buf.len, payload_len + hdr.padding_length, .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + payload_len + hdr.padding_length] });
+                        inkeys.seq +%= 1;
                     }
-                    TRACE(.Debug, "About to read {d}\n", .{remaining_pkt_bytes + Protocol.mac_algo.key_length});
-                    //
-                    self.requestRead(buf.len, (remaining_pkt_bytes + Protocol.mac_algo.key_length), .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + remaining_pkt_bytes + Protocol.mac_algo.key_length] }); // on completion, how much we have
-
-                    inkeys.seq +%= 1;
-                } else {
-                    // copy header
-                    var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, buf[0..Protocol.sizeof_PktHdr]).*;
-                    if (native_endian != .big) {
-                        // flip bytes
-                        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-                    }
-
-                    TRACE(.Debug, ".ReadPktBody hdr={any}", .{hdr});
-                    // read in payload
-                    const payload_len = hdr.packet_length - hdr.padding_length - 1;
-                    std.debug.assert(payload_len <= Protocol.MaxPayload);
-
-                    self.requestRead(buf.len, payload_len + hdr.padding_length, .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + payload_len + hdr.padding_length] });
-                    inkeys.seq +%= 1;
-                }
-            },
-            .ReadPktCompletion => |buf| {
-                TRACEDUMP(.Debug, ".ReadPktCompletion", .{}, buf);
-                try self.session.handlePacket(buf, self);
-            },
+                },
+                .ReadPktCompletion => |buf| {
+                    TRACEDUMP(.Debug, ".ReadPktCompletion", .{}, buf);
+                    try self.session.handlePacket(buf, self);
+                },
+            }
         }
-    }
 
-
-    fn canProcessIoSessionState(self: *Self) bool {
-        return switch (self.session.ioSessionState) {
-            // Idle needs both sides free — session will decide what to do
-            .Idle => self.iostate_rd == .Idle and self.iostate_wr == .Idle,
-            .Init => true,
-            // Read-requiring states only need read side idle
-            .VersionReadLine, .VersionReadLineChar => self.iostate_rd == .Idle,
-            .ReadPktHdr, .ReadPktBody => self.iostate_rd == .Idle,
-            // Write-requiring states need write side idle
-            .VersionWrite => self.iostate_wr == .Idle,
-            // Processing states
-            .VersionReadLineCompletion => true, // just sets next ioSessionState
-            .ReadPktCompletion => self.iostate_wr == .Idle, // handlePacket may event/write
-        };
-    }
-
-    pub fn advance(self: *Self) MisshodError!void {
-        const inkeys = switch(role) {
-            .Client => &self.session.keydata.s2c,
-            .Server => &self.session.keydata.c2s,
-        };
-        while (self.canProcessIoSessionState()) {
-            const prev_io_state = self.session.ioSessionState;
-            const prev_rd = self.iostate_rd;
-            const prev_wr = self.iostate_wr;
-            try self.advanceIoSession(inkeys);
-            // Break if no progress was made to prevent infinite loops
-            const same_io = std.meta.eql(prev_io_state, self.session.ioSessionState);
-            const same_rd = std.meta.eql(prev_rd, self.iostate_rd);
-            const same_wr = std.meta.eql(prev_wr, self.iostate_wr);
-            if (same_io and same_rd and same_wr) break;
+        fn canProcessIoSessionState(self: *Self) bool {
+            return switch (self.session.ioSessionState) {
+                // Idle needs both sides free — session will decide what to do
+                .Idle => self.iostate_rd == .Idle and self.iostate_wr == .Idle,
+                .Init => true,
+                // Read-requiring states only need read side idle
+                .VersionReadLine, .VersionReadLineChar => self.iostate_rd == .Idle,
+                .ReadPktHdr, .ReadPktBody => self.iostate_rd == .Idle,
+                // Write-requiring states need write side idle
+                .VersionWrite => self.iostate_wr == .Idle,
+                // Processing states
+                .VersionReadLineCompletion => true, // just sets next ioSessionState
+                .ReadPktCompletion => self.iostate_wr == .Idle, // handlePacket may event/write
+            };
         }
-    }
 
-    pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
-        try self.session.setPrivateKey(keydata_ascii);
-    }
+        pub fn advance(self: *Self) MisshodError!void {
+            const inkeys = switch (role) {
+                .Client => &self.session.keydata.s2c,
+                .Server => &self.session.keydata.c2s,
+            };
+            while (self.canProcessIoSessionState()) {
+                const prev_io_state = self.session.ioSessionState;
+                const prev_rd = self.iostate_rd;
+                const prev_wr = self.iostate_wr;
+                try self.advanceIoSession(inkeys);
+                // Break if no progress was made to prevent infinite loops
+                const same_io = std.meta.eql(prev_io_state, self.session.ioSessionState);
+                const same_rd = std.meta.eql(prev_rd, self.iostate_rd);
+                const same_wr = std.meta.eql(prev_wr, self.iostate_wr);
+                if (same_io and same_rd and same_wr) break;
+            }
+        }
 
-    pub fn setPrivateKeyPassphrase(self: *Self, data: []const u8) MisshodError!void {
-        try self.session.setPrivateKeyPassphrase(data);
-    }
+        pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
+            try self.session.setPrivateKey(keydata_ascii);
+        }
 
-    pub fn setAuthPassphrase(self: *Self, data: []const u8) MisshodError!void {
-        try self.session.setAuthPassphrase(data);
-    }
+        pub fn setPrivateKeyPassphrase(self: *Self, data: []const u8) MisshodError!void {
+            try self.session.setPrivateKeyPassphrase(data);
+        }
 
-    pub fn isActive(self: *Self) bool {
-        return self.session.isActive();
-    }
+        pub fn setAuthPassphrase(self: *Self, data: []const u8) MisshodError!void {
+            try self.session.setAuthPassphrase(data);
+        }
 
-    pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
-        return self.session.getChannelWriteBuffer(channel_id);
-    }
+        pub fn isActive(self: *Self) bool {
+            return self.session.isActive();
+        }
 
-    pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
-        if (self.iostate_wr == .Idle and self.iostate_rd != .Idle) {
-            try self.session.directChannelWrite(channel_id, nbytes, self);
-        } else {
-            self.iostate_rd = .Idle;
+        pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
+            return self.session.getChannelWriteBuffer(channel_id);
+        }
+
+        pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
+            if (self.iostate_wr == .Idle and self.iostate_rd != .Idle) {
+                try self.session.directChannelWrite(channel_id, nbytes, self);
+            } else {
+                self.iostate_rd = .Idle;
+                self.iostate_wr = .Idle;
+                try self.advance();
+                try self.session.channelWriteComplete(channel_id, nbytes);
+                self.iostate_rd = .Idle;
+                self.iostate_wr = .Idle;
+                try self.advance();
+            }
+        }
+
+        pub fn openSessionChannel(self: *Self) MisshodError!u32 {
+            return switch (role) {
+                .Client => try self.session.openSessionChannel(self),
+                .Server => IoError.UnimplementedService,
+            };
+        }
+
+        pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+            try self.session.sendChannelEof(channel_id);
             self.iostate_wr = .Idle;
             try self.advance();
-            try self.session.channelWriteComplete(channel_id, nbytes);
-            self.iostate_rd = .Idle;
-            self.iostate_wr = .Idle;
-            try self.advance();
         }
-    }
-
-    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
-        try self.session.sendChannelEof(channel_id);
-        self.iostate_wr = .Idle;
-        try self.advance();
-    }
-};
+    };
 }
 
 test "EndSessionReason tagged union" {
@@ -872,8 +883,12 @@ test "client-server full handshake round-trip" {
                         }
                     },
                     .Event => |code| switch (code) {
-                        .CheckHostKey => { client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {}; },
-                        .GetPrivateKey => { client.clearEvent(.GetPrivateKey) catch {}; },
+                        .CheckHostKey => {
+                            client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {};
+                        },
+                        .GetPrivateKey => {
+                            client.clearEvent(.GetPrivateKey) catch {};
+                        },
                         .GetAuthPassphrase => {
                             client.session.setAuthPassphrase("testpass") catch {};
                             client.clearEvent(.GetAuthPassphrase) catch {};
@@ -882,7 +897,10 @@ test "client-server full handshake round-trip" {
                             connected_client = true;
                             client.clearEvent(.Connected) catch {};
                         },
-                        .EndSession => { connected_client = false; break; },
+                        .EndSession => {
+                            connected_client = false;
+                            break;
+                        },
                         else => {},
                     },
                 }
@@ -920,8 +938,12 @@ test "client-server full handshake round-trip" {
                             server.grantAccess(true) catch {};
                             server.clearEvent(.{ .UserAuth = .{ .username = "", .auth = null } }) catch {};
                         },
-                        .Connected => { server.clearEvent(.{ .Connected = 0 }) catch {}; },
-                        .ChannelRequest => { server.clearEvent(.{ .ChannelRequest = .{ .channel = 0, .request = .Shell } }) catch {}; },
+                        .Connected => {
+                            server.clearEvent(.{ .Connected = 0 }) catch {};
+                        },
+                        .ChannelRequest => {
+                            server.clearEvent(.{ .ChannelRequest = .{ .channel = 0, .request = .Shell } }) catch {};
+                        },
                         else => {},
                     },
                 }
@@ -1379,7 +1401,9 @@ test "full handshake round-trip then channel data exchange" {
                             client.clearEvent(.{ .RxData = data }) catch {};
                         },
                         .EndSession => break,
-                        else => { client.clearEvent(code) catch {}; },
+                        else => {
+                            client.clearEvent(code) catch {};
+                        },
                     },
                 }
             } else {
@@ -1409,7 +1433,9 @@ test "full handshake round-trip then channel data exchange" {
                             server.clearEvent(.{ .Connected = 0 }) catch {};
                         },
                         .ChannelRequest => server.clearEvent(.{ .ChannelRequest = .{ .channel = 0, .request = .Shell } }) catch {},
-                        else => { server.clearEvent(code) catch {}; },
+                        else => {
+                            server.clearEvent(code) catch {};
+                        },
                     },
                 }
 
@@ -1512,7 +1538,9 @@ test "client channelWriteComplete uses direct write when read is active" {
                             client.clearEvent(.Connected) catch {};
                         },
                         .EndSession => break,
-                        else => { client.clearEvent(code) catch {}; },
+                        else => {
+                            client.clearEvent(code) catch {};
+                        },
                     },
                 }
             } else {
@@ -1539,7 +1567,9 @@ test "client channelWriteComplete uses direct write when read is active" {
                         },
                         .Connected => server.clearEvent(.{ .Connected = 0 }) catch {},
                         .ChannelRequest => server.clearEvent(.{ .ChannelRequest = .{ .channel = 0, .request = .Shell } }) catch {},
-                        else => { server.clearEvent(code) catch {}; },
+                        else => {
+                            server.clearEvent(code) catch {};
+                        },
                     },
                 }
             }

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -416,7 +416,7 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
-            .Open => {
+            .OpenWrite, .Open => {
                 self.setIoSessionState(.ReadPktHdr);
             },
         }


### PR DESCRIPTION
## Summary
- add `openSessionChannel()` for client-opened raw session channels
- route client channel-open packets through a new `OpenWrite` channel state
- preserve the existing auto shell channel and `Connected` event while adding `ChannelOpened` and `ChannelOpenFailure` events
- add unit coverage for open serialization, raw confirmation, failure cleanup, pending-open rejection, and sequential opens

Fixes #39

## Tests
- `zig test src/test.zig`
- `zig build`
- `zig build test`