### PR TITLE
Support SSH port forwarding primitives

### DIFF
--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -49,6 +49,17 @@ pub const SessionState = enum {
     ChannelActive,
 };
 
+const PendingGlobalRequestKind = enum {
+    TcpipForward,
+    CancelTcpipForward,
+};
+
+const PendingGlobalRequest = struct {
+    kind: PendingGlobalRequestKind,
+    bind_address: []const u8,
+    bind_port: u32,
+};
+
 pub const Session = struct {
     const Self = @This();
 
@@ -70,6 +81,8 @@ pub const Session = struct {
     channel_table: ChannelTable,
     active_channel_id: ?u32,
     pending_window_change: ?[4]u32,
+    pending_global_request: ?PendingGlobalRequest,
+    pending_global_request_bind_address: [Protocol.MaxSSHPacket]u8 = undefined,
     kbd_interactive_response: ?[]u8, // allocated
     is_rekeying: bool,
 
@@ -95,6 +108,7 @@ pub const Session = struct {
             .channel_table = ChannelTable{},
             .active_channel_id = null,
             .pending_window_change = null,
+            .pending_global_request = null,
             .kbd_interactive_response = null,
             .is_rekeying = false,
         };
@@ -692,6 +706,64 @@ pub const Session = struct {
         return chan.local_id;
     }
 
+    pub fn openLocalForwardChannel(
+        self: *Self,
+        misshod: *MisshodClient,
+        host: []const u8,
+        port: u32,
+        originator_host: []const u8,
+        originator_port: u32,
+    ) MisshodError!u32 {
+        return try self.openDirectTcpipChannel(misshod, host, port, originator_host, originator_port);
+    }
+
+    fn sendTcpipForwardGlobalRequest(
+        self: *Self,
+        misshod: *MisshodClient,
+        kind: PendingGlobalRequestKind,
+        bind_address: []const u8,
+        bind_port: u32,
+    ) MisshodError!void {
+        if (misshod.iostate_wr != .Idle or self.active_channel_id != null or self.pending_global_request != null) {
+            return IoError.cannotAcceptWrite;
+        }
+        if (self.sessionState != .ChannelActive) {
+            return IoError.NotReady;
+        }
+        if (bind_address.len > self.pending_global_request_bind_address.len) {
+            return IoError.tooBig;
+        }
+
+        @memcpy(self.pending_global_request_bind_address[0..bind_address.len], bind_address);
+        const stored_bind_address = self.pending_global_request_bind_address[0..bind_address.len];
+
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST));
+        try pkt.writeU32LenString(switch (kind) {
+            .TcpipForward => "tcpip-forward",
+            .CancelTcpipForward => "cancel-tcpip-forward",
+        });
+        try pkt.writeBoolean(true); // want reply
+        try pkt.writeU32LenString(stored_bind_address);
+        try pkt.writeU32(bind_port);
+
+        const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.c2s, &pkt, &misshod.iobuf_wr);
+        self.pending_global_request = .{
+            .kind = kind,
+            .bind_address = stored_bind_address,
+            .bind_port = bind_port,
+        };
+        misshod.requestWrite(wrapped, .Idle);
+    }
+
+    pub fn requestRemoteForward(self: *Self, misshod: *MisshodClient, bind_address: []const u8, bind_port: u32) MisshodError!void {
+        try self.sendTcpipForwardGlobalRequest(misshod, .TcpipForward, bind_address, bind_port);
+    }
+
+    pub fn cancelRemoteForward(self: *Self, misshod: *MisshodClient, bind_address: []const u8, bind_port: u32) MisshodError!void {
+        try self.sendTcpipForwardGlobalRequest(misshod, .CancelTcpipForward, bind_address, bind_port);
+    }
+
     pub fn acceptChannelOpen(self: *Self, channel_id: u32) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
         if (chan.state != .Open) return IoError.UnexpectedResponse;
@@ -908,6 +980,48 @@ pub const Session = struct {
         self.requestChannelOpenEvent(misshod, chan);
     }
 
+    fn handleGlobalRequestSuccess(self: *Self, rdr: *BufferReader, misshod: *MisshodClient) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        switch (pending.kind) {
+            .TcpipForward => {
+                const bound_port = if (pending.bind_port == 0) try rdr.readU32() else pending.bind_port;
+                misshod.requestEvent(.{ .TcpipForwardSuccess = .{
+                    .bind_address = pending.bind_address,
+                    .requested_port = pending.bind_port,
+                    .bound_port = bound_port,
+                } }, .Idle);
+            },
+            .CancelTcpipForward => {
+                misshod.requestEvent(.{ .CancelTcpipForwardSuccess = .{
+                    .bind_address = pending.bind_address,
+                    .bind_port = pending.bind_port,
+                } }, .Idle);
+            },
+        }
+    }
+
+    fn handleGlobalRequestFailure(self: *Self, misshod: *MisshodClient) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        switch (pending.kind) {
+            .TcpipForward => {
+                misshod.requestEvent(.{ .TcpipForwardFailure = .{
+                    .bind_address = pending.bind_address,
+                    .bind_port = pending.bind_port,
+                } }, .Idle);
+            },
+            .CancelTcpipForward => {
+                misshod.requestEvent(.{ .CancelTcpipForwardFailure = .{
+                    .bind_address = pending.bind_address,
+                    .bind_port = pending.bind_port,
+                } }, .Idle);
+            },
+        }
+    }
+
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodClient) MisshodError!void {
         var rdr = try misshod.getRecvBuffer(misshod.iobuf_rd[0..buf.len], &self.keydata.s2c);
 
@@ -1090,6 +1204,12 @@ pub const Session = struct {
                     self.setSessionState(.KeyboardInteractiveInfoRsp);
                     self.setIoSessionState(.Idle);
                 }
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_SUCCESS) => {
+                try self.handleGlobalRequestSuccess(&rdr, misshod);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_FAILURE) => {
+                try self.handleGlobalRequestFailure(misshod);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN) => {
                 try self.handleChannelOpenPacket(&rdr, misshod);
@@ -1369,6 +1489,107 @@ test "openDirectTcpipChannel writes direct-tcpip open payload" {
     try std.testing.expectEqual(@as(u32, 443), try rdr.readU32());
     try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
     try std.testing.expectEqual(@as(u32, 55555), try rdr.readU32());
+}
+
+test "requestRemoteForward writes tcpip-forward global request" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    try m.requestRemoteForward("127.0.0.1", 0);
+    try std.testing.expect(m.session.pending_global_request != null);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST), try rdr.readU8());
+    try std.testing.expectEqualStrings("tcpip-forward", try rdr.readU32LenString());
+    try std.testing.expect(try rdr.readBoolean());
+    try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 0), try rdr.readU32());
+}
+
+test "cancelRemoteForward writes cancel-tcpip-forward global request" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+
+    try m.cancelRemoteForward("127.0.0.1", 2200);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST), try rdr.readU8());
+    try std.testing.expectEqualStrings("cancel-tcpip-forward", try rdr.readU32LenString());
+    try std.testing.expect(try rdr.readBoolean());
+    try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 2200), try rdr.readU32());
+}
+
+test "handlePacket: request success maps allocated tcpip-forward port" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+    try m.requestRemoteForward("127.0.0.1", 0);
+    try m.consumed(m.wr_nbytes);
+
+    var payload_backing: [16]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_SUCCESS));
+    try pw.writeU32(2222);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .TcpipForwardSuccess => |forward| {
+                try std.testing.expectEqualStrings("127.0.0.1", forward.bind_address);
+                try std.testing.expectEqual(@as(u32, 0), forward.requested_port);
+                try std.testing.expectEqual(@as(u32, 2222), forward.bound_port);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "handlePacket: request failure maps cancel-tcpip-forward failure" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.ChannelActive);
+    try m.cancelRemoteForward("127.0.0.1", 2200);
+    try m.consumed(m.wr_nbytes);
+
+    var payload_backing: [8]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_FAILURE));
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .CancelTcpipForwardFailure => |cancel| {
+                try std.testing.expectEqualStrings("127.0.0.1", cancel.bind_address);
+                try std.testing.expectEqual(@as(u32, 2200), cancel.bind_port);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "openSessionChannel rejects another open while one is pending" {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -84,6 +84,10 @@ pub const MisshodClientEventCodes = union(enum) {
     ChannelOpened: u32,
     ChannelOpenFailure: ChannelOpenFailure,
     ChannelOpenRequest: ChannelOpenRequestEvent,
+    TcpipForwardSuccess: TcpipForwardSuccess,
+    TcpipForwardFailure: TcpipForwardFailure,
+    CancelTcpipForwardSuccess: TcpipForwardRequest,
+    CancelTcpipForwardFailure: TcpipForwardRequest,
     RxData: []const u8,
     RxExtendedData: ExtendedData,
     Banner: []const u8,
@@ -101,6 +105,22 @@ pub const ChannelOpenFailure = struct {
     channel: u32,
     reason_code: u32,
     description: []const u8,
+};
+
+pub const TcpipForwardRequest = struct {
+    bind_address: []const u8,
+    bind_port: u32,
+};
+
+pub const TcpipForwardSuccess = struct {
+    bind_address: []const u8,
+    requested_port: u32,
+    bound_port: u32,
+};
+
+pub const TcpipForwardFailure = struct {
+    bind_address: []const u8,
+    bind_port: u32,
 };
 
 pub const DirectTcpipOpen = struct {
@@ -185,12 +205,16 @@ pub const MisshodServerEventCodes = union(enum) {
     UserAuth: UserCredentials,
     GetPubkeyForUser: []const u8,
     Connected: u32,
+    ChannelOpened: u32,
+    ChannelOpenFailure: ChannelOpenFailure,
     RxData: ChannelData,
     RxExtendedData: ChannelExtendedData,
     WindowChange: WindowSize,
     Signal: ChannelSignal,
     ChannelRequest: ChannelRequestEvent,
     ChannelOpenRequest: ChannelOpenRequestEvent,
+    TcpipForward: TcpipForwardRequest,
+    CancelTcpipForward: TcpipForwardRequest,
 };
 
 pub fn MisshodEvent(role: Role) type {
@@ -310,6 +334,12 @@ pub fn MisshodImpl(role: Role) type {
                     switch (iotype.action) {
                         .Eventing => |eventCode| {
                             if (@intFromEnum(eventCode) == @intFromEnum(clearEventCode)) {
+                                if (comptime role == .Server) {
+                                    switch (eventCode) {
+                                        .TcpipForward, .CancelTcpipForward => return IoError.badClearEvent,
+                                        else => {},
+                                    }
+                                }
                                 // event succesfully cleared
                                 self.session.setIoSessionState(iotype.next_state);
                                 self.iostate_wr = .Idle;
@@ -747,6 +777,49 @@ pub fn MisshodImpl(role: Role) type {
             };
         }
 
+        pub fn openLocalForwardChannel(
+            self: *Self,
+            host: []const u8,
+            port: u32,
+            originator_host: []const u8,
+            originator_port: u32,
+        ) MisshodError!u32 {
+            return try self.openDirectTcpipChannel(host, port, originator_host, originator_port);
+        }
+
+        pub fn requestRemoteForward(self: *Self, bind_address: []const u8, bind_port: u32) MisshodError!void {
+            return switch (role) {
+                .Client => try self.session.requestRemoteForward(self, bind_address, bind_port),
+                .Server => IoError.UnimplementedService,
+            };
+        }
+
+        pub fn cancelRemoteForward(self: *Self, bind_address: []const u8, bind_port: u32) MisshodError!void {
+            return switch (role) {
+                .Client => try self.session.cancelRemoteForward(self, bind_address, bind_port),
+                .Server => IoError.UnimplementedService,
+            };
+        }
+
+        pub fn openForwardedTcpipChannel(
+            self: *Self,
+            connected_host: []const u8,
+            connected_port: u32,
+            originator_host: []const u8,
+            originator_port: u32,
+        ) MisshodError!u32 {
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => try self.session.openForwardedTcpipChannel(
+                    self,
+                    connected_host,
+                    connected_port,
+                    originator_host,
+                    originator_port,
+                ),
+            };
+        }
+
         fn clearPendingChannelOpenRequest(self: *Self, channel_id: u32) MisshodError!void {
             switch (self.iostate_wr) {
                 .Idle => return,
@@ -763,6 +836,92 @@ pub fn MisshodImpl(role: Role) type {
                     else => return IoError.cannotAcceptWrite,
                 },
             }
+        }
+
+        fn clearPendingTcpipForwardEvent(self: *Self) MisshodError!void {
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    switch (self.iostate_wr) {
+                        .Idle => return IoError.badClearEvent,
+                        .Active => |iotype| switch (iotype.action) {
+                            .Eventing => |eventCode| switch (eventCode) {
+                                .TcpipForward => {
+                                    self.session.setIoSessionState(iotype.next_state);
+                                    self.iostate_wr = .Idle;
+                                },
+                                else => return IoError.badClearEvent,
+                            },
+                            else => return IoError.cannotAcceptWrite,
+                        },
+                    }
+                },
+            };
+        }
+
+        fn clearPendingCancelTcpipForwardEvent(self: *Self) MisshodError!void {
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    switch (self.iostate_wr) {
+                        .Idle => return IoError.badClearEvent,
+                        .Active => |iotype| switch (iotype.action) {
+                            .Eventing => |eventCode| switch (eventCode) {
+                                .CancelTcpipForward => {
+                                    self.session.setIoSessionState(iotype.next_state);
+                                    self.iostate_wr = .Idle;
+                                },
+                                else => return IoError.badClearEvent,
+                            },
+                            else => return IoError.cannotAcceptWrite,
+                        },
+                    }
+                },
+            };
+        }
+
+        pub fn acceptTcpipForward(self: *Self, bound_port: u32) MisshodError!void {
+            try self.clearPendingTcpipForwardEvent();
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    try self.session.acceptTcpipForward(self, bound_port);
+                    try self.advance();
+                },
+            };
+        }
+
+        pub fn rejectTcpipForward(self: *Self) MisshodError!void {
+            try self.clearPendingTcpipForwardEvent();
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    try self.session.rejectTcpipForward(self);
+                    try self.advance();
+                },
+            };
+        }
+
+        pub fn acceptCancelTcpipForward(self: *Self) MisshodError!void {
+            try self.clearPendingCancelTcpipForwardEvent();
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    try self.session.acceptCancelTcpipForward(self);
+                    try self.advance();
+                },
+            };
+        }
+
+        pub fn rejectCancelTcpipForward(self: *Self) MisshodError!void {
+            try self.clearPendingCancelTcpipForwardEvent();
+            return switch (role) {
+                .Client => IoError.UnimplementedService,
+                .Server => {
+                    try self.session.rejectCancelTcpipForward(self);
+                    try self.advance();
+                },
+            };
         }
 
         pub fn acceptChannelOpen(self: *Self, channel_id: u32) MisshodError!void {

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -38,6 +38,8 @@ pub const MsgId = enum(u8) {
     SSH_MSG_USERAUTH_PK_OK = 60, // also SSH_MSG_USERAUTH_INFO_REQUEST per RFC 4256
     SSH_MSG_USERAUTH_INFO_RESPONSE = 61,
     SSH_MSG_GLOBAL_REQUEST = 80,
+    SSH_MSG_REQUEST_SUCCESS = 81,
+    SSH_MSG_REQUEST_FAILURE = 82,
     SSH_MSG_CHANNEL_OPEN = 90,
     SSH_MSG_CHANNEL_OPEN_CONFIRMATION = 91,
     SSH_MSG_CHANNEL_OPEN_FAILURE = 92,
@@ -49,7 +51,6 @@ pub const MsgId = enum(u8) {
     SSH_MSG_CHANNEL_REQUEST = 98,
     SSH_MSG_CHANNEL_SUCCESS = 99,
 };
-
 
 // SSH packet header, appears before payload
 // https://datatracker.ietf.org/doc/html/rfc4253#section-6
@@ -138,9 +139,9 @@ pub const KeyDataBi = struct {
     s2c: KeyDataUni,
 
     pub fn init() Self {
-        return Self {
-            .c2s = .{.seq = 0},
-            .s2c = .{.seq = 0},
+        return Self{
+            .c2s = .{ .seq = 0 },
+            .s2c = .{ .seq = 0 },
         };
     }
 
@@ -154,7 +155,7 @@ pub const KeyDataBi = struct {
     }
 
     // generate session keys from shared secret
-    pub fn genKeys(self:* Self, H: [hash_algo.digest_length]u8, shared_secret_k:[kex_algo.shared_length]u8, session_id: [hash_algo.digest_length]u8) !void {
+    pub fn genKeys(self: *Self, H: [hash_algo.digest_length]u8, shared_secret_k: [kex_algo.shared_length]u8, session_id: [hash_algo.digest_length]u8) !void {
 
         // https://datatracker.ietf.org/doc/html/rfc4253#section-7.2
 
@@ -221,7 +222,7 @@ pub const KeyDataBi = struct {
     }
 };
 
-pub fn wrapPkt(rand:*std.Random, encrypted:bool, keysuni:*KeyDataUni, buffer: *BufferWriter, iobuf: []u8) MisshodError![]const u8 {
+pub fn wrapPkt(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, buffer: *BufferWriter, iobuf: []u8) MisshodError![]const u8 {
     // https://datatracker.ietf.org/doc/html/rfc4253#section-6
     // pad such that whole packet (payload + hdr) is multiple of block_size
     const buffer_len = buffer.active().len;
@@ -288,6 +289,9 @@ test "MsgId enum values match SSH RFC" {
     try std.testing.expectEqual(@as(u8, 4), @intFromEnum(MsgId.SSH_MSG_DEBUG));
 
     // RFC 4254 channel messages
+    try std.testing.expectEqual(@as(u8, 80), @intFromEnum(MsgId.SSH_MSG_GLOBAL_REQUEST));
+    try std.testing.expectEqual(@as(u8, 81), @intFromEnum(MsgId.SSH_MSG_REQUEST_SUCCESS));
+    try std.testing.expectEqual(@as(u8, 82), @intFromEnum(MsgId.SSH_MSG_REQUEST_FAILURE));
     try std.testing.expectEqual(@as(u8, 90), @intFromEnum(MsgId.SSH_MSG_CHANNEL_OPEN));
     try std.testing.expectEqual(@as(u8, 94), @intFromEnum(MsgId.SSH_MSG_CHANNEL_DATA));
     try std.testing.expectEqual(@as(u8, 96), @intFromEnum(MsgId.SSH_MSG_CHANNEL_EOF));

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -40,6 +40,18 @@ pub const SessionState = enum {
     ChannelActive,
 };
 
+const PendingGlobalRequestKind = enum {
+    TcpipForward,
+    CancelTcpipForward,
+};
+
+const PendingGlobalRequest = struct {
+    kind: PendingGlobalRequestKind,
+    want_reply: bool,
+    bind_address: []const u8,
+    bind_port: u32,
+};
+
 pub const Session = struct {
     const Self = @This();
 
@@ -57,6 +69,8 @@ pub const Session = struct {
     encrypted: bool,
     channel_table: ChannelTable,
     active_channel_id: ?u32,
+    pending_global_request: ?PendingGlobalRequest,
+    pending_global_request_bind_address: [Protocol.MaxSSHPacket]u8 = undefined,
     is_rekeying: bool,
 
     privkey_ascii: ?[]u8, // allocated
@@ -83,6 +97,7 @@ pub const Session = struct {
             .auth_passphrase = null,
             .channel_table = ChannelTable{},
             .active_channel_id = null,
+            .pending_global_request = null,
             .is_rekeying = false,
         };
 
@@ -312,6 +327,23 @@ pub const Session = struct {
         self.active_channel_id = chan.local_id;
 
         switch (chan.state) {
+            .OpenWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+                try pkt.writeU32LenString(chan.channel_type.name());
+                try pkt.writeU32(chan.local_id);
+                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxPayload);
+                if (chan.channel_type.hasTcpipOpenPayload()) {
+                    try pkt.writeU32LenString(chan.tcpip_open.host);
+                    try pkt.writeU32(chan.tcpip_open.port);
+                    try pkt.writeU32LenString(chan.tcpip_open.originator_host);
+                    try pkt.writeU32(chan.tcpip_open.originator_port);
+                }
+                chan.state = .Open;
+                self.active_channel_id = null;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
+            },
             .ConfirmWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
@@ -419,7 +451,7 @@ pub const Session = struct {
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
-            .OpenWrite, .Open => {
+            .Open => {
                 self.setIoSessionState(.ReadPktHdr);
             },
         }
@@ -443,6 +475,37 @@ pub const Session = struct {
         self.active_channel_id = channel_id;
         self.setSessionState(.ChannelActive);
         self.setIoSessionState(.Idle);
+    }
+
+    pub fn openForwardedTcpipChannel(
+        self: *Self,
+        misshod: *MisshodServer,
+        connected_host: []const u8,
+        connected_port: u32,
+        originator_host: []const u8,
+        originator_port: u32,
+    ) MisshodError!u32 {
+        if (misshod.iostate_wr != .Idle or self.active_channel_id != null) {
+            return IoError.cannotAcceptWrite;
+        }
+        if (self.sessionState != .Authenticated and self.sessionState != .ChannelActive) {
+            return IoError.NotReady;
+        }
+
+        const chan = self.channel_table.allocChannel(0, 0, 0) orelse return IoError.tooManyChannels;
+        chan.channel_type = .ForwardedTcpip;
+        chan.tcpip_open = .{
+            .host = connected_host,
+            .port = connected_port,
+            .originator_host = originator_host,
+            .originator_port = originator_port,
+        };
+        chan.state = .OpenWrite;
+        self.active_channel_id = chan.local_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+        try self.advanceChannel(misshod, &self.keydata.s2c);
+        return chan.local_id;
     }
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
@@ -557,6 +620,78 @@ pub const Session = struct {
         misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.s2c, &pkt, &misshod.iobuf_wr), .Idle);
     }
 
+    fn sendGlobalRequestSuccess(
+        self: *Self,
+        misshod: *MisshodServer,
+        include_bound_port: bool,
+        bound_port: u32,
+    ) MisshodError!void {
+        if (misshod.iostate_wr != .Idle) return IoError.cannotAcceptWrite;
+
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_SUCCESS));
+        if (include_bound_port) {
+            try pkt.writeU32(bound_port);
+        }
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.s2c, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
+    }
+
+    fn sendGlobalRequestFailure(self: *Self, misshod: *MisshodServer) MisshodError!void {
+        if (misshod.iostate_wr != .Idle) return IoError.cannotAcceptWrite;
+
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_FAILURE));
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.s2c, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
+    }
+
+    pub fn acceptTcpipForward(self: *Self, misshod: *MisshodServer, bound_port: u32) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        if (pending.kind != .TcpipForward) return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        if (!pending.want_reply) {
+            self.setIoSessionState(.ReadPktHdr);
+            return;
+        }
+        try self.sendGlobalRequestSuccess(misshod, pending.bind_port == 0, bound_port);
+    }
+
+    pub fn rejectTcpipForward(self: *Self, misshod: *MisshodServer) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        if (pending.kind != .TcpipForward) return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        if (!pending.want_reply) {
+            self.setIoSessionState(.ReadPktHdr);
+            return;
+        }
+        try self.sendGlobalRequestFailure(misshod);
+    }
+
+    pub fn acceptCancelTcpipForward(self: *Self, misshod: *MisshodServer) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        if (pending.kind != .CancelTcpipForward) return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        if (!pending.want_reply) {
+            self.setIoSessionState(.ReadPktHdr);
+            return;
+        }
+        try self.sendGlobalRequestSuccess(misshod, false, 0);
+    }
+
+    pub fn rejectCancelTcpipForward(self: *Self, misshod: *MisshodServer) MisshodError!void {
+        const pending = self.pending_global_request orelse return IoError.UnexpectedResponse;
+        if (pending.kind != .CancelTcpipForward) return IoError.UnexpectedResponse;
+        self.pending_global_request = null;
+
+        if (!pending.want_reply) {
+            self.setIoSessionState(.ReadPktHdr);
+            return;
+        }
+        try self.sendGlobalRequestFailure(misshod);
+    }
+
     fn readTcpipOpen(rdr: *BufferReader) MisshodError!TcpipOpen {
         return .{
             .host = try rdr.readU32LenString(),
@@ -625,6 +760,96 @@ pub const Session = struct {
             self.active_channel_id = null;
             self.setSessionState(.ChannelActive);
             self.requestChannelOpenEvent(misshod, chan);
+        }
+    }
+
+    fn handleGlobalRequestPacket(self: *Self, rdr: *BufferReader, misshod: *MisshodServer) MisshodError!void {
+        const request_name = try rdr.readU32LenString();
+        const want_reply = try rdr.readBoolean();
+
+        if (std.mem.eql(u8, request_name, "tcpip-forward") or std.mem.eql(u8, request_name, "cancel-tcpip-forward")) {
+            if (self.pending_global_request != null) {
+                if (want_reply) {
+                    try self.sendGlobalRequestFailure(misshod);
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
+                return;
+            }
+
+            const bind_address = try rdr.readU32LenString();
+            const bind_port = try rdr.readU32();
+            if (bind_address.len > self.pending_global_request_bind_address.len) {
+                return IoError.tooBig;
+            }
+            @memcpy(self.pending_global_request_bind_address[0..bind_address.len], bind_address);
+            const stored_bind_address = self.pending_global_request_bind_address[0..bind_address.len];
+
+            const kind: PendingGlobalRequestKind = if (std.mem.eql(u8, request_name, "tcpip-forward"))
+                .TcpipForward
+            else
+                .CancelTcpipForward;
+
+            self.pending_global_request = .{
+                .kind = kind,
+                .want_reply = want_reply,
+                .bind_address = stored_bind_address,
+                .bind_port = bind_port,
+            };
+            const event = Misshod.TcpipForwardRequest{
+                .bind_address = stored_bind_address,
+                .bind_port = bind_port,
+            };
+            switch (kind) {
+                .TcpipForward => misshod.requestEvent(.{ .TcpipForward = event }, .Idle),
+                .CancelTcpipForward => misshod.requestEvent(.{ .CancelTcpipForward = event }, .Idle),
+            }
+            return;
+        }
+
+        if (want_reply) {
+            try self.sendGlobalRequestFailure(misshod);
+        } else {
+            self.setIoSessionState(.ReadPktHdr);
+        }
+    }
+
+    fn handleChannelOpenConfirmationPacket(self: *Self, rdr: *BufferReader, misshod: *MisshodServer) MisshodError!void {
+        const recipient = try rdr.readU32();
+        const sender = try rdr.readU32();
+        const peer_window = try rdr.readU32();
+        const max_packet_size = try rdr.readU32();
+        if (self.channel_table.findByLocalId(recipient)) |chan| {
+            chan.remote_id = sender;
+            chan.peer_window = peer_window;
+            chan.remote_max_packet_size = max_packet_size;
+            chan.state = .Data;
+            self.active_channel_id = chan.local_id;
+            self.setSessionState(.ChannelActive);
+            misshod.requestEvent(.{ .ChannelOpened = chan.local_id }, .Idle);
+        } else {
+            self.setIoSessionState(.ReadPktHdr);
+        }
+    }
+
+    fn handleChannelOpenFailurePacket(self: *Self, rdr: *BufferReader, misshod: *MisshodServer) MisshodError!void {
+        const recipient = try rdr.readU32();
+        const reason_code = try rdr.readU32();
+        const description = try rdr.readU32LenString();
+        _ = try rdr.readU32LenString(); // language tag
+
+        if (self.channel_table.findByLocalId(recipient)) |chan| {
+            const local_id = chan.local_id;
+            self.channel_table.freeChannel(local_id);
+            self.active_channel_id = null;
+            self.setSessionState(.ChannelActive);
+            misshod.requestEvent(.{ .ChannelOpenFailure = .{
+                .channel = local_id,
+                .reason_code = reason_code,
+                .description = description,
+            } }, .Idle);
+        } else {
+            self.setIoSessionState(.ReadPktHdr);
         }
     }
 
@@ -855,8 +1080,17 @@ pub const Session = struct {
                     return IoError.UnexpectedResponse; // why is client asking now?
                 }
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST) => {
+                try self.handleGlobalRequestPacket(&rdr, misshod);
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN) => {
                 try self.handleChannelOpenPacket(&rdr, misshod);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION) => {
+                try self.handleChannelOpenConfirmationPacket(&rdr, misshod);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE) => {
+                try self.handleChannelOpenFailurePacket(&rdr, misshod);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST) => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
@@ -1209,4 +1443,125 @@ test "handlePacket: unknown channel type writes open failure" {
     try std.testing.expectEqual(@as(u32, 99), try rdr.readU32());
     try std.testing.expectEqual(SshOpenFailureReason.UnknownChannelType, try rdr.readU32());
     try std.testing.expectEqualStrings("unknown channel type", try rdr.readU32LenString());
+}
+
+test "handlePacket: tcpip-forward emits event and accept writes allocated port" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [96]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST));
+    try pw.writeU32LenString("tcpip-forward");
+    try pw.writeBoolean(true);
+    try pw.writeU32LenString("127.0.0.1");
+    try pw.writeU32(0);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    @memset(&m.iobuf_rd, 0xaa);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .TcpipForward => |forward| {
+                try std.testing.expectEqualStrings("127.0.0.1", forward.bind_address);
+                try std.testing.expectEqual(@as(u32, 0), forward.bind_port);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    try m.acceptTcpipForward(2222);
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_SUCCESS), try rdr.readU8());
+    try std.testing.expectEqual(@as(u32, 2222), try rdr.readU32());
+}
+
+test "handlePacket: cancel-tcpip-forward emits event and reject writes failure" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [96]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST));
+    try pw.writeU32LenString("cancel-tcpip-forward");
+    try pw.writeBoolean(true);
+    try pw.writeU32LenString("127.0.0.1");
+    try pw.writeU32(2200);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .CancelTcpipForward => |cancel| {
+                try std.testing.expectEqualStrings("127.0.0.1", cancel.bind_address);
+                try std.testing.expectEqual(@as(u32, 2200), cancel.bind_port);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    try m.rejectCancelTcpipForward();
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_FAILURE), try rdr.readU8());
+}
+
+test "handlePacket: unknown global request with reply writes failure" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [64]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_GLOBAL_REQUEST));
+    try pw.writeU32LenString("unknown-request");
+    try pw.writeBoolean(true);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_REQUEST_FAILURE), try rdr.readU8());
+}
+
+test "openForwardedTcpipChannel writes forwarded-tcpip open payload" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.setSessionState(.Authenticated);
+
+    const channel_id = try m.openForwardedTcpipChannel("127.0.0.1", 2200, "203.0.113.10", 44444);
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(ChannelType.ForwardedTcpip, chan.channel_type);
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
+    try std.testing.expectEqualStrings("forwarded-tcpip", try rdr.readU32LenString());
+    try std.testing.expectEqual(channel_id, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 2200), try rdr.readU32());
+    try std.testing.expectEqualStrings("203.0.113.10", try rdr.readU32LenString());
+    try std.testing.expectEqual(@as(u32, 44444), try rdr.readU32());
 }


### PR DESCRIPTION
Closes #15.

## Summary
- add RFC 4254 global request message IDs and remote-forward request/response event types
- add client APIs for local forward channels, remote forward requests, and remote forward cancellation
- add server parsing/reply APIs for tcpip-forward and cancel-tcpip-forward plus server forwarded-tcpip opens
- add coverage for serialization, parsing, reply mapping, and forwarded-tcpip channel opens

## Tests
- zig test src/test.zig
- zig build
- zig build test --summary all