### PR TITLE
Support non-session channel opens

### DIFF
--- a/src/channel.zig
+++ b/src/channel.zig
@@ -8,6 +8,41 @@ pub const ClientChannelOpenMode = enum {
     RawSession,
 };
 
+pub const ChannelType = enum {
+    Session,
+    DirectTcpip,
+    ForwardedTcpip,
+
+    pub fn name(self: ChannelType) []const u8 {
+        return switch (self) {
+            .Session => "session",
+            .DirectTcpip => "direct-tcpip",
+            .ForwardedTcpip => "forwarded-tcpip",
+        };
+    }
+
+    pub fn fromName(channel_name: []const u8) ?ChannelType {
+        if (std.mem.eql(u8, channel_name, "session")) return .Session;
+        if (std.mem.eql(u8, channel_name, "direct-tcpip")) return .DirectTcpip;
+        if (std.mem.eql(u8, channel_name, "forwarded-tcpip")) return .ForwardedTcpip;
+        return null;
+    }
+
+    pub fn hasTcpipOpenPayload(self: ChannelType) bool {
+        return switch (self) {
+            .Session => false,
+            .DirectTcpip, .ForwardedTcpip => true,
+        };
+    }
+};
+
+pub const TcpipOpen = struct {
+    host: []const u8 = "",
+    port: u32 = 0,
+    originator_host: []const u8 = "",
+    originator_port: u32 = 0,
+};
+
 pub const ChannelState = enum {
     OpenWrite,
     Open,
@@ -39,6 +74,10 @@ pub const Channel = struct {
     close_sent: bool,
     close_received: bool,
     client_open_mode: ClientChannelOpenMode,
+    channel_type: ChannelType,
+    tcpip_open: TcpipOpen,
+    open_failure_reason_code: u32,
+    open_failure_description: []const u8,
     state: ChannelState,
 
     pub fn init(local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
@@ -54,6 +93,10 @@ pub const Channel = struct {
             .close_sent = false,
             .close_received = false,
             .client_open_mode = .RawSession,
+            .channel_type = .Session,
+            .tcpip_open = .{},
+            .open_failure_reason_code = 4,
+            .open_failure_description = "too many channels",
             .state = .Open,
         };
     }
@@ -237,7 +280,24 @@ test "Channel init sets default values" {
     try std.testing.expect(!ch.close_sent);
     try std.testing.expect(!ch.close_received);
     try std.testing.expectEqual(ClientChannelOpenMode.RawSession, ch.client_open_mode);
+    try std.testing.expectEqual(ChannelType.Session, ch.channel_type);
+    try std.testing.expectEqualStrings("", ch.tcpip_open.host);
+    try std.testing.expectEqual(@as(u32, 0), ch.tcpip_open.port);
+    try std.testing.expectEqualStrings("", ch.tcpip_open.originator_host);
+    try std.testing.expectEqual(@as(u32, 0), ch.tcpip_open.originator_port);
+    try std.testing.expectEqual(@as(u32, 4), ch.open_failure_reason_code);
+    try std.testing.expectEqualStrings("too many channels", ch.open_failure_description);
     try std.testing.expectEqual(ChannelState.Open, ch.state);
+}
+
+test "ChannelType maps SSH names" {
+    try std.testing.expectEqual(ChannelType.Session, ChannelType.fromName("session").?);
+    try std.testing.expectEqual(ChannelType.DirectTcpip, ChannelType.fromName("direct-tcpip").?);
+    try std.testing.expectEqual(ChannelType.ForwardedTcpip, ChannelType.fromName("forwarded-tcpip").?);
+    try std.testing.expect(ChannelType.fromName("x11") == null);
+    try std.testing.expectEqualStrings("direct-tcpip", ChannelType.DirectTcpip.name());
+    try std.testing.expect(ChannelType.DirectTcpip.hasTcpipOpenPayload());
+    try std.testing.expect(!ChannelType.Session.hasTcpipOpenPayload());
 }
 
 test "closing one channel does not affect another" {

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -2,9 +2,11 @@ const std = @import("std");
 const util = @import("util.zig");
 const TRACE = util.trace;
 const TRACEDUMP = util.tracedump;
-const MisshodClient = @import("misshod.zig").MisshodClient;
-const MisshodError = @import("misshod.zig").MisshodError;
-const IoError = @import("misshod.zig").IoError;
+const Misshod = @import("misshod.zig");
+const MisshodClient = Misshod.MisshodClient;
+const MisshodError = Misshod.MisshodError;
+const IoError = Misshod.IoError;
+const SshOpenFailureReason = Misshod.SshOpenFailureReason;
 const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
@@ -18,6 +20,8 @@ const Channel = @import("channel.zig").Channel;
 const ChannelTable = @import("channel.zig").ChannelTable;
 const ChannelState = @import("channel.zig").ChannelState;
 const ClientChannelOpenMode = @import("channel.zig").ClientChannelOpenMode;
+const ChannelType = @import("channel.zig").ChannelType;
+const TcpipOpen = @import("channel.zig").TcpipOpen;
 
 pub const SessionState = enum {
     Init,
@@ -132,11 +136,23 @@ pub const Session = struct {
         self.sessionState = newState;
     }
 
-    fn allocateClientSessionChannel(self: *Self, mode: ClientChannelOpenMode) MisshodError!*Channel {
+    fn allocateClientChannel(
+        self: *Self,
+        mode: ClientChannelOpenMode,
+        channel_type: ChannelType,
+        tcpip_open: TcpipOpen,
+    ) MisshodError!*Channel {
+        if (mode == .AutoShell and channel_type != .Session) return IoError.UnexpectedResponse;
         const chan = self.channel_table.allocChannel(0, 0, 0) orelse return IoError.tooManyChannels;
         chan.client_open_mode = mode;
+        chan.channel_type = channel_type;
+        chan.tcpip_open = tcpip_open;
         chan.state = .OpenWrite;
         return chan;
+    }
+
+    fn allocateClientSessionChannel(self: *Self, mode: ClientChannelOpenMode) MisshodError!*Channel {
+        return self.allocateClientChannel(mode, .Session, .{});
     }
 
     pub fn advanceSession(self: *Self, misshod: *MisshodClient) MisshodError!void {
@@ -425,10 +441,16 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
-                try pkt.writeU32LenString("session"); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
+                try pkt.writeU32LenString(chan.channel_type.name()); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
                 try pkt.writeU32(chan.local_id); // sender channel
                 try pkt.writeU32(Protocol.MaxPayload); // initial window size
                 try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
+                if (chan.channel_type.hasTcpipOpenPayload()) {
+                    try pkt.writeU32LenString(chan.tcpip_open.host);
+                    try pkt.writeU32(chan.tcpip_open.port);
+                    try pkt.writeU32LenString(chan.tcpip_open.originator_host);
+                    try pkt.writeU32(chan.tcpip_open.originator_port);
+                }
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.ChannelOpenRsp);
             },
@@ -591,8 +613,27 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
-            .ConfirmWrite, .OpenFailureWrite => {
-                self.setIoSessionState(.ReadPktHdr);
+            .ConfirmWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+                try pkt.writeU32(chan.remote_id);
+                try pkt.writeU32(chan.local_id);
+                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxPayload);
+                chan.state = if (chan.channel_type == .Session) .Connected else .Data;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+            },
+            .OpenFailureWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+                try pkt.writeU32(chan.remote_id);
+                try pkt.writeU32(chan.open_failure_reason_code);
+                try pkt.writeU32LenString(chan.open_failure_description);
+                try pkt.writeU32LenString("");
+                const local_id = chan.local_id;
+                self.channel_table.freeChannel(local_id);
+                self.active_channel_id = null;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
         }
     }
@@ -622,6 +663,53 @@ pub const Session = struct {
         self.setIoSessionState(.Idle);
         try self.advanceChannel(misshod, &self.keydata.c2s);
         return chan.local_id;
+    }
+
+    pub fn openDirectTcpipChannel(
+        self: *Self,
+        misshod: *MisshodClient,
+        host: []const u8,
+        port: u32,
+        originator_host: []const u8,
+        originator_port: u32,
+    ) MisshodError!u32 {
+        if (misshod.iostate_wr != .Idle or self.active_channel_id != null) {
+            return IoError.cannotAcceptWrite;
+        }
+        if (self.sessionState != .ChannelActive) {
+            return IoError.NotReady;
+        }
+
+        const chan = try self.allocateClientChannel(.RawSession, .DirectTcpip, .{
+            .host = host,
+            .port = port,
+            .originator_host = originator_host,
+            .originator_port = originator_port,
+        });
+        self.active_channel_id = chan.local_id;
+        self.setIoSessionState(.Idle);
+        try self.advanceChannel(misshod, &self.keydata.c2s);
+        return chan.local_id;
+    }
+
+    pub fn acceptChannelOpen(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.state != .Open) return IoError.UnexpectedResponse;
+        chan.state = .ConfirmWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+    }
+
+    pub fn rejectChannelOpen(self: *Self, channel_id: u32, reason_code: u32, description: []const u8) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.state != .Open) return IoError.UnexpectedResponse;
+        chan.open_failure_reason_code = reason_code;
+        chan.open_failure_description = description;
+        chan.state = .OpenFailureWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
     }
 
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
@@ -729,6 +817,95 @@ pub const Session = struct {
         self.kex_hash_order = self.kex_hash_order.check(.V_C);
         self.kex_hasher.writeU32LenString(Protocol.version);
         return vers;
+    }
+
+    fn sendChannelOpenFailure(
+        self: *Self,
+        misshod: *MisshodClient,
+        recipient: u32,
+        reason_code: u32,
+        description: []const u8,
+    ) MisshodError!void {
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+        try pkt.writeU32(recipient);
+        try pkt.writeU32(reason_code);
+        try pkt.writeU32LenString(description);
+        try pkt.writeU32LenString("");
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.c2s, &pkt, &misshod.iobuf_wr), .Idle);
+    }
+
+    fn readTcpipOpen(rdr: *BufferReader) MisshodError!TcpipOpen {
+        return .{
+            .host = try rdr.readU32LenString(),
+            .port = try rdr.readU32(),
+            .originator_host = try rdr.readU32LenString(),
+            .originator_port = try rdr.readU32(),
+        };
+    }
+
+    fn requestChannelOpenEvent(self: *Self, misshod: *MisshodClient, chan: *Channel) void {
+        _ = self;
+        const request: Misshod.ChannelOpenRequestType = switch (chan.channel_type) {
+            .Session => .Session,
+            .DirectTcpip => .{ .DirectTcpip = .{
+                .host = chan.tcpip_open.host,
+                .port = chan.tcpip_open.port,
+                .originator_host = chan.tcpip_open.originator_host,
+                .originator_port = chan.tcpip_open.originator_port,
+            } },
+            .ForwardedTcpip => .{ .ForwardedTcpip = .{
+                .connected_host = chan.tcpip_open.host,
+                .connected_port = chan.tcpip_open.port,
+                .originator_host = chan.tcpip_open.originator_host,
+                .originator_port = chan.tcpip_open.originator_port,
+            } },
+        };
+        misshod.requestEvent(.{ .ChannelOpenRequest = .{ .channel = chan.local_id, .request = request } }, .Idle);
+    }
+
+    fn handleChannelOpenPacket(self: *Self, rdr: *BufferReader, misshod: *MisshodClient) MisshodError!void {
+        // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
+        const chantype = try rdr.readU32LenString();
+        const remote_id = try rdr.readU32();
+        const peer_window = try rdr.readU32();
+        const max_packet_size = try rdr.readU32();
+        const channel_type = ChannelType.fromName(chantype) orelse {
+            try self.sendChannelOpenFailure(
+                misshod,
+                remote_id,
+                SshOpenFailureReason.UnknownChannelType,
+                "unknown channel type",
+            );
+            return;
+        };
+
+        if (channel_type == .Session) {
+            try self.sendChannelOpenFailure(
+                misshod,
+                remote_id,
+                SshOpenFailureReason.AdministrativelyProhibited,
+                "client does not accept session channel opens",
+            );
+            return;
+        }
+
+        const tcpip_open = if (channel_type.hasTcpipOpenPayload()) try readTcpipOpen(rdr) else TcpipOpen{};
+        const chan = self.channel_table.allocChannel(remote_id, peer_window, max_packet_size) orelse {
+            try self.sendChannelOpenFailure(
+                misshod,
+                remote_id,
+                SshOpenFailureReason.ResourceShortage,
+                "too many channels",
+            );
+            return;
+        };
+        chan.channel_type = channel_type;
+        chan.tcpip_open = tcpip_open;
+        chan.state = .Open;
+        self.active_channel_id = null;
+        self.setSessionState(.ChannelActive);
+        self.requestChannelOpenEvent(misshod, chan);
     }
 
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodClient) MisshodError!void {
@@ -914,6 +1091,9 @@ pub const Session = struct {
                     self.setIoSessionState(.Idle);
                 }
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN) => {
+                try self.handleChannelOpenPacket(&rdr, misshod);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION) => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
                 const recipient = try rdr.readU32(); // recipient channel
@@ -925,12 +1105,12 @@ pub const Session = struct {
                     chan.peer_window = peer_window;
                     chan.remote_max_packet_size = max_packet_size;
                     switch (chan.client_open_mode) {
-                        .AutoShell => {
+                        .AutoShell => if (chan.channel_type == .Session) {
                             chan.state = .Open;
                             self.active_channel_id = chan.local_id;
                             self.setSessionState(.ChannelActive);
                             self.setIoSessionState(.Idle);
-                        },
+                        } else return IoError.UnexpectedResponse,
                         .RawSession => {
                             chan.state = .Data;
                             self.active_channel_id = chan.local_id;
@@ -1154,6 +1334,7 @@ test "openSessionChannel writes channel open for new raw session channel" {
 
     const chan = m.session.channel_table.findByLocalId(channel_id).?;
     try std.testing.expectEqual(ClientChannelOpenMode.RawSession, chan.client_open_mode);
+    try std.testing.expectEqual(ChannelType.Session, chan.channel_type);
     try std.testing.expectEqual(ChannelState.OpenWrite, chan.state);
 
     const data = try m.peek(Protocol.MaxSSHPacket);
@@ -1163,6 +1344,31 @@ test "openSessionChannel writes channel open for new raw session channel" {
     try std.testing.expectEqual(channel_id, try rdr.readU32());
     try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
     try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+}
+
+test "openDirectTcpipChannel writes direct-tcpip open payload" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    const channel_id = try m.openDirectTcpipChannel("example.com", 443, "127.0.0.1", 55555);
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(ChannelType.DirectTcpip, chan.channel_type);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
+    try std.testing.expectEqualStrings("direct-tcpip", try rdr.readU32LenString());
+    try std.testing.expectEqual(channel_id, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqualStrings("example.com", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 443), try rdr.readU32());
+    try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 55555), try rdr.readU32());
 }
 
 test "openSessionChannel rejects another open while one is pending" {
@@ -1509,6 +1715,94 @@ test "handlePacket: raw channel confirmation emits ChannelOpened without shell s
 
     try m.clearEvent(.{ .ChannelOpened = chan.local_id });
     try std.testing.expect(std.meta.eql(m.iostate_wr, .Idle));
+}
+
+test "handlePacket: direct-tcpip confirmation emits ChannelOpened" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(0, 0, 0).?;
+    chan.client_open_mode = .RawSession;
+    chan.channel_type = .DirectTcpip;
+    chan.state = .OpenWrite;
+
+    var payload_backing: [32]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try pw.writeU32(chan.local_id); // recipient channel
+    try pw.writeU32(42); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelOpenRsp);
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try std.testing.expectEqual(ChannelState.Data, chan.state);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpened => |channel_id| try std.testing.expectEqual(chan.local_id, channel_id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "handlePacket: forwarded-tcpip open emits request and accept confirms" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [160]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString("forwarded-tcpip");
+    try pw.writeU32(77); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+    try pw.writeU32LenString("127.0.0.1");
+    try pw.writeU32(2222);
+    try pw.writeU32LenString("10.0.0.2");
+    try pw.writeU32(54321);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    const channel_id = switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpenRequest => |request| blk: {
+                switch (request.request) {
+                    .ForwardedTcpip => |tcp| {
+                        try std.testing.expectEqualStrings("127.0.0.1", tcp.connected_host);
+                        try std.testing.expectEqual(@as(u32, 2222), tcp.connected_port);
+                        try std.testing.expectEqualStrings("10.0.0.2", tcp.originator_host);
+                        try std.testing.expectEqual(@as(u32, 54321), tcp.originator_port);
+                    },
+                    else => return error.TestUnexpectedResult,
+                }
+                break :blk request.channel;
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    };
+
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(ChannelType.ForwardedTcpip, chan.channel_type);
+    try std.testing.expectEqual(ChannelState.Open, chan.state);
+
+    try m.acceptChannelOpen(channel_id);
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION), try rdr.readU8());
+    try std.testing.expectEqual(@as(u32, 77), try rdr.readU32());
+    try std.testing.expectEqual(channel_id, try rdr.readU32());
 }
 
 test "handlePacket: auto-shell confirmation still emits Connected" {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -83,16 +83,49 @@ pub const MisshodClientEventCodes = union(enum) {
     Connected,
     ChannelOpened: u32,
     ChannelOpenFailure: ChannelOpenFailure,
+    ChannelOpenRequest: ChannelOpenRequestEvent,
     RxData: []const u8,
     RxExtendedData: ExtendedData,
     Banner: []const u8,
     KeyboardInteractive: KeyboardInteractivePrompt,
 };
 
+pub const SshOpenFailureReason = struct {
+    pub const AdministrativelyProhibited: u32 = 1;
+    pub const ConnectFailed: u32 = 2;
+    pub const UnknownChannelType: u32 = 3;
+    pub const ResourceShortage: u32 = 4;
+};
+
 pub const ChannelOpenFailure = struct {
     channel: u32,
     reason_code: u32,
     description: []const u8,
+};
+
+pub const DirectTcpipOpen = struct {
+    host: []const u8,
+    port: u32,
+    originator_host: []const u8,
+    originator_port: u32,
+};
+
+pub const ForwardedTcpipOpen = struct {
+    connected_host: []const u8,
+    connected_port: u32,
+    originator_host: []const u8,
+    originator_port: u32,
+};
+
+pub const ChannelOpenRequestType = union(enum) {
+    Session,
+    DirectTcpip: DirectTcpipOpen,
+    ForwardedTcpip: ForwardedTcpipOpen,
+};
+
+pub const ChannelOpenRequestEvent = struct {
+    channel: u32,
+    request: ChannelOpenRequestType,
 };
 
 pub const ExtendedData = struct {
@@ -157,6 +190,7 @@ pub const MisshodServerEventCodes = union(enum) {
     WindowChange: WindowSize,
     Signal: ChannelSignal,
     ChannelRequest: ChannelRequestEvent,
+    ChannelOpenRequest: ChannelOpenRequestEvent,
 };
 
 pub fn MisshodEvent(role: Role) type {
@@ -692,6 +726,55 @@ pub fn MisshodImpl(role: Role) type {
                 .Client => try self.session.openSessionChannel(self),
                 .Server => IoError.UnimplementedService,
             };
+        }
+
+        pub fn openDirectTcpipChannel(
+            self: *Self,
+            host: []const u8,
+            port: u32,
+            originator_host: []const u8,
+            originator_port: u32,
+        ) MisshodError!u32 {
+            return switch (role) {
+                .Client => try self.session.openDirectTcpipChannel(
+                    self,
+                    host,
+                    port,
+                    originator_host,
+                    originator_port,
+                ),
+                .Server => IoError.UnimplementedService,
+            };
+        }
+
+        fn clearPendingChannelOpenRequest(self: *Self, channel_id: u32) MisshodError!void {
+            switch (self.iostate_wr) {
+                .Idle => return,
+                .Active => |iotype| switch (iotype.action) {
+                    .Eventing => |eventCode| switch (eventCode) {
+                        .ChannelOpenRequest => |request| {
+                            if (request.channel != channel_id) return IoError.badClearEvent;
+                            self.session.setIoSessionState(iotype.next_state);
+                            self.iostate_wr = .Idle;
+                            return;
+                        },
+                        else => return IoError.badClearEvent,
+                    },
+                    else => return IoError.cannotAcceptWrite,
+                },
+            }
+        }
+
+        pub fn acceptChannelOpen(self: *Self, channel_id: u32) MisshodError!void {
+            try self.clearPendingChannelOpenRequest(channel_id);
+            try self.session.acceptChannelOpen(channel_id);
+            try self.advance();
+        }
+
+        pub fn rejectChannelOpen(self: *Self, channel_id: u32, reason_code: u32, description: []const u8) MisshodError!void {
+            try self.clearPendingChannelOpenRequest(channel_id);
+            try self.session.rejectChannelOpen(channel_id, reason_code, description);
+            try self.advance();
         }
 
         pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -2,9 +2,11 @@ const std = @import("std");
 const util = @import("util.zig");
 const TRACE = util.trace;
 const TRACEDUMP = util.tracedump;
-const MisshodServer = @import("misshod.zig").MisshodServer;
-const MisshodError = @import("misshod.zig").MisshodError;
-const IoError = @import("misshod.zig").IoError;
+const Misshod = @import("misshod.zig");
+const MisshodServer = Misshod.MisshodServer;
+const MisshodError = Misshod.MisshodError;
+const IoError = Misshod.IoError;
+const SshOpenFailureReason = Misshod.SshOpenFailureReason;
 const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
@@ -17,6 +19,8 @@ const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
 const ChannelTable = @import("channel.zig").ChannelTable;
 const ChannelState = @import("channel.zig").ChannelState;
+const ChannelType = @import("channel.zig").ChannelType;
+const TcpipOpen = @import("channel.zig").TcpipOpen;
 
 pub const SessionState = enum {
     Init,
@@ -59,14 +63,14 @@ pub const Session = struct {
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
 
-    auth_pubkey_attempted:[Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined, // U32LenString with algo name + pubkey
-    q_c:[Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
+    auth_pubkey_attempted: [Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined, // U32LenString with algo name + pubkey
+    q_c: [Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
 
     privkey_blob: [Protocol.srv_hostkey_algo.SecretKey.encoded_length]u8 = undefined,
     pubkey_blob: [Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
 
     pub fn init(rand: std.Random, hostkey_ascii: []const u8, allocator: std.mem.Allocator) !Self {
-        var s = Self {
+        var s = Self{
             .ioSessionState = .Init,
             .sessionState = .Init,
             .rand = rand,
@@ -119,7 +123,7 @@ pub const Session = struct {
         self.sessionState = newState;
     }
 
-    pub fn grantAccess(self: *Self, allow:bool) MisshodError!void {
+    pub fn grantAccess(self: *Self, allow: bool) MisshodError!void {
         if (self.sessionState != .CheckUserPasswordAuth) {
             return IoError.UnexpectedResponse;
         } else {
@@ -239,7 +243,6 @@ pub const Session = struct {
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.NewKeysRead);
-
             },
             .NewKeysRead => {
                 self.setIoSessionState(.ReadPktHdr);
@@ -261,7 +264,7 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_FAILURE));
                 try pkt.writeU32LenString("password,publickey");
-                try pkt.writeBoolean(false);    // partial success
+                try pkt.writeBoolean(false); // partial success
                 self.setSessionState(.AuthRead);
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
@@ -316,15 +319,15 @@ pub const Session = struct {
                 try pkt.writeU32(chan.local_id);
                 try pkt.writeU32(Protocol.MaxPayload);
                 try pkt.writeU32(Protocol.MaxPayload);
-                chan.state = .Connected;
+                chan.state = if (chan.channel_type == .Session) .Connected else .Data;
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
             .OpenFailureWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
                 try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32(4); // SSH_OPEN_RESOURCE_SHORTAGE
-                try pkt.writeU32LenString("too many channels");
+                try pkt.writeU32(chan.open_failure_reason_code);
+                try pkt.writeU32LenString(chan.open_failure_description);
                 try pkt.writeU32LenString("");
                 self.channel_table.freeChannel(chan.local_id);
                 self.active_channel_id = null;
@@ -420,6 +423,26 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
         }
+    }
+
+    pub fn acceptChannelOpen(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.state != .Open) return IoError.UnexpectedResponse;
+        chan.state = .ConfirmWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+    }
+
+    pub fn rejectChannelOpen(self: *Self, channel_id: u32, reason_code: u32, description: []const u8) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.state != .Open) return IoError.UnexpectedResponse;
+        chan.open_failure_reason_code = reason_code;
+        chan.open_failure_description = description;
+        chan.state = .OpenFailureWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
     }
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
@@ -518,6 +541,93 @@ pub const Session = struct {
         return vers;
     }
 
+    fn sendChannelOpenFailure(
+        self: *Self,
+        misshod: *MisshodServer,
+        recipient: u32,
+        reason_code: u32,
+        description: []const u8,
+    ) MisshodError!void {
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+        try pkt.writeU32(recipient);
+        try pkt.writeU32(reason_code);
+        try pkt.writeU32LenString(description);
+        try pkt.writeU32LenString("");
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.s2c, &pkt, &misshod.iobuf_wr), .Idle);
+    }
+
+    fn readTcpipOpen(rdr: *BufferReader) MisshodError!TcpipOpen {
+        return .{
+            .host = try rdr.readU32LenString(),
+            .port = try rdr.readU32(),
+            .originator_host = try rdr.readU32LenString(),
+            .originator_port = try rdr.readU32(),
+        };
+    }
+
+    fn requestChannelOpenEvent(self: *Self, misshod: *MisshodServer, chan: *Channel) void {
+        _ = self;
+        const request: Misshod.ChannelOpenRequestType = switch (chan.channel_type) {
+            .Session => .Session,
+            .DirectTcpip => .{ .DirectTcpip = .{
+                .host = chan.tcpip_open.host,
+                .port = chan.tcpip_open.port,
+                .originator_host = chan.tcpip_open.originator_host,
+                .originator_port = chan.tcpip_open.originator_port,
+            } },
+            .ForwardedTcpip => .{ .ForwardedTcpip = .{
+                .connected_host = chan.tcpip_open.host,
+                .connected_port = chan.tcpip_open.port,
+                .originator_host = chan.tcpip_open.originator_host,
+                .originator_port = chan.tcpip_open.originator_port,
+            } },
+        };
+        misshod.requestEvent(.{ .ChannelOpenRequest = .{ .channel = chan.local_id, .request = request } }, .Idle);
+    }
+
+    fn handleChannelOpenPacket(self: *Self, rdr: *BufferReader, misshod: *MisshodServer) MisshodError!void {
+        // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
+        const chantype = try rdr.readU32LenString();
+        const remote_id = try rdr.readU32();
+        const peer_window = try rdr.readU32();
+        const max_packet_size = try rdr.readU32();
+        const channel_type = ChannelType.fromName(chantype) orelse {
+            try self.sendChannelOpenFailure(
+                misshod,
+                remote_id,
+                SshOpenFailureReason.UnknownChannelType,
+                "unknown channel type",
+            );
+            return;
+        };
+        const tcpip_open = if (channel_type.hasTcpipOpenPayload()) try readTcpipOpen(rdr) else TcpipOpen{};
+
+        const chan = self.channel_table.allocChannel(remote_id, peer_window, max_packet_size) orelse {
+            try self.sendChannelOpenFailure(
+                misshod,
+                remote_id,
+                SshOpenFailureReason.ResourceShortage,
+                "too many channels",
+            );
+            return;
+        };
+        chan.channel_type = channel_type;
+        chan.tcpip_open = tcpip_open;
+
+        if (channel_type == .Session) {
+            chan.state = .ConfirmWrite;
+            self.active_channel_id = chan.local_id;
+            self.setSessionState(.ChannelActive);
+            self.setIoSessionState(.Idle);
+        } else {
+            chan.state = .Open;
+            self.active_channel_id = null;
+            self.setSessionState(.ChannelActive);
+            self.requestChannelOpenEvent(misshod, chan);
+        }
+    }
+
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodServer) MisshodError!void {
         var rdr = try misshod.getRecvBuffer(misshod.iobuf_rd[0..buf.len], &self.keydata.c2s);
 
@@ -532,8 +642,7 @@ pub const Session = struct {
 
                 const is_rekey = self.sessionState != .KexInitRead;
                 if (is_rekey) {
-                    if (self.sessionState != .ChannelActive)
-                    {
+                    if (self.sessionState != .ChannelActive) {
                         self.setIoSessionState(.ReadPktHdr);
                         return;
                     }
@@ -632,7 +741,7 @@ pub const Session = struct {
                         return IoError.UnimplementedService;
                     }
                 } else {
-                    return IoError.UnexpectedResponse;  // why is client asking now?
+                    return IoError.UnexpectedResponse; // why is client asking now?
                 }
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST) => {
@@ -643,7 +752,7 @@ pub const Session = struct {
                     const svcname = try rdr.readU32LenString();
                     const authtyp = try rdr.readU32LenString();
 
-                    TRACE(.Debug, "username={s} svcname={s} authtyp={s}", .{username, svcname, authtyp});
+                    TRACE(.Debug, "username={s} svcname={s} authtyp={s}", .{ username, svcname, authtyp });
                     if (!std.mem.eql(u8, svcname, "ssh-connection")) {
                         return IoError.UnimplementedService;
                     }
@@ -657,14 +766,14 @@ pub const Session = struct {
                         self.setSessionState(.CheckUserPasswordAuth);
                         misshod.requestEvent(.{ .UserAuth = .{
                             .username = username,
-                            .auth = .{.Password = password},
+                            .auth = .{ .Password = password },
                         } }, .Idle);
                     } else if (std.mem.eql(u8, authtyp, "publickey")) {
                         const forreal = try rdr.readBoolean();
                         const algoname = try rdr.readU32LenString();
                         const typed_pubkey = try rdr.readU32LenString();
 
-                        TRACE(.Debug, "forreal={any} algoname={s} typed_pubkey len={d}", .{forreal, algoname, typed_pubkey.len});
+                        TRACE(.Debug, "forreal={any} algoname={s} typed_pubkey len={d}", .{ forreal, algoname, typed_pubkey.len });
 
                         // extract raw pubkey
                         var nb = util.NamedBlob.init(typed_pubkey);
@@ -724,15 +833,12 @@ pub const Session = struct {
                             self.setSessionState(.CheckUserPasswordAuth);
                             misshod.requestEvent(.{ .UserAuth = .{
                                 .username = username,
-                                .auth = .{.Pubkey = typed_pubkey},
+                                .auth = .{ .Pubkey = typed_pubkey },
                             } }, .Idle);
                         }
                     } else if (std.mem.eql(u8, authtyp, "none")) {
                         self.setSessionState(.CheckUserPasswordAuth);
-                        misshod.requestEvent(.{ .UserAuth = .{
-                            .username = username,
-                            .auth = null
-                        } }, .Idle);
+                        misshod.requestEvent(.{ .UserAuth = .{ .username = username, .auth = null } }, .Idle);
                     } else if (std.mem.eql(u8, authtyp, "keyboard-interactive")) {
                         // RFC 4256 §3.1
                         _ = try rdr.readU32LenString(); // language tag
@@ -746,37 +852,11 @@ pub const Session = struct {
                         return IoError.UnimplementedService;
                     }
                 } else {
-                    return IoError.UnexpectedResponse;  // why is client asking now?
+                    return IoError.UnexpectedResponse; // why is client asking now?
                 }
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN) => {
-                // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
-                const chantype = try rdr.readU32LenString();
-                const remote_id = try rdr.readU32();
-                const peer_window = try rdr.readU32();
-                const max_packet_size = try rdr.readU32();
-
-                if (!std.mem.eql(u8, chantype, "session")) {
-                    return IoError.UnimplementedService;
-                }
-
-                if (self.channel_table.allocChannel(remote_id, peer_window, max_packet_size)) |chan| {
-                    chan.state = .ConfirmWrite;
-                    self.active_channel_id = chan.local_id;
-                } else {
-                    var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                    try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
-                    try pkt.writeU32(remote_id);
-                    try pkt.writeU32(4);
-                    try pkt.writeU32LenString("too many channels");
-                    try pkt.writeU32LenString("");
-                    const outkeys = &self.keydata.s2c;
-                    misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                    return;
-                }
-
-                self.setSessionState(.ChannelActive);
-                self.setIoSessionState(.Idle);
+                try self.handleChannelOpenPacket(&rdr, misshod);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST) => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
@@ -840,7 +920,7 @@ pub const Session = struct {
                     return;
                 } else {
                     TRACE(.Debug, "channel req '{s}'", .{typ});
-                    if (wantreply) {    // can't do this
+                    if (wantreply) { // can't do this
                         return IoError.UnimplementedService;
                     }
                 }
@@ -974,7 +1054,6 @@ pub const Session = struct {
             },
         }
     }
-
 };
 
 fn nameListContains(namelist: []const u8, target: []const u8) bool {
@@ -983,4 +1062,151 @@ fn nameListContains(namelist: []const u8, target: []const u8) bool {
         if (std.mem.eql(u8, name, target)) return true;
     }
     return false;
+}
+
+fn buildUnencryptedPacket(buf: []u8, payload: []const u8) usize {
+    const padding_length: u8 = 8;
+    const packet_length: u32 = @intCast(payload.len + padding_length + 1);
+    var hdr: Protocol.PktHdr = .{
+        .packet_length = packet_length,
+        .padding_length = padding_length,
+    };
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+    }
+    @memcpy(buf[0..Protocol.sizeof_PktHdr], util.asPackedBytes(Protocol.PktHdr, &hdr));
+    @memcpy(buf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload.len], payload);
+    @memset(buf[Protocol.sizeof_PktHdr + payload.len .. Protocol.sizeof_PktHdr + payload.len + padding_length], 0);
+    return Protocol.sizeof_PktHdr + payload.len + padding_length;
+}
+
+fn unencryptedPayload(packet: []const u8) []const u8 {
+    var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, packet[0..Protocol.sizeof_PktHdr]).*;
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+    }
+    const payload_len = hdr.packet_length - hdr.padding_length - 1;
+    return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
+}
+
+test "handlePacket: direct-tcpip open emits request and accept confirms" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [160]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString("direct-tcpip");
+    try pw.writeU32(77); // sender channel
+    try pw.writeU32(32768); // initial window size
+    try pw.writeU32(4096); // max packet size
+    try pw.writeU32LenString("example.com");
+    try pw.writeU32(443);
+    try pw.writeU32LenString("127.0.0.1");
+    try pw.writeU32(55555);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    const channel_id = switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpenRequest => |request| blk: {
+                switch (request.request) {
+                    .DirectTcpip => |tcp| {
+                        try std.testing.expectEqualStrings("example.com", tcp.host);
+                        try std.testing.expectEqual(@as(u32, 443), tcp.port);
+                        try std.testing.expectEqualStrings("127.0.0.1", tcp.originator_host);
+                        try std.testing.expectEqual(@as(u32, 55555), tcp.originator_port);
+                    },
+                    else => return error.TestUnexpectedResult,
+                }
+                break :blk request.channel;
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    };
+
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(ChannelType.DirectTcpip, chan.channel_type);
+    try std.testing.expectEqual(ChannelState.Open, chan.state);
+
+    try m.acceptChannelOpen(channel_id);
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION), try rdr.readU8());
+    try std.testing.expectEqual(@as(u32, 77), try rdr.readU32());
+    try std.testing.expectEqual(channel_id, try rdr.readU32());
+}
+
+test "rejectChannelOpen writes caller-provided failure" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [160]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString("direct-tcpip");
+    try pw.writeU32(88); // sender channel
+    try pw.writeU32(32768);
+    try pw.writeU32(4096);
+    try pw.writeU32LenString("example.com");
+    try pw.writeU32(443);
+    try pw.writeU32LenString("127.0.0.1");
+    try pw.writeU32(55555);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    const channel_id = switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelOpenRequest => |request| request.channel,
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    };
+
+    try m.rejectChannelOpen(channel_id, SshOpenFailureReason.ConnectFailed, "connect failed");
+    try std.testing.expect(m.session.channel_table.findByLocalId(channel_id) == null);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE), try rdr.readU8());
+    try std.testing.expectEqual(@as(u32, 88), try rdr.readU32());
+    try std.testing.expectEqual(SshOpenFailureReason.ConnectFailed, try rdr.readU32());
+    try std.testing.expectEqualStrings("connect failed", try rdr.readU32LenString());
+}
+
+test "handlePacket: unknown channel type writes open failure" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [64]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString("x11");
+    try pw.writeU32(99); // sender channel
+    try pw.writeU32(32768);
+    try pw.writeU32(4096);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE), try rdr.readU8());
+    try std.testing.expectEqual(@as(u32, 99), try rdr.readU32());
+    try std.testing.expectEqual(SshOpenFailureReason.UnknownChannelType, try rdr.readU32());
+    try std.testing.expectEqualStrings("unknown channel type", try rdr.readU32LenString());
 }


### PR DESCRIPTION
## Summary
- add channel type metadata and TCP open payload storage for session/direct-tcpip/forwarded-tcpip channels
- add public TCP channel-open request events plus accept/reject APIs
- add client `openDirectTcpipChannel()` and channel-specific open serialization
- parse inbound non-session channel opens on client/server, including unknown-type/resource-shortage failures
- add unit coverage for direct-tcpip, forwarded-tcpip, accept, reject, unknown channel types, and existing session behavior

Fixes #42

## Tests
- `zig test src/test.zig`
- `zig build`
- `zig build test`