### PR TITLE
Support agent forwarding and additional key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It aims to be:
 
 # Building
 
-MiSSHod requires [Zig 0.14.0](https://ziglang.org/download/). 
+MiSSHod requires [Zig 0.16.0](https://ziglang.org/download/).
 
 ## Client
 
@@ -43,8 +43,10 @@ zig build test
 cd mssh
 zig build
 ./zig-out/bin/mssh
-./zig-out/bin/mssh <username@host> <port> [idfile]
+./zig-out/bin/mssh <username@host> <port> [-A|--agent-forward] [idfile]
 ```
+
+Use `-A` or `--agent-forward` to forward the local SSH agent from `SSH_AUTH_SOCK`.
 
 To run a test SSH server (dropbear) in docker
 
@@ -142,4 +144,3 @@ Tiny uses a weaker PRNG, a fixed buffer allocator and does no file I/O.
 MiSSHod was developed rapidly. The main aim was to get it working and learn something along the way. I don't know what's next, but hopefully you can learn something too by looking at a small SSH implementation.
 
 It's entirely undocumented and there aren't enough tests. The IO systems are a bit arcane, as I've tried wherever possible to avoid using excess RAM.
-

--- a/mssh/build.zig
+++ b/mssh/build.zig
@@ -33,7 +33,6 @@ pub fn build(b: *std.Build) void {
         .name = "mssh",
         .root_module = exe_mod,
     });
-    exe.addIncludePath(b.path("src/"));
 
     b.installArtifact(exe);
 

--- a/mssh/build.zig.zon
+++ b/mssh/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .mssh,
     .version = "0.0.1",
-    .fingerprint = 0xa2b4c6d8e0f1a3b5,
+    .fingerprint = 0xf9c4e594f592e3c3,
     .dependencies = .{
         .misshod = .{ .path = ".." },
     },

--- a/mssh/src/main.zig
+++ b/mssh/src/main.zig
@@ -4,34 +4,36 @@ const MisshodClient = @import("misshod").MisshodClient;
 
 // Turn off echo and read a password
 fn readPassphrase(password_buf: []u8) ![]u8 {
-    const in = std.io.getStdIn();
-    var buf = std.io.bufferedReader(in.reader());
-    var r = buf.reader();
+    const stdin_fd = std.c.STDIN_FILENO;
 
-    if (std.posix.isatty(in.handle)) {
+    if (std.c.isatty(stdin_fd) != 0) {
         // disable terminal echo
-        var termios = try std.posix.tcgetattr(in.handle);
+        var termios = try std.posix.tcgetattr(stdin_fd);
         termios.lflag.ECHO = false;
-        try std.posix.tcsetattr(in.handle, .FLUSH, termios);
-        const password = try r.readUntilDelimiterOrEof(password_buf, '\n');
+        try std.posix.tcsetattr(stdin_fd, .FLUSH, termios);
+        const password = try readLine(stdin_fd, password_buf);
         // re-enable echo
         termios.lflag.ECHO = true;
-        try std.posix.tcsetattr(in.handle, .FLUSH, termios);
-        try std.io.getStdOut().writer().print("\n", .{});
-        return password.?;
+        try std.posix.tcsetattr(stdin_fd, .FLUSH, termios);
+        try writeAllFd(std.c.STDOUT_FILENO, "\n");
+        return password;
     } else {
-        const password = try r.readUntilDelimiterOrEof(password_buf, '\n');
-        return password.?;
+        return try readLine(stdin_fd, password_buf);
     }
 }
 
 var original_termios: ?std.posix.termios = null;
+const MaxAgentSockets = 4;
+
+const AgentSocket = struct {
+    channel: u32,
+    fd: std.c.fd_t,
+};
 
 pub fn raw_mode_start() !void {
-    const stdin_reader = std.io.getStdIn();
-    const handle = stdin_reader.handle;
+    const handle = std.c.STDIN_FILENO;
 
-    if (std.posix.isatty(handle)) {
+    if (std.c.isatty(handle) != 0) {
         var termios = try std.posix.tcgetattr(handle);
         original_termios = termios;
 
@@ -54,32 +56,163 @@ pub fn raw_mode_start() !void {
 }
 
 pub fn raw_mode_stop() void {
-    const stdout_writer = std.io.getStdOut().writer();
-
-    const stdin_reader = std.io.getStdIn();
     if (original_termios) |termios| {
-        std.posix.tcsetattr(stdin_reader.handle, .FLUSH, termios) catch {};
+        std.posix.tcsetattr(std.c.STDIN_FILENO, .FLUSH, termios) catch {};
     }
-    _ = stdout_writer.print("\n", .{}) catch 0;
+    writeAllFd(std.c.STDOUT_FILENO, "\n") catch {};
 }
 
-pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+fn connectAgentSocket(path: []const u8) !std.c.fd_t {
+    const fd = std.c.socket(std.c.AF.UNIX, std.c.SOCK.STREAM, 0);
+    if (fd < 0) return error.SocketFailed;
+    errdefer _ = std.c.close(fd);
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    var addr: std.c.sockaddr.un = .{ .family = std.c.AF.UNIX, .path = .{0} ** 108 };
+    if (path.len >= addr.path.len) return error.NameTooLong;
+    @memcpy(addr.path[0..path.len], path);
+
+    const addr_len: std.c.socklen_t = @intCast(@offsetOf(std.c.sockaddr.un, "path") + path.len + 1);
+    if (std.c.connect(fd, @ptrCast(&addr), addr_len) != 0) return error.ConnectFailed;
+    return fd;
+}
+
+fn connectTcp(io: std.Io, host: []const u8, port: u16) !std.Io.net.Stream {
+    if (std.Io.net.IpAddress.parse(host, port)) |address| {
+        return try address.connect(io, .{ .mode = .stream });
+    } else |_| {}
+
+    const host_name = try std.Io.net.HostName.init(host);
+    var results_buffer: [16]std.Io.net.IpAddress.ConnectError!std.Io.net.Stream = undefined;
+    var results: std.Io.Queue(std.Io.net.IpAddress.ConnectError!std.Io.net.Stream) = .init(&results_buffer);
+    try std.Io.net.HostName.connectMany(host_name, io, port, &results, .{ .mode = .stream });
+
+    var last_err: ?anyerror = null;
+    while (true) {
+        const result = results.getOne(io) catch |err| switch (err) {
+            error.Closed => break,
+            else => |e| return e,
+        };
+        const stream = result catch |err| {
+            last_err = err;
+            continue;
+        };
+        return stream;
+    }
+    if (last_err) |err| return err;
+    return error.NoAddressReturned;
+}
+
+fn readFd(fd: std.c.fd_t, buf: []u8) !usize {
+    if (buf.len == 0) return 0;
+    const n = std.c.read(fd, buf.ptr, buf.len);
+    if (n < 0) return error.ReadFailed;
+    return @intCast(n);
+}
+
+fn readLine(fd: std.c.fd_t, buf: []u8) ![]u8 {
+    var n: usize = 0;
+    while (n < buf.len) {
+        const count = try readFd(fd, buf[n .. n + 1]);
+        if (count == 0) break;
+        if (buf[n] == '\n') break;
+        n += 1;
+    }
+    return buf[0..n];
+}
+
+fn writeFd(fd: std.c.fd_t, data: []const u8) !usize {
+    if (data.len == 0) return 0;
+    const n = std.c.write(fd, data.ptr, data.len);
+    if (n < 0) return error.WriteFailed;
+    return @intCast(n);
+}
+
+fn writeAllFd(fd: std.c.fd_t, data: []const u8) !void {
+    var off: usize = 0;
+    while (off < data.len) {
+        const n = std.c.write(fd, data[off..].ptr, data.len - off);
+        if (n <= 0) return error.WriteFailed;
+        off += @intCast(n);
+    }
+}
+
+fn addAgentSocket(sockets: *[MaxAgentSockets]?AgentSocket, channel: u32, path: []const u8) !void {
+    var free_slot: ?*?AgentSocket = null;
+    for (sockets) |*slot| {
+        if (slot.* == null) {
+            free_slot = slot;
+            break;
+        }
+    }
+    const slot = free_slot orelse return error.AgentSocketTableFull;
+    slot.* = .{ .channel = channel, .fd = try connectAgentSocket(path) };
+}
+
+fn findAgentSocket(sockets: *[MaxAgentSockets]?AgentSocket, channel: u32) ?*AgentSocket {
+    for (sockets) |*slot| {
+        if (slot.*) |*agent| {
+            if (agent.channel == channel) return agent;
+        }
+    }
+    return null;
+}
+
+fn closeAgentSocket(sockets: *[MaxAgentSockets]?AgentSocket, channel: u32) void {
+    for (sockets) |*slot| {
+        if (slot.*) |agent| {
+            if (agent.channel == channel) {
+                _ = std.c.close(agent.fd);
+                slot.* = null;
+                return;
+            }
+        }
+    }
+}
+
+fn closeAllAgentSockets(sockets: *[MaxAgentSockets]?AgentSocket) void {
+    for (sockets) |*slot| {
+        if (slot.*) |agent| {
+            _ = std.c.close(agent.fd);
+            slot.* = null;
+        }
+    }
+}
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(allocator);
 
     if (args.len < 3) {
-        std.debug.print("{s} <username@host> <port> [idfile]\n", .{args[0]});
+        std.debug.print("{s} <username@host> <port> [-A|--agent-forward] [idfile]\n", .{args[0]});
         std.process.exit(1);
     }
 
     const user_host = args[1];
     const port = try std.fmt.parseInt(u16, args[2], 10);
+    var agent_forwarding = false;
+    var idfile: ?[]const u8 = null;
     var host_opt: ?[]u8 = null;
     var user_opt: ?[]u8 = null;
+
+    var arg_i: usize = 3;
+    while (arg_i < args.len) : (arg_i += 1) {
+        if (std.mem.eql(u8, args[arg_i], "-A") or std.mem.eql(u8, args[arg_i], "--agent-forward")) {
+            agent_forwarding = true;
+        } else if (idfile == null) {
+            idfile = args[arg_i];
+        } else {
+            std.debug.print("{s} <username@host> <port> [-A|--agent-forward] [idfile]\n", .{args[0]});
+            std.process.exit(1);
+        }
+    }
+
+    const agent_sock_path = if (agent_forwarding)
+        init.environ_map.get("SSH_AUTH_SOCK") orelse {
+            std.debug.print("Agent forwarding requested but SSH_AUTH_SOCK is not set\n", .{});
+            std.process.exit(1);
+        }
+    else
+        null;
 
     var iter = std.mem.tokenizeSequence(u8, user_host, "@");
     var i: usize = 0;
@@ -97,28 +230,33 @@ pub fn main() !void {
 
     if (host_opt) |host| {
         if (user_opt) |user| {
-            var stream = std.net.tcpConnectToHost(allocator, host, port) catch |err| {
+            var stream = connectTcp(init.io, host, port) catch |err| {
                 switch (err) {
-                    posix.ConnectError.ConnectionRefused => std.debug.print("ConnectionRefused\n", .{}),
+                    error.ConnectionRefused => std.debug.print("ConnectionRefused\n", .{}),
                     else => std.debug.print("{any}\n", .{err}),
                 }
                 return;
             };
-            defer stream.close();
+            defer stream.close(init.io);
 
             // make a reasonable prng
             var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-            try posix.getrandom(&seed);
+            if (std.c.getrandom(&seed, seed.len, 0) != seed.len) return error.RandomSeedFailed;
             var prng = std.Random.DefaultCsprng.init(seed);
 
             var misshod = try MisshodClient.init(prng.random(), user, allocator);
-            defer misshod.deinit(allocator);
+            defer misshod.deinit();
+            if (agent_forwarding) {
+                try misshod.enableAgentForwarding();
+            }
 
             defer raw_mode_stop();
 
             var iobuf: [8]u8 = undefined; // could be any size
+            var agent_sockets: [MaxAgentSockets]?AgentSocket = .{null} ** MaxAgentSockets;
+            defer closeAllAgentSockets(&agent_sockets);
             var quit = false;
-            const stdin_reader = std.io.getStdIn();
+            const stdin_fd = std.c.STDIN_FILENO;
 
             outer: while (!quit) {
                 const ev = try misshod.getNextEvent();
@@ -131,8 +269,15 @@ pub fn main() !void {
                                 try raw_mode_start();
                             },
                             .RxData => |buf| {
-                                const stdout_writer = std.io.getStdOut().writer();
-                                try stdout_writer.print("{s}", .{buf});
+                                try writeAllFd(std.c.STDOUT_FILENO, buf);
+                                try misshod.clearEvent(eventCode);
+                            },
+                            .RxExtendedData => |ext| {
+                                _ = ext;
+                                try misshod.clearEvent(eventCode);
+                            },
+                            .Banner => |banner| {
+                                std.debug.print("{s}\n", .{banner});
                                 try misshod.clearEvent(eventCode);
                             },
                             .EndSession => |reason| {
@@ -143,16 +288,15 @@ pub fn main() !void {
                             .CheckHostKey => |keydata| {
                                 // make a decision about whether to accept host key
                                 // a real client could check ~/.ssh/known_hosts
-                                var fingerprint_buf: [512]u8 = undefined;
-                                std.debug.assert(std.base64.standard.Encoder.calcSize(keydata.?.len) <= fingerprint_buf.len);
-                                const fingerprint = std.base64.standard.Encoder.encode(&fingerprint_buf, keydata.?);
+                                var fingerprint_buf: [44]u8 = undefined;
+                                const fingerprint = keydata.fingerprintStr(&fingerprint_buf);
                                 std.debug.print("Auto accepting host key {s}\n", .{fingerprint});
                                 try misshod.clearEvent(eventCode);
                             },
                             .GetPrivateKey => {
-                                if (args.len >= 4) { // id file provided
-                                    const keydata_ascii = std.fs.cwd().readFileAlloc(allocator, args[3], 1024) catch {
-                                        std.debug.print("Failed to open idfile {s}\n", .{args[3]});
+                                if (idfile) |path| {
+                                    const keydata_ascii = std.Io.Dir.cwd().readFileAlloc(init.io, path, allocator, .limited(1024)) catch {
+                                        std.debug.print("Failed to open idfile {s}\n", .{path});
                                         std.process.exit(1);
                                     };
                                     try misshod.setPrivateKey(keydata_ascii);
@@ -170,6 +314,37 @@ pub fn main() !void {
                                 var password_buf: [128]u8 = undefined;
                                 std.debug.print("Password for auth: ", .{});
                                 try misshod.setAuthPassphrase(try readPassphrase(&password_buf));
+                                try misshod.clearEvent(eventCode);
+                            },
+                            .KeyboardInteractive => |prompt| {
+                                var password_buf: [128]u8 = undefined;
+                                std.debug.print("{s}", .{prompt.prompt});
+                                try misshod.session.setKeyboardInteractiveResponse(try readPassphrase(&password_buf));
+                                try misshod.clearEvent(eventCode);
+                            },
+                            .AgentChannelOpen => |channel| {
+                                try misshod.clearEvent(eventCode);
+                                addAgentSocket(&agent_sockets, channel, agent_sock_path.?) catch |err| {
+                                    std.debug.print("Failed to connect SSH_AUTH_SOCK for agent channel {d}: {any}\n", .{ channel, err });
+                                    try misshod.sendChannelEof(channel);
+                                };
+                            },
+                            .AgentData => |agent_data| {
+                                var close_channel = false;
+                                if (findAgentSocket(&agent_sockets, agent_data.channel)) |agent| {
+                                    writeAllFd(agent.fd, agent_data.data) catch |err| {
+                                        std.debug.print("Failed to write agent data for channel {d}: {any}\n", .{ agent_data.channel, err });
+                                        closeAgentSocket(&agent_sockets, agent_data.channel);
+                                        close_channel = true;
+                                    };
+                                } else {
+                                    close_channel = true;
+                                }
+                                try misshod.clearEvent(eventCode);
+                                if (close_channel) try misshod.sendChannelEof(agent_data.channel);
+                            },
+                            .AgentChannelClosed => |channel| {
+                                closeAgentSocket(&agent_sockets, channel);
                                 try misshod.clearEvent(eventCode);
                             },
                         }
@@ -191,27 +366,37 @@ pub fn main() !void {
                         if (consume_len > 0) pollevts |= std.posix.POLL.IN;
                         if (ev == .ReadyToProduce or ev == .ReadyToConsumeAndProduce) pollevts |= std.posix.POLL.OUT;
 
-                        var fds = [_]std.posix.pollfd{
-                            .{
-                                .fd = stream.handle,
-                                .events = pollevts,
-                                .revents = undefined,
-                            },
-                            .{
-                                .fd = stdin_reader.handle,
-                                .events = std.posix.POLL.IN,
-                                .revents = undefined,
-                            },
+                        var fds: [2 + MaxAgentSockets]std.posix.pollfd = undefined;
+                        fds[0] = .{
+                                .fd = stream.socket.handle,
+                            .events = pollevts,
+                            .revents = undefined,
                         };
+                        fds[1] = .{
+                            .fd = stdin_fd,
+                            .events = std.posix.POLL.IN,
+                            .revents = undefined,
+                        };
+                        var fd_count: usize = 2;
+                        for (agent_sockets) |agent_opt| {
+                            if (agent_opt) |agent| {
+                                fds[fd_count] = .{
+                                    .fd = agent.fd,
+                                    .events = std.posix.POLL.IN,
+                                    .revents = undefined,
+                                };
+                                fd_count += 1;
+                            }
+                        }
 
-                        const ready = std.posix.poll(&fds, 1000) catch 0;
+                        const ready = std.posix.poll(fds[0..fd_count], 1000) catch 0;
                         if (ready > 0) {
                             if (fds[0].revents & std.posix.POLL.IN > 0) { // socket is readable
                                 var bytes_to_read = consume_len;
                                 if (bytes_to_read > iobuf.len) {
                                     bytes_to_read = iobuf.len;
                                 }
-                                const nbytes = try stream.read(iobuf[0..bytes_to_read]);
+                                const nbytes = try readFd(stream.socket.handle, iobuf[0..bytes_to_read]);
                                 if (nbytes > 0) {
                                     try misshod.write(iobuf[0..nbytes]);
                                     continue :outer;
@@ -219,17 +404,41 @@ pub fn main() !void {
                             }
                             if (fds[0].revents & std.posix.POLL.OUT > 0) { // socket is writeable
                                 const towrite = try misshod.peek(4);
-                                const bytes_written = try stream.write(towrite);
+                                const bytes_written = try writeFd(stream.socket.handle, towrite);
                                 try misshod.consumed(bytes_written);
                                 continue :outer;
                             }
                             if (fds[1].revents & std.posix.POLL.IN > 0) { // keyboard data in
                                 const buf = try misshod.getChannelWriteBuffer(0);
                                 if (buf.len > 0) {
-                                    const count = stdin_reader.read(buf) catch 0;
+                                    const count = readFd(stdin_fd, buf) catch 0;
                                     if (count > 0) {
                                         try misshod.channelWriteComplete(0, count);
                                         continue :outer;
+                                    }
+                                }
+                            }
+                            var poll_idx: usize = 2;
+                            for (&agent_sockets) |*agent_slot| {
+                                if (agent_slot.*) |agent| {
+                                    const revents = fds[poll_idx].revents;
+                                    poll_idx += 1;
+                                    if (revents & (std.posix.POLL.IN | std.posix.POLL.HUP | std.posix.POLL.ERR) > 0) {
+                                        const buf = try misshod.getChannelWriteBuffer(agent.channel);
+                                        if (buf.len > 0) {
+                                            const count = readFd(agent.fd, buf) catch |err| {
+                                                std.debug.print("Failed to read SSH_AUTH_SOCK for channel {d}: {any}\n", .{ agent.channel, err });
+                                                closeAgentSocket(&agent_sockets, agent.channel);
+                                                try misshod.sendChannelEof(agent.channel);
+                                                continue;
+                                            };
+                                            if (count > 0) {
+                                                try misshod.channelWriteComplete(agent.channel, count);
+                                                continue :outer;
+                                            }
+                                            closeAgentSocket(&agent_sockets, agent.channel);
+                                            try misshod.sendChannelEof(agent.channel);
+                                        }
                                     }
                                 }
                             }

--- a/msshd/build.zig
+++ b/msshd/build.zig
@@ -33,7 +33,6 @@ pub fn build(b: *std.Build) void {
         .name = "msshd",
         .root_module = exe_mod,
     });
-    exe.addIncludePath(b.path("src/"));
 
     b.installArtifact(exe);
 

--- a/msshd/build.zig.zon
+++ b/msshd/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .msshd,
     .version = "0.0.1",
-    .fingerprint = 0xc3d5e7f9a1b2c4d6,
+    .fingerprint = 0x6f46d97445d0ffbe,
     .dependencies = .{
         .misshod = .{ .path = ".." },
     },

--- a/msshd/src/main.zig
+++ b/msshd/src/main.zig
@@ -1,21 +1,39 @@
 const std = @import("std");
-const posix = std.posix;
 const MisshodServer = @import("misshod").MisshodServer;
 
-pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+fn readFd(fd: std.c.fd_t, buf: []u8) !usize {
+    if (buf.len == 0) return 0;
+    const n = std.c.read(fd, buf.ptr, buf.len);
+    if (n < 0) return error.ReadFailed;
+    return @intCast(n);
+}
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+fn writeFd(fd: std.c.fd_t, data: []const u8) !usize {
+    if (data.len == 0) return 0;
+    const n = std.c.write(fd, data.ptr, data.len);
+    if (n < 0) return error.WriteFailed;
+    return @intCast(n);
+}
+
+fn writeAllFd(fd: std.c.fd_t, data: []const u8) !void {
+    var off: usize = 0;
+    while (off < data.len) {
+        const n = try writeFd(fd, data[off..]);
+        if (n == 0) return error.WriteFailed;
+        off += n;
+    }
+}
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(allocator);
 
     if (args.len < 3) {
         std.debug.print("{s} <port> <hostkey>\n", .{args[0]});
         std.process.exit(1);
     }
 
-    const hostkey_ascii = std.fs.cwd().readFileAlloc(allocator, args[2], 1024) catch {
+    const hostkey_ascii = std.Io.Dir.cwd().readFileAlloc(init.io, args[2], allocator, .limited(1024)) catch {
         std.debug.print("Failed to open hostkey file {s}\n", .{args[2]});
         std.process.exit(1);
     };
@@ -23,30 +41,30 @@ pub fn main() !void {
 
     const port = try std.fmt.parseInt(u16, args[1], 10);
 
-    const addr = std.net.Address.initIp4(.{0, 0, 0, 0}, port);
-    var server = try addr.listen(.{.reuse_port = true});
+    const addr: std.Io.net.IpAddress = .{ .ip4 = .unspecified(port) };
+    var server = try addr.listen(init.io, .{ .reuse_address = true });
+    defer server.deinit(init.io);
 
     std.debug.print("Server listening on port {d}\n", .{port});
 
     nextclient: while(true) {
-        const client = try server.accept();
-
-        var stream = client.stream;
-        defer stream.close();
+        var stream = try server.accept(init.io);
+        defer stream.close(init.io);
 
         // make a reasonable prng
         var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-        try posix.getrandom(&seed);
+        if (std.c.getrandom(&seed, seed.len, 0) != seed.len) return error.RandomSeedFailed;
         var prng = std.Random.DefaultCsprng.init(seed);
 
         var misshod = try MisshodServer.init(prng.random(), hostkey_ascii, allocator);
-        defer misshod.deinit(allocator);
+        defer misshod.deinit();
 
         var iobuf: [8]u8 = undefined; // could be any size
         var quit = false;
-        const pipe = try std.posix.pipe();
-        var pipeInFile:std.fs.File = std.fs.File{.handle = pipe[1]};
-        var pipeOutFile:std.fs.File = std.fs.File{.handle = pipe[0]};
+        var pipe: [2]std.c.fd_t = undefined;
+        if (std.c.pipe(&pipe) != 0) return error.PipeFailed;
+        defer _ = std.c.close(pipe[0]);
+        defer _ = std.c.close(pipe[1]);
 
         ioloop: while (!quit) {
             const ev = try misshod.getNextEvent();
@@ -58,10 +76,11 @@ pub fn main() !void {
                             try misshod.clearEvent(eventCode);
                         },
                         .RxData => |rxdata| {
-                            const stdout_writer = std.io.getStdOut().writer();
-                            try stdout_writer.print("{s}", .{rxdata.data});
+                            try writeAllFd(std.c.STDOUT_FILENO, rxdata.data);
 
-                            _ = try pipeInFile.writer().print("You said '{s}'\r\n", .{rxdata.data});
+                            var response_buf: [1024]u8 = undefined;
+                            const response = try std.fmt.bufPrint(&response_buf, "You said '{s}'\r\n", .{rxdata.data});
+                            try writeAllFd(pipe[1], response);
 
                             try misshod.clearEvent(eventCode);
                         },
@@ -81,11 +100,14 @@ pub fn main() !void {
                                     },
                                     .Pubkey => |pubkey| {
                                         var fingerprint_buf: [512]u8 = undefined;
-                                        std.debug.assert(std.base64.standard.Encoder.calcSize(pubkey.len) <= fingerprint_buf.len);
-                                        const fingerprint = std.base64.standard.Encoder.encode(&fingerprint_buf, pubkey);
-                                        std.debug.print("FIXME decide whether to allow username={s} pubkey={s}\n", .{credentials.username, fingerprint});
+                                        std.debug.assert(std.base64.standard.Encoder.calcSize(pubkey.blob.len) <= fingerprint_buf.len);
+                                        const fingerprint = std.base64.standard.Encoder.encode(&fingerprint_buf, pubkey.blob);
+                                        std.debug.print("FIXME decide whether to allow username={s} pubkey_alg={s} pubkey={s}\n", .{ credentials.username, pubkey.algorithm, fingerprint });
 
                                         try misshod.grantAccess(true);  // FIXME
+                                    },
+                                    .KeyboardInteractive => {
+                                        try misshod.grantAccess(false);
                                     },
                                 }
                             } else {
@@ -97,7 +119,7 @@ pub fn main() !void {
                             std.debug.print(".GetPubkeyForUser: {s}\n", .{username});
                             std.debug.assert(false);
                         },
-                        .ChannelRequest, .WindowChange, .Signal, .RxExtendedData => {
+                        .ChannelRequest, .WindowChange, .Signal, .RxExtendedData, .AgentChannelOpen, .AgentChannelClosed => {
                             try misshod.clearEvent(eventCode);
                         },
                     }
@@ -121,12 +143,12 @@ pub fn main() !void {
 
                     var fds = [_]std.posix.pollfd{
                         .{
-                            .fd = stream.handle,
+                            .fd = stream.socket.handle,
                             .events = pollevts,
                             .revents = undefined,
                         },
                         .{
-                            .fd = pipeOutFile.handle,
+                            .fd = pipe[0],
                             .events = std.posix.POLL.IN,
                             .revents = undefined,
                         },
@@ -139,7 +161,7 @@ pub fn main() !void {
                             if (bytes_to_read > iobuf.len) {
                                 bytes_to_read = iobuf.len;
                             }
-                            const nbytes = try stream.read(iobuf[0..bytes_to_read]);
+                            const nbytes = try readFd(stream.socket.handle, iobuf[0..bytes_to_read]);
                             if (nbytes > 0) {
                                 try misshod.write(iobuf[0..nbytes]);
                                 continue :ioloop;
@@ -149,14 +171,14 @@ pub fn main() !void {
                         }
                         if (fds[0].revents & std.posix.POLL.OUT > 0) { // socket is writeable
                             const towrite = try misshod.peek(4);
-                            const bytes_written = try stream.write(towrite);
+                            const bytes_written = try writeFd(stream.socket.handle, towrite);
                             try misshod.consumed(bytes_written);
                             continue :ioloop;
                         }
                         if (fds[1].revents & std.posix.POLL.IN > 0) { // data to be sent (from pipe)
                             const buf = try misshod.getChannelWriteBuffer(0);
                             if (buf.len > 0) {
-                                const count = pipeOutFile.reader().read(buf) catch 0;
+                                const count = readFd(pipe[0], buf) catch 0;
                                 if (count > 0) {
                                     try misshod.channelWriteComplete(0, count);
                                     continue :ioloop;

--- a/src/channel.zig
+++ b/src/channel.zig
@@ -5,6 +5,7 @@ pub const MaxChannels = 4;
 
 pub const ChannelState = enum {
     Open,
+    OpenSent,
     ConfirmWrite,
     RspWrite,
     Connected,
@@ -18,9 +19,15 @@ pub const ChannelState = enum {
     OpenFailureWrite,
 };
 
+pub const ChannelKind = enum {
+    Session,
+    AgentForward,
+};
+
 pub const Channel = struct {
     const Self = @This();
 
+    kind: ChannelKind,
     local_id: u32,
     remote_id: u32,
     peer_window: u32,
@@ -35,7 +42,12 @@ pub const Channel = struct {
     state: ChannelState,
 
     pub fn init(local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
+        return Self.initKind(.Session, local_id, remote_id, peer_window, remote_max_packet_size);
+    }
+
+    pub fn initKind(kind: ChannelKind, local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
         return Self{
+            .kind = kind,
             .local_id = local_id,
             .remote_id = remote_id,
             .peer_window = peer_window,
@@ -78,10 +90,14 @@ pub const ChannelTable = struct {
     last_serviced_slot: usize = 0,
 
     pub fn allocChannel(self: *Self, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) ?*Channel {
+        return self.allocChannelKind(.Session, remote_id, peer_window, remote_max_packet_size);
+    }
+
+    pub fn allocChannelKind(self: *Self, kind: ChannelKind, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) ?*Channel {
         const local_id = self.next_local_id;
         for (&self.channels) |*slot| {
             if (slot.* == null) {
-                slot.* = Channel.init(local_id, remote_id, peer_window, remote_max_packet_size);
+                slot.* = Channel.initKind(kind, local_id, remote_id, peer_window, remote_max_packet_size);
                 self.next_local_id +%= 1;
                 return &(slot.*.?);
             }
@@ -142,7 +158,7 @@ pub const ChannelTable = struct {
             .Connected => true,
             .Data => true,
             .DataTx, .DataTxComplete => true,
-            .DataRx, .Open, .Closed => false,
+            .DataRx, .Open, .OpenSent, .Closed => false,
         };
     }
 
@@ -218,6 +234,7 @@ test "allocChannel returns null when table is full" {
 
 test "Channel init sets default values" {
     const ch = Channel.init(0, 42, 65535, 32768);
+    try std.testing.expectEqual(ChannelKind.Session, ch.kind);
     try std.testing.expectEqual(@as(u32, 0), ch.local_id);
     try std.testing.expectEqual(@as(u32, 42), ch.remote_id);
     try std.testing.expectEqual(@as(u32, 65535), ch.peer_window);
@@ -229,6 +246,13 @@ test "Channel init sets default values" {
     try std.testing.expect(!ch.close_sent);
     try std.testing.expect(!ch.close_received);
     try std.testing.expectEqual(ChannelState.Open, ch.state);
+}
+
+test "allocChannelKind preserves channel kind" {
+    var table = ChannelTable{};
+    const ch = table.allocChannelKind(.AgentForward, 10, 32768, 32768).?;
+    try std.testing.expectEqual(ChannelKind.AgentForward, ch.kind);
+    try std.testing.expectEqual(@as(u32, 0), ch.local_id);
 }
 
 test "closing one channel does not affect another" {

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -11,8 +11,9 @@ const BufferError = @import("buffer.zig").BufferError;
 const BufferReader = @import("buffer.zig").BufferReader;
 const Hasher = @import("hasher.zig").Hasher;
 const AesCtr = @import("aesctr.zig").AesCtr;
-const decodePrivKey = @import("privkey.zig").decodePrivKey;
+const decodeOpenSshPrivateKey = @import("privkey.zig").decodeOpenSshPrivateKey;
 const PrivKeyError = @import("privkey.zig").PrivKeyError;
+const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
 const ChannelTable = @import("channel.zig").ChannelTable;
@@ -57,6 +58,7 @@ pub const Session = struct {
     shared_secret_k: [Protocol.kex_algo.shared_length]u8 = undefined, // K
     kex_hasher: Hasher(Protocol.hash_algo) = undefined, // for building H
     kex_hash_order: Protocol.KexHashOrder = .Init,
+    selected_hostkey_algorithm: ?Key.SignatureAlgorithm,
     session_id: [Protocol.hash_algo.digest_length]u8 = undefined,
     keydata: Protocol.KeyDataBi,
     username: []const u8,
@@ -65,14 +67,15 @@ pub const Session = struct {
     channel_table: ChannelTable,
     active_channel_id: ?u32,
     pending_window_change: ?[4]u32,
+    agent_forwarding_enabled: bool,
+    agent_forwarding_requested: bool,
     kbd_interactive_response: ?[]u8, // allocated
     is_rekeying: bool,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
-    privkey_blob: [Protocol.srv_hostkey_algo.SecretKey.encoded_length]u8 = undefined,
-    pubkey_blob: [Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
+    private_key: ?Key.PrivateKey,
 
     pub fn init(rand: std.Random, username: []const u8, allocator: std.mem.Allocator) !Self {
         return .{
@@ -84,12 +87,16 @@ pub const Session = struct {
             .encrypted = false,
             .keydata = Protocol.KeyDataBi.init(),
             .kex_hasher = Hasher(Protocol.hash_algo).init(), // for hashing H
+            .selected_hostkey_algorithm = null,
             .privkey_ascii = null,
             .privkey_passphrase = null,
             .auth_passphrase = null,
+            .private_key = null,
             .channel_table = ChannelTable{},
             .active_channel_id = null,
             .pending_window_change = null,
+            .agent_forwarding_enabled = false,
+            .agent_forwarding_requested = false,
             .kbd_interactive_response = null,
             .is_rekeying = false,
         };
@@ -107,8 +114,10 @@ pub const Session = struct {
         }
         std.crypto.secureZero(u8, &self.shared_secret_k);
         std.crypto.secureZero(u8, &self.session_id);
-        std.crypto.secureZero(u8, &self.privkey_blob);
-        std.crypto.secureZero(u8, &self.pubkey_blob);
+        if (self.private_key) |*key| {
+            key.clear();
+            self.private_key = null;
+        }
         self.channel_table.secureZeroAll();
         self.keydata.clear();
     }
@@ -147,7 +156,7 @@ pub const Session = struct {
                 try pkt.writeBytes(&cookie);
 
                 try pkt.writeU32LenString(Protocol.kex_algo_name); // kex
-                try pkt.writeU32LenString(Protocol.srv_hostkey_algo_name); // hostkey verification
+                try pkt.writeU32LenString(Key.client_hostkey_algorithms); // hostkey verification
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc c2s
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc s2c
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac c2s
@@ -259,7 +268,11 @@ pub const Session = struct {
             .PubkeyAuthDecodeKeyPasswordless => {
                 if (self.privkey_ascii) |privkey_ascii| { // have private key
                     // attempt passwordless
-                    decodePrivKey(privkey_ascii, null, &self.privkey_blob, &self.pubkey_blob) catch |err| {
+                    if (self.private_key) |*old| {
+                        old.clear();
+                        self.private_key = null;
+                    }
+                    self.private_key = decodeOpenSshPrivateKey(privkey_ascii, null) catch |err| {
                         // free privkey_ascii
                         switch (err) {
                             PrivKeyError.InvalidKeyDecrypt => {
@@ -289,22 +302,20 @@ pub const Session = struct {
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-5.1
                 //https://datatracker.ietf.org/doc/html/rfc4252#section-8
 
-                const secretkey = try Protocol.srv_hostkey_algo.SecretKey.fromBytes(self.privkey_blob);
-                const keypair = try Protocol.srv_hostkey_algo.KeyPair.fromSecretKey(secretkey);
+                const private_key = if (self.private_key) |*key| key else return IoError.UnexpectedResponse;
+                const sig_alg = private_key.defaultSignatureAlgorithm();
 
-                var backing_pubkey_buf: [256]u8 = undefined;
-                var typed_pubkey_buf = BufferWriter.init(&backing_pubkey_buf, 0);
-                try typed_pubkey_buf.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try typed_pubkey_buf.writeU32LenString(&keypair.public_key.bytes);
+                var pubkey_blob: Key.Blob = .{};
+                const typed_pubkey = try private_key.publicBlob(&pubkey_blob);
 
                 try pkt.writeU32LenString(self.username);
                 try pkt.writeU32LenString("ssh-connection");
                 try pkt.writeU32LenString("publickey");
                 try pkt.writeBoolean(true);
-                try pkt.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try pkt.writeU32LenString(typed_pubkey_buf.active());
+                try pkt.writeU32LenString(sig_alg.name());
+                try pkt.writeU32LenString(typed_pubkey);
 
-                var backing_sigbuffer_buf: [512]u8 = undefined;
+                var backing_sigbuffer_buf: [1024]u8 = undefined;
                 var sigbuffer = BufferWriter.init(&backing_sigbuffer_buf, 0);
                 try sigbuffer.writeU32LenString(&self.session_id);
                 try sigbuffer.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
@@ -312,19 +323,13 @@ pub const Session = struct {
                 try sigbuffer.writeU32LenString("ssh-connection");
                 try sigbuffer.writeU32LenString("publickey");
                 try sigbuffer.writeBoolean(true);
-                try sigbuffer.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try sigbuffer.writeU32LenString(typed_pubkey_buf.active());
+                try sigbuffer.writeU32LenString(sig_alg.name());
+                try sigbuffer.writeU32LenString(typed_pubkey);
 
-                // gen signature
-                const sig = try keypair.sign(sigbuffer.active(), null);
-                const sigbytes = sig.toBytes();
-                TRACEDUMP(.Debug, "sigbytes", .{}, &sigbytes);
-
-                var backing_typed_sig_buf: [256]u8 = undefined;
-                var typed_sig_buf = BufferWriter.init(&backing_typed_sig_buf, 0);
-                try typed_sig_buf.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try typed_sig_buf.writeU32LenString(&sigbytes);
-                try pkt.writeU32LenString(typed_sig_buf.active());
+                var typed_sig: Key.SignatureBlob = .{};
+                const sig = try private_key.sign(sig_alg, sigbuffer.active(), &typed_sig);
+                TRACEDUMP(.Debug, "sigbytes", .{}, sig);
+                try pkt.writeU32LenString(sig);
 
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.setSessionState(.AuthRsp);
@@ -332,7 +337,11 @@ pub const Session = struct {
             .PubkeyAuthDecodeKeyPassword => {
                 // attempt decode with passphrase
                 // if this fails, drop to password auth
-                decodePrivKey(self.privkey_ascii.?, self.privkey_passphrase, &self.privkey_blob, &self.pubkey_blob) catch {
+                if (self.private_key) |*old| {
+                    old.clear();
+                    self.private_key = null;
+                }
+                self.private_key = decodeOpenSshPrivateKey(self.privkey_ascii.?, self.privkey_passphrase) catch {
                     if (self.auth_passphrase == null) {
                         misshod.requestEvent(.GetAuthPassphrase, .Idle);
                     }
@@ -386,13 +395,13 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .ChannelOpenReq => {
-                const chan = self.channel_table.allocChannel(0, 0, 0) orelse {
+                const chan = self.channel_table.allocChannelKind(.Session, 0, 0, 0) orelse {
                     return IoError.UnexpectedResponse;
                 };
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
-                try pkt.writeU32LenString("session"); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
+                try pkt.writeU32LenString(Protocol.channel_type_session); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
                 try pkt.writeU32(chan.local_id); // sender channel
                 try pkt.writeU32(Protocol.MaxPayload); // initial window size
                 try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
@@ -425,6 +434,10 @@ pub const Session = struct {
 
         switch (chan.state) {
             .Open => {
+                if (chan.kind != .Session) {
+                    chan.state = .Data;
+                    return;
+                }
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
                 try pkt.writeU32(chan.remote_id);
@@ -485,18 +498,27 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
                 try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32LenString("shell");
-                try pkt.writeBoolean(false); // want reply
+                if (self.agent_forwarding_enabled and !self.agent_forwarding_requested) {
+                    try pkt.writeU32LenString(Protocol.channel_request_auth_agent);
+                    try pkt.writeBoolean(false); // want reply
+                    self.agent_forwarding_requested = true;
+                } else {
+                    try pkt.writeU32LenString("shell");
+                    try pkt.writeBoolean(false); // want reply
+                    chan.state = .Connected;
+                }
 
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                chan.state = .Connected;
             },
             .Connected => {
-                misshod.requestEvent(.Connected, .Idle);
+                switch (chan.kind) {
+                    .Session => misshod.requestEvent(.Connected, .Idle),
+                    .AgentForward => misshod.requestEvent(.{ .AgentChannelOpen = chan.local_id }, .Idle),
+                }
                 chan.state = .Data;
             },
             .Data => {
-                if (self.pending_window_change != null) {
+                if (chan.kind == .Session and self.pending_window_change != null) {
                     // Send window-change directly
                     const wc = self.pending_window_change.?;
                     self.pending_window_change = null;
@@ -575,15 +597,28 @@ pub const Session = struct {
             },
             .Closed => {
                 const local_id = chan.local_id;
+                const kind = chan.kind;
                 self.channel_table.freeChannel(local_id);
                 self.active_channel_id = null;
-                if (self.channel_table.activeCount() == 0) {
+                if (kind == .AgentForward) {
+                    misshod.requestEvent(.{ .AgentChannelClosed = local_id }, .Idle);
+                } else if (self.channel_table.activeCount() == 0) {
                     misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
                 } else {
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
-            .ConfirmWrite, .OpenFailureWrite => {
+            .ConfirmWrite => {
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+                try pkt.writeU32(chan.remote_id);
+                try pkt.writeU32(chan.local_id);
+                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxPayload);
+                chan.state = .Connected;
+                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+            },
+            .OpenSent, .OpenFailureWrite => {
                 self.setIoSessionState(.ReadPktHdr);
             },
         }
@@ -664,6 +699,15 @@ pub const Session = struct {
         }
     }
 
+    pub fn enableAgentForwarding(self: *Self) MisshodError!void {
+        switch (self.sessionState) {
+            .ChannelActive => return IoError.UnexpectedResponse,
+            else => {
+                self.agent_forwarding_enabled = true;
+            },
+        }
+    }
+
     pub fn setKeyboardInteractiveResponse(self: *Self, response: []const u8) MisshodError!void {
         self.clearAndFreeOptional(&self.kbd_interactive_response);
         self.kbd_interactive_response = try self.allocator.dupe(u8, response);
@@ -708,6 +752,16 @@ pub const Session = struct {
         return vers;
     }
 
+    fn sendChannelOpenFailure(self: *Self, misshod: *MisshodClient, remote_id: u32, reason_code: u32, description: []const u8) MisshodError!void {
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+        try pkt.writeU32(remote_id);
+        try pkt.writeU32(reason_code);
+        try pkt.writeU32LenString(description);
+        try pkt.writeU32LenString("");
+        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, &self.keydata.c2s, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
+    }
+
     pub fn handlePacket(self: *Self, buf: []const u8, misshod: *MisshodClient) MisshodError!void {
         var rdr = try misshod.getRecvBuffer(misshod.iobuf_rd[0..buf.len], &self.keydata.s2c);
 
@@ -745,10 +799,17 @@ pub const Session = struct {
                 const cookie = try rdr.readBytes(16);
                 TRACEDUMP(.Debug, "cookie", .{}, cookie);
 
-                // RFC 4253 §7.1 - validate peer supports our algorithms
+                const kex_namelist = try rdr.readU32LenString();
+                if (!nameListContains(kex_namelist, Protocol.kex_algo_name)) {
+                    TRACE(.Info, "No mutual algorithm for kex_algorithms: peer offers '{s}', we need '{s}'", .{ kex_namelist, Protocol.kex_algo_name });
+                    return IoError.AlgorithmNegotiationFailed;
+                }
+                const hostkey_namelist = try rdr.readU32LenString();
+                self.selected_hostkey_algorithm = Key.selectHostKeyAlgorithm(hostkey_namelist, null) orelse {
+                    TRACE(.Info, "No mutual algorithm for server_host_key_algorithms: peer offers '{s}', we need '{s}'", .{ hostkey_namelist, Key.client_hostkey_algorithms });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
                 const required_algos = [_]struct { name: []const u8, required: []const u8 }{
-                    .{ .name = "kex_algorithms", .required = Protocol.kex_algo_name },
-                    .{ .name = "server_host_key_algorithms", .required = Protocol.srv_hostkey_algo_name },
                     .{ .name = "encryption_algorithms_client_to_server", .required = Protocol.enc_algo_name },
                     .{ .name = "encryption_algorithms_server_to_client", .required = Protocol.enc_algo_name },
                     .{ .name = "mac_algorithms_client_to_server", .required = Protocol.mac_algo_name },
@@ -819,16 +880,12 @@ pub const Session = struct {
 
                     @memcpy(&self.session_id, &kexhash); // store as session_id
 
-                    // verify server's signature on the hash
-                    var nb = util.NamedBlob.init(self.hostkey_ks.?);
-                    const rawpubkey = try nb.getBlob();
-                    const pubkey = try Protocol.srv_hostkey_algo.PublicKey.fromBytes(rawpubkey[0..Protocol.srv_hostkey_algo.PublicKey.encoded_length].*);
-
-                    nb = util.NamedBlob.init(sig_exch_hash);
-                    const rawsig = try nb.getBlob();
-                    const sig = Protocol.srv_hostkey_algo.Signature.fromBytes(rawsig[0..Protocol.srv_hostkey_algo.Signature.encoded_length].*);
-
-                    try sig.verify(&kexhash, pubkey);
+                    const selected_sig_alg = self.selected_hostkey_algorithm orelse return IoError.UnexpectedResponse;
+                    const sig_alg = try Key.signatureAlgorithm(sig_exch_hash);
+                    if (sig_alg != selected_sig_alg) return IoError.AlgorithmNegotiationFailed;
+                    const pubkey = try Key.parsePublicKeyBlob(self.hostkey_ks.?);
+                    if (pubkey.algorithm() != selected_sig_alg.keyAlgorithm()) return IoError.AlgorithmNegotiationFailed;
+                    try Key.verifySignature(pubkey, sig_exch_hash, &kexhash);
 
                     // generate keys
                     try self.keydata.genKeys(kexhash, self.shared_secret_k, self.session_id);
@@ -892,6 +949,28 @@ pub const Session = struct {
                     self.setIoSessionState(.Idle);
                 }
             },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN) => {
+                // OpenSSH agent forwarding: the server opens an agent channel back to the client.
+                const chantype = try rdr.readU32LenString();
+                const remote_id = try rdr.readU32();
+                const peer_window = try rdr.readU32();
+                const max_packet_size = try rdr.readU32();
+
+                if (!self.agent_forwarding_enabled or !Protocol.isAgentChannelType(chantype)) {
+                    try self.sendChannelOpenFailure(misshod, remote_id, 1, "unsupported channel type");
+                    return;
+                }
+
+                if (self.channel_table.allocChannelKind(.AgentForward, remote_id, peer_window, max_packet_size)) |chan| {
+                    chan.state = .ConfirmWrite;
+                    self.active_channel_id = chan.local_id;
+                    self.setSessionState(.ChannelActive);
+                    self.setIoSessionState(.Idle);
+                } else {
+                    try self.sendChannelOpenFailure(misshod, remote_id, 4, "too many channels");
+                    return;
+                }
+            },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION) => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
                 const recipient = try rdr.readU32(); // recipient channel
@@ -926,7 +1005,10 @@ pub const Session = struct {
                 }
                 const s = try rdr.readU32LenString();
                 chan.consumeLocalWindow(@intCast(s.len));
-                misshod.requestEvent(.{ .RxData = s }, .Idle);
+                switch (chan.kind) {
+                    .Session => misshod.requestEvent(.{ .RxData = s }, .Idle),
+                    .AgentForward => misshod.requestEvent(.{ .AgentData = .{ .channel = chan.local_id, .data = s } }, .Idle),
+                }
                 chan.state = .Data;
                 self.active_channel_id = chan.local_id;
                 self.setSessionState(.ChannelActive);
@@ -979,12 +1061,19 @@ pub const Session = struct {
                 };
                 chan.close_received = true;
                 if (chan.close_sent) {
-                    self.channel_table.freeChannel(chan.local_id);
-                    self.active_channel_id = null;
-                    if (self.channel_table.activeCount() == 0) {
-                        misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                    if (chan.kind == .AgentForward) {
+                        self.active_channel_id = chan.local_id;
+                        chan.state = .Closed;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
                     } else {
-                        self.setIoSessionState(.ReadPktHdr);
+                        self.channel_table.freeChannel(chan.local_id);
+                        self.active_channel_id = null;
+                        if (self.channel_table.activeCount() == 0) {
+                            misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                        } else {
+                            self.setIoSessionState(.ReadPktHdr);
+                        }
                     }
                 } else {
                     self.active_channel_id = chan.local_id;
@@ -1145,6 +1234,87 @@ test "handlePacket: SSH_MSG_DISCONNECT surfaces reason code" {
     }
 }
 
+test "handlePacket: auth-agent channel open requires opt-in" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString(Protocol.channel_type_auth_agent_openssh);
+    try pw.writeU32(42);
+    try pw.writeU32(32768);
+    try pw.writeU32(32768);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try std.testing.expectEqual(@as(u32, 0), m.session.channel_table.activeCount());
+    try std.testing.expect(m.iostate_wr != .Idle);
+}
+
+test "handlePacket: auth-agent channel open creates agent channel when enabled" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    try m.session.enableAgentForwarding();
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+    try pw.writeU32LenString(Protocol.channel_type_auth_agent);
+    try pw.writeU32(42);
+    try pw.writeU32(32768);
+    try pw.writeU32(32768);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const chan = m.session.channel_table.findByLocalId(0).?;
+    try std.testing.expectEqual(.AgentForward, chan.kind);
+    try std.testing.expectEqual(@as(u32, 42), chan.remote_id);
+    try std.testing.expectEqual(ChannelState.ConfirmWrite, chan.state);
+    try std.testing.expectEqual(SessionState.ChannelActive, m.session.sessionState);
+}
+
+test "handlePacket: agent channel data surfaces AgentData event" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannelKind(.AgentForward, 42, 32768, 32768).?;
+    chan.state = .DataRx;
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
+    try pw.writeU32(chan.local_id);
+    try pw.writeU32LenString("agent-bytes");
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .AgentData => |data| {
+                try std.testing.expectEqual(chan.local_id, data.channel);
+                try std.testing.expectEqualStrings("agent-bytes", data.data);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
 test "handlePacket: SSH_MSG_CHANNEL_CLOSE when not yet sent triggers close reply" {
     var prng = std.Random.DefaultPrng.init(42);
     var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
@@ -1233,8 +1403,6 @@ test "client session deinit zeros sensitive fields" {
     try session.setAuthPassphrase("my-auth-password");
     @memset(&session.shared_secret_k, 0xAA);
     @memset(&session.session_id, 0xBB);
-    @memset(&session.privkey_blob, 0xCC);
-    @memset(&session.pubkey_blob, 0xDD);
 
     session.deinit();
 
@@ -1243,8 +1411,7 @@ test "client session deinit zeros sensitive fields" {
     try std.testing.expect(session.auth_passphrase == null);
     for (session.shared_secret_k) |b| try std.testing.expectEqual(@as(u8, 0), b);
     for (session.session_id) |b| try std.testing.expectEqual(@as(u8, 0), b);
-    for (session.privkey_blob) |b| try std.testing.expectEqual(@as(u8, 0), b);
-    for (session.pubkey_blob) |b| try std.testing.expectEqual(@as(u8, 0), b);
+    try std.testing.expect(session.private_key == null);
 }
 
 test "setPrivateKey replaces previous key" {

--- a/src/key.zig
+++ b/src/key.zig
@@ -1,0 +1,524 @@
+const std = @import("std");
+const BufferReader = @import("buffer.zig").BufferReader;
+const BufferWriter = @import("buffer.zig").BufferWriter;
+const BufferError = @import("buffer.zig").BufferError;
+
+const Ed25519 = std.crypto.sign.Ed25519;
+const EcdsaP256 = std.crypto.sign.ecdsa.EcdsaP256Sha256;
+
+pub const ed25519_name = "ssh-ed25519";
+pub const ecdsa_p256_name = "ecdsa-sha2-nistp256";
+pub const ecdsa_p256_curve_name = "nistp256";
+pub const rsa_key_name = "ssh-rsa";
+pub const rsa_sha2_256_name = "rsa-sha2-256";
+pub const rsa_sha2_512_name = "rsa-sha2-512";
+
+pub const client_hostkey_algorithms = rsa_sha2_512_name ++ "," ++
+    rsa_sha2_256_name ++ "," ++
+    ecdsa_p256_name ++ "," ++
+    ed25519_name;
+
+pub const MaxRsaBits = 4096;
+pub const MaxRsaBytes = MaxRsaBits / 8;
+pub const MaxPublicKeyBlobLen = 4 + ecdsa_p256_name.len + 4 + ecdsa_p256_curve_name.len + 4 + EcdsaP256.PublicKey.uncompressed_sec1_encoded_length;
+pub const MaxRsaPublicKeyBlobLen = 4 + rsa_key_name.len + 4 + 8 + 4 + MaxRsaBytes + 1;
+pub const MaxKeyBlobLen = @max(MaxPublicKeyBlobLen, MaxRsaPublicKeyBlobLen);
+pub const MaxSignatureBlobLen = 4 + rsa_sha2_512_name.len + 4 + MaxRsaBytes;
+
+pub const KeyError = error{
+    UnsupportedKeyAlgorithm,
+    InvalidKeyBlob,
+    InvalidSignature,
+    SignatureAlgorithmMismatch,
+    SigningFailed,
+    RsaComponentTooLarge,
+    RsaKeyTooSmall,
+} || BufferError;
+
+pub const KeyAlgorithm = enum {
+    Ed25519,
+    EcdsaP256,
+    Rsa,
+};
+
+pub const SignatureAlgorithm = enum {
+    Ed25519,
+    EcdsaP256Sha256,
+    RsaSha256,
+    RsaSha512,
+
+    pub fn fromName(alg_name: []const u8) ?SignatureAlgorithm {
+        if (std.mem.eql(u8, alg_name, ed25519_name)) return .Ed25519;
+        if (std.mem.eql(u8, alg_name, ecdsa_p256_name)) return .EcdsaP256Sha256;
+        if (std.mem.eql(u8, alg_name, rsa_sha2_256_name)) return .RsaSha256;
+        if (std.mem.eql(u8, alg_name, rsa_sha2_512_name)) return .RsaSha512;
+        return null;
+    }
+
+    pub fn name(self: SignatureAlgorithm) []const u8 {
+        return switch (self) {
+            .Ed25519 => ed25519_name,
+            .EcdsaP256Sha256 => ecdsa_p256_name,
+            .RsaSha256 => rsa_sha2_256_name,
+            .RsaSha512 => rsa_sha2_512_name,
+        };
+    }
+
+    pub fn keyAlgorithm(self: SignatureAlgorithm) KeyAlgorithm {
+        return switch (self) {
+            .Ed25519 => .Ed25519,
+            .EcdsaP256Sha256 => .EcdsaP256,
+            .RsaSha256, .RsaSha512 => .Rsa,
+        };
+    }
+};
+
+pub const Blob = struct {
+    buf: [MaxKeyBlobLen]u8 = undefined,
+    len: usize = 0,
+
+    pub fn set(self: *Blob, bytes: []const u8) KeyError!void {
+        if (bytes.len > self.buf.len) return error.InvalidKeyBlob;
+        @memcpy(self.buf[0..bytes.len], bytes);
+        self.len = bytes.len;
+    }
+
+    pub fn slice(self: *const Blob) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    pub fn clear(self: *Blob) void {
+        std.crypto.secureZero(u8, &self.buf);
+        self.len = 0;
+    }
+};
+
+pub const SignatureBlob = struct {
+    buf: [MaxSignatureBlobLen]u8 = undefined,
+    len: usize = 0,
+
+    pub fn slice(self: *const SignatureBlob) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    pub fn clear(self: *SignatureBlob) void {
+        std.crypto.secureZero(u8, &self.buf);
+        self.len = 0;
+    }
+};
+
+pub const RsaComponent = struct {
+    bytes: [MaxRsaBytes]u8 = .{0} ** MaxRsaBytes,
+    len: usize = 0,
+
+    pub fn set(self: *RsaComponent, bytes: []const u8) KeyError!void {
+        const trimmed = trimMpint(bytes);
+        if (trimmed.len > MaxRsaBytes) return error.RsaComponentTooLarge;
+        std.crypto.secureZero(u8, &self.bytes);
+        @memcpy(self.bytes[0..trimmed.len], trimmed);
+        self.len = trimmed.len;
+    }
+
+    pub fn slice(self: *const RsaComponent) []const u8 {
+        return self.bytes[0..self.len];
+    }
+
+    pub fn clear(self: *RsaComponent) void {
+        std.crypto.secureZero(u8, &self.bytes);
+        self.len = 0;
+    }
+};
+
+pub const RsaPrivateKey = struct {
+    n: RsaComponent = .{},
+    e: RsaComponent = .{},
+    d: RsaComponent = .{},
+    iqmp: RsaComponent = .{},
+    p: RsaComponent = .{},
+    q: RsaComponent = .{},
+
+    pub fn clear(self: *RsaPrivateKey) void {
+        self.n.clear();
+        self.e.clear();
+        self.d.clear();
+        self.iqmp.clear();
+        self.p.clear();
+        self.q.clear();
+    }
+};
+
+pub const PublicKey = union(KeyAlgorithm) {
+    Ed25519: [Ed25519.PublicKey.encoded_length]u8,
+    EcdsaP256: [EcdsaP256.PublicKey.uncompressed_sec1_encoded_length]u8,
+    Rsa: struct {
+        n: RsaComponent,
+        e: RsaComponent,
+    },
+
+    pub fn algorithm(self: PublicKey) KeyAlgorithm {
+        return switch (self) {
+            .Ed25519 => .Ed25519,
+            .EcdsaP256 => .EcdsaP256,
+            .Rsa => .Rsa,
+        };
+    }
+};
+
+pub const PrivateKey = union(KeyAlgorithm) {
+    Ed25519: struct {
+        public: [Ed25519.PublicKey.encoded_length]u8,
+        secret: [Ed25519.SecretKey.encoded_length]u8,
+    },
+    EcdsaP256: struct {
+        public_sec1: [EcdsaP256.PublicKey.uncompressed_sec1_encoded_length]u8,
+        secret_scalar: [EcdsaP256.SecretKey.encoded_length]u8,
+    },
+    Rsa: RsaPrivateKey,
+
+    pub fn algorithm(self: PrivateKey) KeyAlgorithm {
+        return switch (self) {
+            .Ed25519 => .Ed25519,
+            .EcdsaP256 => .EcdsaP256,
+            .Rsa => .Rsa,
+        };
+    }
+
+    pub fn defaultSignatureAlgorithm(self: *const PrivateKey) SignatureAlgorithm {
+        return switch (self.*) {
+            .Ed25519 => .Ed25519,
+            .EcdsaP256 => .EcdsaP256Sha256,
+            .Rsa => .RsaSha512,
+        };
+    }
+
+    pub fn hostKeyAlgorithms(self: *const PrivateKey) []const u8 {
+        return switch (self.*) {
+            .Ed25519 => ed25519_name,
+            .EcdsaP256 => ecdsa_p256_name,
+            .Rsa => rsa_sha2_512_name ++ "," ++ rsa_sha2_256_name,
+        };
+    }
+
+    pub fn supportsSignatureAlgorithm(self: *const PrivateKey, alg: SignatureAlgorithm) bool {
+        return self.algorithm() == alg.keyAlgorithm();
+    }
+
+    pub fn publicBlob(self: *const PrivateKey, out: *Blob) KeyError![]const u8 {
+        var w = BufferWriter.init(&out.buf, 0);
+        switch (self.*) {
+            .Ed25519 => |key| {
+                try w.writeU32LenString(ed25519_name);
+                try w.writeU32LenString(&key.public);
+            },
+            .EcdsaP256 => |key| {
+                try w.writeU32LenString(ecdsa_p256_name);
+                try w.writeU32LenString(ecdsa_p256_curve_name);
+                try w.writeU32LenString(&key.public_sec1);
+            },
+            .Rsa => |key| {
+                try w.writeU32LenString(rsa_key_name);
+                try writeMpint(&w, key.e.slice());
+                try writeMpint(&w, key.n.slice());
+            },
+        }
+        out.len = w.active().len;
+        return out.slice();
+    }
+
+    pub fn publicKey(self: *const PrivateKey) PublicKey {
+        return switch (self.*) {
+            .Ed25519 => |key| .{ .Ed25519 = key.public },
+            .EcdsaP256 => |key| .{ .EcdsaP256 = key.public_sec1 },
+            .Rsa => |key| .{ .Rsa = .{ .n = key.n, .e = key.e } },
+        };
+    }
+
+    pub fn sign(self: *const PrivateKey, alg: SignatureAlgorithm, msg: []const u8, out: *SignatureBlob) KeyError![]const u8 {
+        if (!self.supportsSignatureAlgorithm(alg)) return error.SignatureAlgorithmMismatch;
+
+        var signature_payload_buf: [MaxRsaBytes]u8 = undefined;
+        var signature_payload: []const u8 = undefined;
+
+        switch (self.*) {
+            .Ed25519 => |key| {
+                const secret = Ed25519.SecretKey.fromBytes(key.secret) catch return error.InvalidKeyBlob;
+                const keypair = Ed25519.KeyPair.fromSecretKey(secret) catch return error.InvalidKeyBlob;
+                const sig = keypair.sign(msg, null) catch return error.SigningFailed;
+                const sigbytes = sig.toBytes();
+                @memcpy(signature_payload_buf[0..sigbytes.len], &sigbytes);
+                signature_payload = signature_payload_buf[0..sigbytes.len];
+            },
+            .EcdsaP256 => |key| {
+                const secret = EcdsaP256.SecretKey.fromBytes(key.secret_scalar) catch return error.InvalidKeyBlob;
+                const keypair = EcdsaP256.KeyPair.fromSecretKey(secret) catch return error.InvalidKeyBlob;
+                const sig = keypair.sign(msg, null) catch return error.SigningFailed;
+                const sigbytes = sig.toBytes();
+                var inner = BufferWriter.init(&signature_payload_buf, 0);
+                try writeMpint(&inner, sigbytes[0 .. sigbytes.len / 2]);
+                try writeMpint(&inner, sigbytes[sigbytes.len / 2 ..]);
+                signature_payload = inner.active();
+            },
+            .Rsa => |key| {
+                signature_payload = switch (alg) {
+                    .RsaSha256 => try rsaSign(std.crypto.hash.sha2.Sha256, key, msg, &signature_payload_buf),
+                    .RsaSha512 => try rsaSign(std.crypto.hash.sha2.Sha512, key, msg, &signature_payload_buf),
+                    else => return error.SignatureAlgorithmMismatch,
+                };
+            },
+        }
+
+        var outer = BufferWriter.init(&out.buf, 0);
+        try outer.writeU32LenString(alg.name());
+        try outer.writeU32LenString(signature_payload);
+        out.len = outer.active().len;
+        return out.slice();
+    }
+
+    pub fn clear(self: *PrivateKey) void {
+        switch (self.*) {
+            .Ed25519 => |*key| {
+                std.crypto.secureZero(u8, &key.public);
+                std.crypto.secureZero(u8, &key.secret);
+            },
+            .EcdsaP256 => |*key| {
+                std.crypto.secureZero(u8, &key.public_sec1);
+                std.crypto.secureZero(u8, &key.secret_scalar);
+            },
+            .Rsa => |*key| key.clear(),
+        }
+    }
+};
+
+pub fn parsePublicKeyBlob(blob: []const u8) KeyError!PublicKey {
+    var r = BufferReader.init(blob);
+    const alg = try r.readU32LenString();
+
+    if (std.mem.eql(u8, alg, ed25519_name)) {
+        const public = try r.readU32LenString();
+        if (public.len != Ed25519.PublicKey.encoded_length) return error.InvalidKeyBlob;
+        return .{ .Ed25519 = public[0..Ed25519.PublicKey.encoded_length].* };
+    }
+
+    if (std.mem.eql(u8, alg, ecdsa_p256_name)) {
+        const curve = try r.readU32LenString();
+        if (!std.mem.eql(u8, curve, ecdsa_p256_curve_name)) return error.UnsupportedKeyAlgorithm;
+        const sec1 = try r.readU32LenString();
+        if (sec1.len != EcdsaP256.PublicKey.uncompressed_sec1_encoded_length) return error.InvalidKeyBlob;
+        _ = EcdsaP256.PublicKey.fromSec1(sec1) catch return error.InvalidKeyBlob;
+        return .{ .EcdsaP256 = sec1[0..EcdsaP256.PublicKey.uncompressed_sec1_encoded_length].* };
+    }
+
+    if (std.mem.eql(u8, alg, rsa_key_name)) {
+        var e: RsaComponent = .{};
+        var n: RsaComponent = .{};
+        try e.set(try r.readU32LenString());
+        try n.set(try r.readU32LenString());
+        try validateRsaPublicComponents(n.slice(), e.slice());
+        return .{ .Rsa = .{ .n = n, .e = e } };
+    }
+
+    return error.UnsupportedKeyAlgorithm;
+}
+
+pub fn verifySignature(public_key: PublicKey, typed_signature: []const u8, msg: []const u8) KeyError!void {
+    var r = BufferReader.init(typed_signature);
+    const sig_name = try r.readU32LenString();
+    const sig_payload = try r.readU32LenString();
+    const sig_alg = SignatureAlgorithm.fromName(sig_name) orelse return error.UnsupportedKeyAlgorithm;
+    if (sig_alg.keyAlgorithm() != public_key.algorithm()) return error.SignatureAlgorithmMismatch;
+
+    switch (public_key) {
+        .Ed25519 => |raw_public| {
+            if (sig_payload.len != Ed25519.Signature.encoded_length) return error.InvalidSignature;
+            const pubkey = Ed25519.PublicKey.fromBytes(raw_public) catch return error.InvalidKeyBlob;
+            const sig = Ed25519.Signature.fromBytes(sig_payload[0..Ed25519.Signature.encoded_length].*);
+            sig.verify(msg, pubkey) catch return error.InvalidSignature;
+        },
+        .EcdsaP256 => |sec1| {
+            const pubkey = EcdsaP256.PublicKey.fromSec1(&sec1) catch return error.InvalidKeyBlob;
+            const sig = try parseEcdsaSignature(sig_payload);
+            sig.verify(msg, pubkey) catch return error.InvalidSignature;
+        },
+        .Rsa => |rsa| {
+            switch (sig_alg) {
+                .RsaSha256 => try rsaVerify(std.crypto.hash.sha2.Sha256, rsa.n.slice(), rsa.e.slice(), sig_payload, msg),
+                .RsaSha512 => try rsaVerify(std.crypto.hash.sha2.Sha512, rsa.n.slice(), rsa.e.slice(), sig_payload, msg),
+                else => return error.SignatureAlgorithmMismatch,
+            }
+        },
+    }
+}
+
+pub fn signatureAlgorithm(typed_signature: []const u8) KeyError!SignatureAlgorithm {
+    var r = BufferReader.init(typed_signature);
+    const sig_name = try r.readU32LenString();
+    return SignatureAlgorithm.fromName(sig_name) orelse error.UnsupportedKeyAlgorithm;
+}
+
+pub fn writePublicKeyBlob(public_key: PublicKey, out: *Blob) KeyError![]const u8 {
+    var w = BufferWriter.init(&out.buf, 0);
+    switch (public_key) {
+        .Ed25519 => |raw| {
+            try w.writeU32LenString(ed25519_name);
+            try w.writeU32LenString(&raw);
+        },
+        .EcdsaP256 => |sec1| {
+            try w.writeU32LenString(ecdsa_p256_name);
+            try w.writeU32LenString(ecdsa_p256_curve_name);
+            try w.writeU32LenString(&sec1);
+        },
+        .Rsa => |rsa| {
+            try w.writeU32LenString(rsa_key_name);
+            try writeMpint(&w, rsa.e.slice());
+            try writeMpint(&w, rsa.n.slice());
+        },
+    }
+    out.len = w.active().len;
+    return out.slice();
+}
+
+pub fn selectHostKeyAlgorithm(peer_namelist: []const u8, private_key: ?*const PrivateKey) ?SignatureAlgorithm {
+    const preference = [_]SignatureAlgorithm{ .RsaSha512, .RsaSha256, .EcdsaP256Sha256, .Ed25519 };
+    for (preference) |alg| {
+        if (!nameListContains(peer_namelist, alg.name())) continue;
+        if (private_key) |key| {
+            if (!key.supportsSignatureAlgorithm(alg)) continue;
+        }
+        return alg;
+    }
+    return null;
+}
+
+pub fn nameListContains(namelist: []const u8, needle: []const u8) bool {
+    var iter = std.mem.splitSequence(u8, namelist, ",");
+    while (iter.next()) |item| {
+        if (std.mem.eql(u8, item, needle)) return true;
+    }
+    return false;
+}
+
+pub fn writeMpint(w: *BufferWriter, bytes: []const u8) BufferError!void {
+    const v = trimMpint(bytes);
+    if (v.len == 0) {
+        try w.writeU32(0);
+        return;
+    }
+
+    const needs_pad = (v[0] & 0x80) != 0;
+    try w.writeU32(@intCast(v.len + @intFromBool(needs_pad)));
+    if (needs_pad) try w.writeU8(0);
+    try w.writeBytes(v);
+}
+
+pub fn trimMpint(bytes: []const u8) []const u8 {
+    var i: usize = 0;
+    while (i < bytes.len and bytes[i] == 0) : (i += 1) {}
+    return bytes[i..];
+}
+
+fn parseEcdsaSignature(sig_payload: []const u8) KeyError!EcdsaP256.Signature {
+    var r = BufferReader.init(sig_payload);
+    const r_mpint = trimMpint(try r.readU32LenString());
+    const s_mpint = trimMpint(try r.readU32LenString());
+    if (r_mpint.len > EcdsaP256.SecretKey.encoded_length or s_mpint.len > EcdsaP256.SecretKey.encoded_length) {
+        return error.InvalidSignature;
+    }
+
+    var raw: [EcdsaP256.Signature.encoded_length]u8 = .{0} ** EcdsaP256.Signature.encoded_length;
+    @memcpy(raw[EcdsaP256.SecretKey.encoded_length - r_mpint.len .. EcdsaP256.SecretKey.encoded_length], r_mpint);
+    @memcpy(raw[EcdsaP256.Signature.encoded_length - s_mpint.len ..], s_mpint);
+    return EcdsaP256.Signature.fromBytes(raw);
+}
+
+fn validateRsaPublicComponents(n: []const u8, e: []const u8) KeyError!void {
+    if (n.len < 64 or n.len > MaxRsaBytes) return error.InvalidKeyBlob;
+    if (e.len == 0 or e.len > 8) return error.InvalidKeyBlob;
+    if ((n[n.len - 1] & 1) == 0) return error.InvalidKeyBlob;
+    if ((e[e.len - 1] & 1) == 0) return error.InvalidKeyBlob;
+}
+
+fn rsaSign(comptime Hash: type, key: RsaPrivateKey, msg: []const u8, out: *[MaxRsaBytes]u8) KeyError![]const u8 {
+    try validateRsaPublicComponents(key.n.slice(), key.e.slice());
+    const modulus_len = key.n.len;
+    if (modulus_len == 0 or modulus_len > out.len) return error.InvalidKeyBlob;
+
+    var encoded: [MaxRsaBytes]u8 = undefined;
+    try pkcs1v15Encode(Hash, msg, encoded[0..modulus_len]);
+
+    const Modulus = std.crypto.ff.Modulus(MaxRsaBits);
+    const modulus = Modulus.fromBytes(key.n.slice(), .big) catch return error.InvalidKeyBlob;
+    const m = Modulus.Fe.fromBytes(modulus, encoded[0..modulus_len], .big) catch return error.InvalidKeyBlob;
+    const s = modulus.powWithEncodedExponent(m, key.d.slice(), .big) catch return error.SigningFailed;
+    s.toBytes(out[0..modulus_len], .big) catch return error.SigningFailed;
+    return out[0..modulus_len];
+}
+
+fn rsaVerify(comptime Hash: type, n: []const u8, e: []const u8, sig: []const u8, msg: []const u8) KeyError!void {
+    try validateRsaPublicComponents(n, e);
+    if (sig.len != n.len) return error.InvalidSignature;
+
+    const Modulus = std.crypto.ff.Modulus(MaxRsaBits);
+    const modulus = Modulus.fromBytes(n, .big) catch return error.InvalidKeyBlob;
+    const s = Modulus.Fe.fromBytes(modulus, sig, .big) catch return error.InvalidSignature;
+    const m = modulus.powWithEncodedPublicExponent(s, e, .big) catch return error.InvalidSignature;
+
+    var decoded: [MaxRsaBytes]u8 = undefined;
+    m.toBytes(decoded[0..n.len], .big) catch return error.InvalidSignature;
+
+    var expected: [MaxRsaBytes]u8 = undefined;
+    try pkcs1v15Encode(Hash, msg, expected[0..n.len]);
+    if (!constantTimeEql(decoded[0..n.len], expected[0..n.len])) return error.InvalidSignature;
+}
+
+fn pkcs1v15Encode(comptime Hash: type, msg: []const u8, em: []u8) KeyError!void {
+    const digest_prefix = digestInfoPrefix(Hash);
+    const t_len = digest_prefix.len + Hash.digest_length;
+    if (em.len < t_len + 11) return error.RsaKeyTooSmall;
+
+    var digest: [Hash.digest_length]u8 = undefined;
+    Hash.hash(msg, &digest, .{});
+
+    em[0] = 0x00;
+    em[1] = 0x01;
+    const ps_end = em.len - t_len - 1;
+    @memset(em[2..ps_end], 0xff);
+    em[ps_end] = 0x00;
+    @memcpy(em[ps_end + 1 .. ps_end + 1 + digest_prefix.len], digest_prefix);
+    @memcpy(em[em.len - Hash.digest_length ..], &digest);
+}
+
+fn digestInfoPrefix(comptime Hash: type) []const u8 {
+    return &switch (Hash) {
+        std.crypto.hash.sha2.Sha256 => .{
+            0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
+            0x00, 0x04, 0x20,
+        },
+        std.crypto.hash.sha2.Sha512 => .{
+            0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
+            0x00, 0x04, 0x40,
+        },
+        else => @compileError("unsupported RSA hash"),
+    };
+}
+
+fn constantTimeEql(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    var acc: u8 = 0;
+    for (a, b) |x, y| acc |= x ^ y;
+    return acc == 0;
+}
+
+test "nameListContains finds algorithm names exactly" {
+    try std.testing.expect(nameListContains(client_hostkey_algorithms, rsa_sha2_512_name));
+    try std.testing.expect(nameListContains(client_hostkey_algorithms, ed25519_name));
+    try std.testing.expect(!nameListContains(client_hostkey_algorithms, "ssh-r"));
+}
+
+test "mpint writer trims leading zeros and pads positive values" {
+    var backing: [16]u8 = undefined;
+    var w = BufferWriter.init(&backing, 0);
+    try writeMpint(&w, &.{ 0, 0x80 });
+    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0, 2, 0, 0x80 }, w.active());
+}

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -6,11 +6,12 @@ const ClientSession = @import("client_session.zig").Session;
 const ServerSession = @import("server_session.zig").Session;
 const BufferError = @import("buffer.zig").BufferError;
 const PrivKeyError = @import("privkey.zig").PrivKeyError;
+const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferReader = @import("buffer.zig").BufferReader;
 
-pub const MisshodError = std.crypto.errors.Error || std.mem.Allocator.Error || BufferError || IoError || PrivKeyError;
+pub const MisshodError = std.crypto.errors.Error || std.mem.Allocator.Error || BufferError || IoError || PrivKeyError || Key.KeyError;
 
 pub const IoError = error{
     cannotAcceptWrite,
@@ -82,6 +83,9 @@ pub const MisshodClientEventCodes = union(enum) {
     Connected,
     RxData: []const u8,
     RxExtendedData: ExtendedData,
+    AgentChannelOpen: u32,
+    AgentData: ChannelData,
+    AgentChannelClosed: u32,
     Banner: []const u8,
     KeyboardInteractive: KeyboardInteractivePrompt,
 };
@@ -93,8 +97,13 @@ pub const ExtendedData = struct {
 
 pub const UserCredentialsPasswordOrPubkey = union(enum) {
     Password: []const u8,
-    Pubkey: []const u8,
+    Pubkey: PublicKeyIdentity,
     KeyboardInteractive: []const u8, // submethods
+};
+
+pub const PublicKeyIdentity = struct {
+    algorithm: []const u8,
+    blob: []const u8,
 };
 
 pub const UserCredentials = struct {
@@ -107,6 +116,7 @@ pub const ChannelRequestType = union(enum) {
     Exec: []const u8,
     Subsystem: []const u8,
     Env: struct { name: []const u8, value: []const u8 },
+    AgentForward,
 };
 
 pub const ChannelRequestEvent = struct {
@@ -143,6 +153,8 @@ pub const MisshodServerEventCodes = union(enum) {
     UserAuth: UserCredentials,
     GetPubkeyForUser: []const u8,
     Connected: u32,
+    AgentChannelOpen: u32,
+    AgentChannelClosed: u32,
     RxData: ChannelData,
     RxExtendedData: ChannelExtendedData,
     WindowChange: WindowSize,
@@ -688,6 +700,26 @@ pub fn MisshodImpl(role: Role) type {
         self.iostate_wr = .Idle;
         try self.advance();
     }
+
+    pub fn enableAgentForwarding(self: *Self) MisshodError!void {
+        switch (role) {
+            .Client => return try self.session.enableAgentForwarding(),
+            .Server => return IoError.UnimplementedService,
+        }
+    }
+
+    pub fn openAgentChannel(self: *Self) MisshodError!u32 {
+        switch (role) {
+            .Client => return IoError.UnimplementedService,
+            .Server => {
+                self.iostate_rd = .Idle;
+                self.iostate_wr = .Idle;
+                const channel_id = try self.session.openAgentChannel();
+                try self.advance();
+                return channel_id;
+            },
+        }
+    }
 };
 }
 
@@ -724,6 +756,29 @@ test "MisshodClientEventCodes Banner variant" {
         .Banner => |text| {
             try std.testing.expectEqualStrings("Welcome to the server", text);
         },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "MisshodClientEventCodes agent forwarding variants" {
+    const open_evt: MisshodClientEventCodes = .{ .AgentChannelOpen = 3 };
+    switch (open_evt) {
+        .AgentChannelOpen => |channel| try std.testing.expectEqual(@as(u32, 3), channel),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const data_evt: MisshodClientEventCodes = .{ .AgentData = .{ .channel = 3, .data = "agent-data" } };
+    switch (data_evt) {
+        .AgentData => |data| {
+            try std.testing.expectEqual(@as(u32, 3), data.channel);
+            try std.testing.expectEqualStrings("agent-data", data.data);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const closed_evt: MisshodClientEventCodes = .{ .AgentChannelClosed = 3 };
+    switch (closed_evt) {
+        .AgentChannelClosed => |channel| try std.testing.expectEqual(@as(u32, 3), channel),
         else => return error.TestUnexpectedResult,
     }
 }
@@ -791,6 +846,14 @@ test "ChannelRequestType Shell variant" {
     const req: ChannelRequestType = .Shell;
     switch (req) {
         .Shell => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ChannelRequestType AgentForward variant" {
+    const req: ChannelRequestType = .AgentForward;
+    switch (req) {
+        .AgentForward => {},
         else => return error.TestUnexpectedResult,
     }
 }
@@ -1548,4 +1611,145 @@ test "client channelWriteComplete uses direct write when read is active" {
 
     try std.testing.expect(connected_client);
     try std.testing.expect(sent_channel_data);
+}
+
+fn driveHandshakeForKeys(hostkey_ascii: []const u8, client_key_ascii: ?[]const u8, expected_pubkey_algorithm: ?[]const u8) !void {
+    var cprng = std.Random.DefaultPrng.init(1000);
+    var sprng = std.Random.DefaultPrng.init(2000);
+
+    var client = try MisshodClient.init(cprng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    var server = try MisshodServer.init(sprng.random(), hostkey_ascii, std.testing.allocator);
+    defer server.deinit();
+
+    var c2s_buf: [65536]u8 = undefined;
+    var s2c_buf: [65536]u8 = undefined;
+    var c2s_len: usize = 0;
+    var s2c_len: usize = 0;
+    var connected_client = false;
+    var saw_expected_pubkey = expected_pubkey_algorithm == null;
+
+    const Endpoint = enum { client_ep, server_ep };
+    const endpoints = [_]Endpoint{ .client_ep, .server_ep };
+
+    var steps: usize = 0;
+    while (steps < 2000) : (steps += 1) {
+        if (connected_client and saw_expected_pubkey) break;
+
+        for (endpoints) |ep| {
+            if (ep == .client_ep) {
+                const cev = client.getNextEvent() catch continue;
+                switch (cev) {
+                    .ReadyToProduce => {
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        if (s2c_len > 0) {
+                            const feed = @min(n, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
+                    .ReadyToConsumeAndProduce => |s| {
+                        const data = client.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(c2s_buf[c2s_len .. c2s_len + data.len], data);
+                        c2s_len += data.len;
+                        client.consumed(data.len) catch {};
+                        if (s2c_len > 0) {
+                            const feed = @min(s.consume, s2c_len);
+                            client.write(s2c_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &s2c_buf, s2c_buf[feed..s2c_len]);
+                            s2c_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .CheckHostKey => client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {},
+                        .GetPrivateKey => {
+                            if (client_key_ascii) |key| client.setPrivateKey(key) catch {};
+                            client.clearEvent(.GetPrivateKey) catch {};
+                        },
+                        .GetAuthPassphrase => {
+                            client.session.setAuthPassphrase("testpass") catch {};
+                            client.clearEvent(.GetAuthPassphrase) catch {};
+                        },
+                        .Connected => {
+                            connected_client = true;
+                            client.clearEvent(.Connected) catch {};
+                        },
+                        .EndSession => break,
+                        else => { client.clearEvent(code) catch {}; },
+                    },
+                }
+            } else {
+                const sev = server.getNextEvent() catch continue;
+                switch (sev) {
+                    .ReadyToProduce => {
+                        const data = server.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(s2c_buf[s2c_len .. s2c_len + data.len], data);
+                        s2c_len += data.len;
+                        server.consumed(data.len) catch {};
+                    },
+                    .ReadyToConsume => |n| {
+                        if (c2s_len > 0) {
+                            const feed = @min(n, c2s_len);
+                            server.write(c2s_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
+                            c2s_len -= feed;
+                        }
+                    },
+                    .ReadyToConsumeAndProduce => |s| {
+                        const data = server.peek(Protocol.MaxSSHPacket) catch continue;
+                        @memcpy(s2c_buf[s2c_len .. s2c_len + data.len], data);
+                        s2c_len += data.len;
+                        server.consumed(data.len) catch {};
+                        if (c2s_len > 0) {
+                            const feed = @min(s.consume, c2s_len);
+                            server.write(c2s_buf[0..feed]) catch {};
+                            std.mem.copyForwards(u8, &c2s_buf, c2s_buf[feed..c2s_len]);
+                            c2s_len -= feed;
+                        }
+                    },
+                    .Event => |code| switch (code) {
+                        .UserAuth => |credentials| {
+                            if (expected_pubkey_algorithm) |expected| {
+                                if (credentials.auth) |auth| switch (auth) {
+                                    .Pubkey => |pubkey| {
+                                        try std.testing.expectEqualStrings(expected, pubkey.algorithm);
+                                        try std.testing.expect(pubkey.blob.len > 0);
+                                        saw_expected_pubkey = true;
+                                    },
+                                    else => {},
+                                };
+                            }
+                            server.grantAccess(true) catch {};
+                            server.clearEvent(.{ .UserAuth = .{ .username = "", .auth = null } }) catch {};
+                        },
+                        .Connected => server.clearEvent(.{ .Connected = 0 }) catch {},
+                        .ChannelRequest => server.clearEvent(.{ .ChannelRequest = .{ .channel = 0, .request = .Shell } }) catch {},
+                        else => { server.clearEvent(code) catch {}; },
+                    },
+                }
+            }
+        }
+    }
+
+    try std.testing.expect(connected_client);
+    try std.testing.expect(saw_expected_pubkey);
+}
+
+test "handshake supports ECDSA and RSA host keys" {
+    const privkey = @import("privkey.zig");
+    try driveHandshakeForKeys(privkey.testkey_ecdsa_p256, null, null);
+    try driveHandshakeForKeys(privkey.testkey_rsa_2048, null, null);
+}
+
+test "public key auth supports Ed25519 ECDSA and RSA SHA2 keys" {
+    const privkey = @import("privkey.zig");
+    try driveHandshakeForKeys(privkey.testkey_valid, privkey.testkey_valid, "ssh-ed25519");
+    try driveHandshakeForKeys(privkey.testkey_valid, privkey.testkey_ecdsa_p256, "ecdsa-sha2-nistp256");
+    try driveHandshakeForKeys(privkey.testkey_valid, privkey.testkey_rsa_2048, "rsa-sha2-512");
 }

--- a/src/privkey.zig
+++ b/src/privkey.zig
@@ -6,13 +6,14 @@ const TRACEDUMP = util.tracedump;
 const AesCtr = @import("aesctr.zig").AesCtr;
 const BufferReader = @import("buffer.zig").BufferReader;
 const BufferError = @import("buffer.zig").BufferError;
+const Key = @import("key.zig");
 
 // cat id_ed25519  | grep -v "^-----" | base64 -d | xxd
 
 const KdfError = crypto.pwhash.KdfError;
 const HasherError = crypto.pwhash.HasherError;
 
-pub const PrivKeyError = PrivKeyInternalError || BufferError || std.base64.Error || crypto.pwhash.Error || KdfError || HasherError || std.crypto.errors.EncodingError;
+pub const PrivKeyError = PrivKeyInternalError || BufferError || Key.KeyError || std.base64.Error || crypto.pwhash.Error || KdfError || HasherError || std.crypto.errors.EncodingError;
 
 pub const PrivKeyInternalError = error{
     PrivKeyOutofSpace,
@@ -21,9 +22,6 @@ pub const PrivKeyInternalError = error{
     InvalidInput,
     UnsupportedPrivKey,
 };
-
-// This format has only been tested for Ed25519 files
-const srv_hostkey_algo = std.crypto.sign.Ed25519;
 
 fn decodeAsciiToBinary(keydata_ascii: []const u8, keydata_bin_buf: []u8) PrivKeyError![]u8 {
     const pre_banner = "-----BEGIN OPENSSH PRIVATE KEY-----";
@@ -49,8 +47,8 @@ fn decodeAsciiToBinary(keydata_ascii: []const u8, keydata_bin_buf: []u8) PrivKey
     }
 }
 
-pub fn decodePrivKey(keydata_ascii: []const u8, passphrase_opt: ?[]const u8, privkey_blob: *[srv_hostkey_algo.SecretKey.encoded_length]u8, pubkey_blob: *[srv_hostkey_algo.PublicKey.encoded_length]u8) PrivKeyError!void {
-    var keydata_bin_buf: [1024]u8 = undefined;
+pub fn decodeOpenSshPrivateKey(keydata_ascii: []const u8, passphrase_opt: ?[]const u8) PrivKeyError!Key.PrivateKey {
+    var keydata_bin_buf: [8192]u8 = undefined;
     const bin = try decodeAsciiToBinary(keydata_ascii, &keydata_bin_buf);
     TRACEDUMP(.Debug, "raw len={d}", .{bin.len}, bin);
 
@@ -105,7 +103,8 @@ pub fn decodePrivKey(keydata_ascii: []const u8, passphrase_opt: ?[]const u8, pri
                 TRACEDUMP(.Debug, "bcrypt hash", .{}, &hash);
                 // https://www.thedigitalcatonline.com/blog/2021/06/03/public-key-cryptography-openssh-private-keys/#a-poorly-documented-format-2ea8
                 var aesctr = AesCtrT.init(hash[AesCtrT.key_size..].*, hash[0..AesCtrT.key_size].*);
-                var dec: [1024]u8 = undefined; // FIXME
+                var dec: [8192]u8 = undefined;
+                if (enc_section.len > dec.len) return PrivKeyError.PrivKeyOutofSpace;
                 aesctr.encrypt(enc_section, dec[0..enc_section.len]);
                 TRACEDUMP(.Debug, "dec", .{}, dec[0..enc_section.len]);
                 // copy decrypted area over original encrypted
@@ -139,15 +138,86 @@ pub fn decodePrivKey(keydata_ascii: []const u8, passphrase_opt: ?[]const u8, pri
     const key_algo = try encbuffer.readU32LenString();
     TRACE(.Debug, "key_algo={s}\n", .{key_algo});
 
-    const key_blob_pub = try encbuffer.readU32LenString();
-    TRACEDUMP(.Debug, "key_blob_pub", .{}, key_blob_pub);
+    var private_key = try parsePrivateSectionKey(key_algo, &encbuffer);
 
-    @memcpy(pubkey_blob, key_blob_pub);
+    var private_pubkey_blob: Key.Blob = .{};
+    const generated_pubkey = try private_key.publicBlob(&private_pubkey_blob);
+    if (!std.mem.eql(u8, generated_pubkey, pubkey)) {
+        private_key.clear();
+        return PrivKeyError.BadPrivKey;
+    }
 
-    const key_blob_prv = try encbuffer.readU32LenString();
-    TRACEDUMP(.Debug, "key_blob_prv", .{}, key_blob_prv);
+    return private_key;
+}
 
-    @memcpy(privkey_blob, key_blob_prv);
+pub fn decodePrivKey(keydata_ascii: []const u8, passphrase_opt: ?[]const u8, privkey_blob: *[std.crypto.sign.Ed25519.SecretKey.encoded_length]u8, pubkey_blob: *[std.crypto.sign.Ed25519.PublicKey.encoded_length]u8) PrivKeyError!void {
+    var private_key = try decodeOpenSshPrivateKey(keydata_ascii, passphrase_opt);
+    defer private_key.clear();
+
+    switch (private_key) {
+        .Ed25519 => |key| {
+            @memcpy(privkey_blob, &key.secret);
+            @memcpy(pubkey_blob, &key.public);
+        },
+        else => return PrivKeyError.UnsupportedPrivKey,
+    }
+}
+
+fn parsePrivateSectionKey(key_algo: []const u8, encbuffer: *BufferReader) PrivKeyError!Key.PrivateKey {
+    if (std.mem.eql(u8, key_algo, Key.ed25519_name)) {
+        const key_blob_pub = try encbuffer.readU32LenString();
+        const key_blob_prv = try encbuffer.readU32LenString();
+        TRACEDUMP(.Debug, "ed25519 key_blob_pub", .{}, key_blob_pub);
+        TRACEDUMP(.Debug, "ed25519 key_blob_prv", .{}, key_blob_prv);
+        if (key_blob_pub.len != std.crypto.sign.Ed25519.PublicKey.encoded_length or
+            key_blob_prv.len != std.crypto.sign.Ed25519.SecretKey.encoded_length)
+        {
+            return PrivKeyError.BadPrivKey;
+        }
+        return .{ .Ed25519 = .{
+            .public = key_blob_pub[0..std.crypto.sign.Ed25519.PublicKey.encoded_length].*,
+            .secret = key_blob_prv[0..std.crypto.sign.Ed25519.SecretKey.encoded_length].*,
+        } };
+    }
+
+    if (std.mem.eql(u8, key_algo, Key.ecdsa_p256_name)) {
+        const curve = try encbuffer.readU32LenString();
+        if (!std.mem.eql(u8, curve, Key.ecdsa_p256_curve_name)) return PrivKeyError.UnsupportedPrivKey;
+        const sec1 = try encbuffer.readU32LenString();
+        if (sec1.len != std.crypto.sign.ecdsa.EcdsaP256Sha256.PublicKey.uncompressed_sec1_encoded_length) {
+            return PrivKeyError.BadPrivKey;
+        }
+        const secret_mpint = try encbuffer.readU32LenString();
+        const secret_scalar = try mpintToFixed(std.crypto.sign.ecdsa.EcdsaP256Sha256.SecretKey.encoded_length, secret_mpint);
+        const secret_key = std.crypto.sign.ecdsa.EcdsaP256Sha256.SecretKey.fromBytes(secret_scalar) catch return PrivKeyError.BadPrivKey;
+        const keypair = std.crypto.sign.ecdsa.EcdsaP256Sha256.KeyPair.fromSecretKey(secret_key) catch return PrivKeyError.BadPrivKey;
+        if (!std.mem.eql(u8, &keypair.public_key.toUncompressedSec1(), sec1)) return PrivKeyError.BadPrivKey;
+        return .{ .EcdsaP256 = .{
+            .public_sec1 = sec1[0..std.crypto.sign.ecdsa.EcdsaP256Sha256.PublicKey.uncompressed_sec1_encoded_length].*,
+            .secret_scalar = secret_scalar,
+        } };
+    }
+
+    if (std.mem.eql(u8, key_algo, Key.rsa_key_name)) {
+        var rsa: Key.RsaPrivateKey = .{};
+        try rsa.n.set(try encbuffer.readU32LenString());
+        try rsa.e.set(try encbuffer.readU32LenString());
+        try rsa.d.set(try encbuffer.readU32LenString());
+        try rsa.iqmp.set(try encbuffer.readU32LenString());
+        try rsa.p.set(try encbuffer.readU32LenString());
+        try rsa.q.set(try encbuffer.readU32LenString());
+        return .{ .Rsa = rsa };
+    }
+
+    return PrivKeyError.UnsupportedPrivKey;
+}
+
+fn mpintToFixed(comptime len: usize, mpint: []const u8) PrivKeyError![len]u8 {
+    const trimmed = Key.trimMpint(mpint);
+    if (trimmed.len > len) return PrivKeyError.BadPrivKey;
+    var out: [len]u8 = .{0} ** len;
+    @memcpy(out[len - trimmed.len ..], trimmed);
+    return out;
 }
 
 pub const testkey_valid = "-----BEGIN OPENSSH PRIVATE KEY-----\n" ++
@@ -192,9 +262,47 @@ const testkey_encrypted_valid_passworded = "-----BEGIN OPENSSH PRIVATE KEY-----\
 
 const testkey_encrypted_valid_password = "secretpassword";
 
+pub const testkey_ecdsa_p256 = "-----BEGIN OPENSSH PRIVATE KEY-----\n" ++
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n" ++
+    "1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQoNzjURTO/Ky+QNRi8TBgDlEqN1Pii\n" ++
+    "5uGWIB2kfqd4y9JI4MEcV3GKfdhVGQQxCvMbiy+6FNpWVP5JvMUbyq27AAAAsN8uAk3fLg\n" ++
+    "JNAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCg3ONRFM78rL5A1\n" ++
+    "GLxMGAOUSo3U+KLm4ZYgHaR+p3jL0kjgwRxXcYp92FUZBDEK8xuLL7oU2lZU/km8xRvKrb\n" ++
+    "sAAAAhALqVUmkFwlmnxIndTZ9+/sVOy5pP3A50/dLiNl6DBO0DAAAAEm1pc3Nob2QtZWNk\n" ++
+    "c2EtdGVzdAECAwQF\n" ++
+    "-----END OPENSSH PRIVATE KEY-----\n";
+
+pub const testkey_rsa_2048 = "-----BEGIN OPENSSH PRIVATE KEY-----\n" ++
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn\n" ++
+    "NhAAAAAwEAAQAAAQEArU7FSCT5zmVKP/akkA5VyWq8yxeWlznJ1dVqxXuvLSkpCVpLcHDU\n" ++
+    "qZl4hA7NBxjtrAYEgQrgi11dqQyQVAu38kEkgnjIoZinvWpUqD2K6GEZLg8ZUn0xuvnZtU\n" ++
+    "rEarZG7oENVbF6zZV8USmKda0fM5T/pTVMAga3FF/3oE/9IZiSNO3F2poM+xecei4r+ev9\n" ++
+    "S2SRuLAazD4jcC2g8jFvjY1bYIP88kfRhbKOH4S07NbBWfTr3USuNZbtSublv3HrMYosnA\n" ++
+    "7ktEvdMh1+cO9sbb1EQMr71W9u5KTZ+GwbKCWdZsKfFPUyqP+1P4JgUoN26D+4bIeb+Vxf\n" ++
+    "7Q0IczBQIwAAA8gPpA/YD6QP2AAAAAdzc2gtcnNhAAABAQCtTsVIJPnOZUo/9qSQDlXJar\n" ++
+    "zLF5aXOcnV1WrFe68tKSkJWktwcNSpmXiEDs0HGO2sBgSBCuCLXV2pDJBUC7fyQSSCeMih\n" ++
+    "mKe9alSoPYroYRkuDxlSfTG6+dm1SsRqtkbugQ1VsXrNlXxRKYp1rR8zlP+lNUwCBrcUX/\n" ++
+    "egT/0hmJI07cXamgz7F5x6Liv56/1LZJG4sBrMPiNwLaDyMW+NjVtgg/zyR9GFso4fhLTs\n" ++
+    "1sFZ9OvdRK41lu1K5uW/cesxiiycDuS0S90yHX5w72xtvURAyvvVb27kpNn4bBsoJZ1mwp\n" ++
+    "8U9TKo/7U/gmBSg3boP7hsh5v5XF/tDQhzMFAjAAAAAwEAAQAAAQAT7q7W9NW8TL8E60eS\n" ++
+    "/+sS7tFG5HAf9XgGvXR5wRdtMMI0/qsVhAyZcvq+6XrgOZhARDLpaohXzwWyJy1EVVKzLJ\n" ++
+    "XX4a9lkoqcSOnyrZ1Xy68bMoZdi+OX1xuYc8Bya4Nt8+7GL9LpaStypD31+dLQWm8qn54d\n" ++
+    "z4rn73+p8vkwj0yP5o0fZwvZqUVDZcSEAGgjj3TIXY0jtCaiD6/Vjm+5M4IGNxsOO52OeP\n" ++
+    "VEBVtV7KaBfZZv926l2Dc9/FNDCpYPOqhFHp2DcuLgeYUSfbiBsheyuCkbvRgglZVHMwBl\n" ++
+    "zoCDJQnHfGhxgzDklQdlkZOuSLidpIW66N0+mjchBqZVAAAAgALNsDPO0UkizZq6Rm0UV2\n" ++
+    "ibD5mO2aNArzU9Fkh7EQdWQ9NL9G4pDhMInNl8Fq2gPHpKfMjTAEeT81ElLAOShweyqvkz\n" ++
+    "/qnEwFe+KCZQoh9ejO/7eHH7ewR64C+Gu1N0brHt20R05pxmmRKnmRS1ZPEi+4MhrlPE2e\n" ++
+    "JJoWscAWxVAAAAgQDi1UpmqO8G2KTVxRCWpBSCjtPfz9hxR4eNi53F2tJ4KtdSK5VnGh+F\n" ++
+    "kfC3AI8PpqjDW5sEZl/zAeYPRbrtfyGiAbZbwdxU3mZ9QAHHQ7FRcyokhMifez/kC1vbfS\n" ++
+    "hkXRrgmgsv7/Kx7chTA88LEgQbUdumQyQxHNY2q3uKls/4VQAAAIEAw5eSfb7qpWHnsrsx\n" ++
+    "qKJqQ9Xux3uApcG8XWd/VgxFzo6Ie7UJtoXS9BpBHEnRPdh+tXWtx43KEOZCOmk+MyGqrS\n" ++
+    "XRWn8/QntAMvuWbJNTtM1qtgMq5u1GWnqJaRmx3xSTjHbwoZ0Qf4uYTUS4cftU6XDY+g1d\n" ++
+    "HxutD6YVr9AffpcAAAAQbWlzc2hvZC1yc2EtdGVzdAECAw==\n" ++
+    "-----END OPENSSH PRIVATE KEY-----\n";
+
 test "decodepriv" {
-    var blob: [srv_hostkey_algo.SecretKey.encoded_length]u8 = undefined;
-    var pubblob: [srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined;
+    var blob: [std.crypto.sign.Ed25519.SecretKey.encoded_length]u8 = undefined;
+    var pubblob: [std.crypto.sign.Ed25519.PublicKey.encoded_length]u8 = undefined;
 
     try std.testing.expectError(PrivKeyError.BadPrivKey, decodePrivKey(testkey_invalid_bad_preamble, null, &blob, &pubblob));
     try std.testing.expectError(PrivKeyError.BadPrivKey, decodePrivKey(testkey_invalid_missing_footer, null, &blob, &pubblob));
@@ -204,4 +312,27 @@ test "decodepriv" {
     try std.testing.expect(std.mem.eql(u8, &blob, &[_]u8{ 168, 158, 23, 77, 212, 94, 57, 255, 157, 6, 173, 128, 17, 109, 67, 232, 3, 126, 106, 1, 93, 9, 70, 135, 50, 35, 207, 108, 76, 128, 251, 24, 189, 27, 142, 8, 84, 46, 86, 64, 66, 99, 249, 172, 207, 208, 211, 134, 21, 193, 250, 85, 48, 57, 251, 81, 133, 110, 66, 16, 244, 86, 130, 249 }));
     try decodePrivKey(testkey_valid, null, &blob, &pubblob);
     try std.testing.expect(std.mem.eql(u8, &blob, &[_]u8{ 166, 119, 186, 89, 114, 101, 152, 133, 196, 14, 211, 238, 206, 143, 73, 223, 41, 101, 45, 196, 132, 150, 240, 240, 41, 82, 229, 54, 152, 193, 40, 220, 232, 131, 168, 235, 233, 3, 218, 50, 159, 159, 165, 94, 166, 155, 49, 203, 223, 47, 9, 101, 69, 137, 215, 186, 3, 175, 96, 21, 112, 247, 116, 245 }));
+}
+
+test "decode OpenSSH private key algorithms and sign/verify" {
+    const cases = .{
+        .{ testkey_valid, Key.KeyAlgorithm.Ed25519 },
+        .{ testkey_ecdsa_p256, Key.KeyAlgorithm.EcdsaP256 },
+        .{ testkey_rsa_2048, Key.KeyAlgorithm.Rsa },
+    };
+
+    inline for (cases) |case| {
+        var private_key = try decodeOpenSshPrivateKey(case[0], null);
+        defer private_key.clear();
+        try std.testing.expectEqual(case[1], private_key.algorithm());
+
+        var public_blob: Key.Blob = .{};
+        const blob = try private_key.publicBlob(&public_blob);
+        const public_key = try Key.parsePublicKeyBlob(blob);
+
+        var sig_blob: Key.SignatureBlob = .{};
+        const sig = try private_key.sign(private_key.defaultSignatureAlgorithm(), "misshod message", &sig_blob);
+        try Key.verifySignature(public_key, sig, "misshod message");
+        try std.testing.expectError(Key.KeyError.InvalidSignature, Key.verifySignature(public_key, sig, "tampered message"));
+    }
 }

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -110,6 +110,16 @@ pub const enc_algo = std.crypto.core.aes.Aes256;
 pub const enc_algo_name = "aes256-ctr";
 pub const AesCtrT = AesCtr(enc_algo);
 
+pub const channel_type_session = "session";
+pub const channel_type_auth_agent_openssh = "auth-agent@openssh.com";
+pub const channel_type_auth_agent = "auth-agent";
+pub const channel_request_auth_agent = "auth-agent-req@openssh.com";
+
+pub fn isAgentChannelType(channel_type: []const u8) bool {
+    return std.mem.eql(u8, channel_type, channel_type_auth_agent_openssh) or
+        std.mem.eql(u8, channel_type, channel_type_auth_agent);
+}
+
 // Note, the buffers are not used for storage, they're just passed forward to signal to receiver where the data can be found
 pub const IoSessionState = union(enum) {
     Init,
@@ -304,6 +314,12 @@ test "MaxChannelDataLen accounts for framing overhead" {
     try std.testing.expectEqual(MaxPayload - 9, MaxChannelDataLen);
     try std.testing.expect(MaxChannelDataLen > 0);
     try std.testing.expect(MaxChannelDataLen > 64); // must be larger than old hardcoded value
+}
+
+test "agent forwarding channel type aliases" {
+    try std.testing.expect(isAgentChannelType(channel_type_auth_agent_openssh));
+    try std.testing.expect(isAgentChannelType(channel_type_auth_agent));
+    try std.testing.expect(!isAgentChannelType(channel_type_session));
 }
 
 test "KeyDataBi.clear zeros all key material" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -11,8 +11,9 @@ const BufferError = @import("buffer.zig").BufferError;
 const BufferReader = @import("buffer.zig").BufferReader;
 const Hasher = @import("hasher.zig").Hasher;
 const AesCtr = @import("aesctr.zig").AesCtr;
-const decodePrivKey = @import("privkey.zig").decodePrivKey;
+const decodeOpenSshPrivateKey = @import("privkey.zig").decodeOpenSshPrivateKey;
 const PrivKeyError = @import("privkey.zig").PrivKeyError;
+const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
 const ChannelTable = @import("channel.zig").ChannelTable;
@@ -47,6 +48,7 @@ pub const Session = struct {
     shared_secret_k: [Protocol.kex_algo.shared_length]u8 = undefined, // K
     kex_hasher: Hasher(Protocol.hash_algo) = undefined, // for building H
     kex_hash_order: Protocol.KexHashOrder = .Init,
+    selected_hostkey_algorithm: ?Key.SignatureAlgorithm,
     session_id: [Protocol.hash_algo.digest_length]u8 = undefined,
     keydata: Protocol.KeyDataBi,
     rand: std.Random = undefined,
@@ -59,11 +61,11 @@ pub const Session = struct {
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
 
-    auth_pubkey_attempted:[Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined, // U32LenString with algo name + pubkey
-    q_c:[Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
+    auth_pubkey_attempted: Key.Blob,
+    auth_pubkey_algorithm: ?Key.SignatureAlgorithm,
+    q_c:[Protocol.kex_algo.public_length]u8 = undefined,
 
-    privkey_blob: [Protocol.srv_hostkey_algo.SecretKey.encoded_length]u8 = undefined,
-    pubkey_blob: [Protocol.srv_hostkey_algo.PublicKey.encoded_length]u8 = undefined,
+    host_private_key: Key.PrivateKey,
 
     pub fn init(rand: std.Random, hostkey_ascii: []const u8, allocator: std.mem.Allocator) !Self {
         var s = Self {
@@ -74,15 +76,19 @@ pub const Session = struct {
             .encrypted = false,
             .keydata = Protocol.KeyDataBi.init(),
             .kex_hasher = Hasher(Protocol.hash_algo).init(), // for hashing H
+            .selected_hostkey_algorithm = null,
             .privkey_ascii = null,
             .privkey_passphrase = null,
             .auth_passphrase = null,
+            .auth_pubkey_attempted = .{},
+            .auth_pubkey_algorithm = null,
+            .host_private_key = undefined,
             .channel_table = ChannelTable{},
             .active_channel_id = null,
             .is_rekeying = false,
         };
 
-        try decodePrivKey(hostkey_ascii, null, &s.privkey_blob, &s.pubkey_blob);
+        s.host_private_key = try decodeOpenSshPrivateKey(hostkey_ascii, null);
 
         return s;
     }
@@ -93,9 +99,9 @@ pub const Session = struct {
         self.clearAndFreeOptional(&self.auth_passphrase);
         std.crypto.secureZero(u8, &self.shared_secret_k);
         std.crypto.secureZero(u8, &self.session_id);
-        std.crypto.secureZero(u8, &self.privkey_blob);
-        std.crypto.secureZero(u8, &self.pubkey_blob);
-        std.crypto.secureZero(u8, &self.auth_pubkey_attempted);
+        self.host_private_key.clear();
+        self.auth_pubkey_attempted.clear();
+        self.auth_pubkey_algorithm = null;
         std.crypto.secureZero(u8, &self.q_c);
         self.channel_table.secureZeroAll();
         self.keydata.clear();
@@ -149,7 +155,7 @@ pub const Session = struct {
                 try pkt.writeBytes(&cookie);
 
                 try pkt.writeU32LenString(Protocol.kex_algo_name); // kex
-                try pkt.writeU32LenString(Protocol.srv_hostkey_algo_name); // hostkey verification
+                try pkt.writeU32LenString(self.host_private_key.hostKeyAlgorithms()); // hostkey verification
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc c2s
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc s2c
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac c2s
@@ -177,16 +183,13 @@ pub const Session = struct {
 
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_REPLY));
 
-                // hostkey_ks
-                var backing_buf: [256]u8 = undefined;
-                var typed_ks_buf = BufferWriter.init(&backing_buf, 0);
-                try typed_ks_buf.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try typed_ks_buf.writeU32LenString(&self.pubkey_blob);
+                var hostkey_blob_buf: Key.Blob = .{};
+                const hostkey_blob = try self.host_private_key.publicBlob(&hostkey_blob_buf);
 
-                TRACEDUMP(.Debug, "ks", .{}, typed_ks_buf.payload);
+                TRACEDUMP(.Debug, "ks", .{}, hostkey_blob);
                 self.kex_hash_order = self.kex_hash_order.check(.K_S);
-                self.kex_hasher.writeU32LenString(typed_ks_buf.payload);
-                try pkt.writeU32LenString(typed_ks_buf.payload);
+                self.kex_hasher.writeU32LenString(hostkey_blob);
+                try pkt.writeU32LenString(hostkey_blob);
 
                 self.kex_hash_order = self.kex_hash_order.check(.Q_C);
                 self.kex_hasher.writeU32LenString(&self.q_c);
@@ -216,15 +219,10 @@ pub const Session = struct {
 
                 @memcpy(&self.session_id, &kexhash); // store as session_id
 
-                const secretkey = try Protocol.srv_hostkey_algo.SecretKey.fromBytes(self.privkey_blob);
-                const host_keypair = try Protocol.srv_hostkey_algo.KeyPair.fromSecretKey(secretkey);
-
-                const sig = try host_keypair.sign(&kexhash, null);
-                var typed_sig_buf = BufferWriter.init(&backing_buf, 0);
-                try typed_sig_buf.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try typed_sig_buf.writeU32LenString(&sig.toBytes());
-
-                try pkt.writeU32LenString(typed_sig_buf.payload);
+                const sig_alg = self.selected_hostkey_algorithm orelse self.host_private_key.defaultSignatureAlgorithm();
+                var typed_sig: Key.SignatureBlob = .{};
+                const sig = try self.host_private_key.sign(sig_alg, &kexhash, &typed_sig);
+                try pkt.writeU32LenString(sig);
 
                 // generate keys
                 try self.keydata.genKeys(kexhash, self.shared_secret_k, self.session_id);
@@ -274,14 +272,9 @@ pub const Session = struct {
             .AuthPkAllowed => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_PK_OK));
-                try pkt.writeU32LenString(Protocol.srv_hostkey_algo_name);
-
-                var backing_pubkey_buf: [256]u8 = undefined;
-                var typed_pubkey_buf = BufferWriter.init(&backing_pubkey_buf, 0);
-                try typed_pubkey_buf.writeU32LenString(Protocol.srv_hostkey_algo_name);
-                try typed_pubkey_buf.writeU32LenString(&self.auth_pubkey_attempted);
-
-                try pkt.writeU32LenString(typed_pubkey_buf.payload);
+                const auth_alg = self.auth_pubkey_algorithm orelse return IoError.UnexpectedResponse;
+                try pkt.writeU32LenString(auth_alg.name());
+                try pkt.writeU32LenString(self.auth_pubkey_attempted.slice());
                 self.setSessionState(.AuthRead);
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
@@ -408,15 +401,32 @@ pub const Session = struct {
             },
             .Closed => {
                 const local_id = chan.local_id;
+                const kind = chan.kind;
                 self.channel_table.freeChannel(local_id);
                 self.active_channel_id = null;
-                if (self.channel_table.activeCount() == 0) {
+                if (kind == .AgentForward) {
+                    misshod.requestEvent(.{ .AgentChannelClosed = local_id }, .ReadPktHdr);
+                } else if (self.channel_table.activeCount() == 0) {
                     misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
                 } else {
                     self.setIoSessionState(.ReadPktHdr);
                 }
             },
             .Open => {
+                if (chan.kind == .AgentForward) {
+                    var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                    try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
+                    try pkt.writeU32LenString(Protocol.channel_type_auth_agent_openssh);
+                    try pkt.writeU32(chan.local_id);
+                    try pkt.writeU32(Protocol.MaxPayload);
+                    try pkt.writeU32(Protocol.MaxPayload);
+                    chan.state = .OpenSent;
+                    misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
+            },
+            .OpenSent => {
                 self.setIoSessionState(.ReadPktHdr);
             },
         }
@@ -477,6 +487,15 @@ pub const Session = struct {
         self.active_channel_id = channel_id;
         self.setSessionState(.ChannelActive);
         self.setIoSessionState(.Idle);
+    }
+
+    pub fn openAgentChannel(self: *Self) MisshodError!u32 {
+        const chan = self.channel_table.allocChannelKind(.AgentForward, 0, 0, 0) orelse return IoError.UnexpectedResponse;
+        chan.state = .Open;
+        self.active_channel_id = chan.local_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+        return chan.local_id;
     }
 
     pub fn setPrivateKey(self: *Self, keydata_ascii: []const u8) MisshodError!void {
@@ -555,10 +574,18 @@ pub const Session = struct {
                 const cookie = try rdr.readBytes(16);
                 TRACEDUMP(.Debug, "cookie", .{}, cookie);
 
-                // RFC 4253 §7.1 - validate peer supports our algorithms
+                const kex_namelist = try rdr.readU32LenString();
+                if (!nameListContains(kex_namelist, Protocol.kex_algo_name)) {
+                    TRACE(.Info, "No mutual algorithm for kex_algorithms: peer offers '{s}', we need '{s}'", .{ kex_namelist, Protocol.kex_algo_name });
+                    return IoError.AlgorithmNegotiationFailed;
+                }
+                const hostkey_namelist = try rdr.readU32LenString();
+                self.selected_hostkey_algorithm = Key.selectHostKeyAlgorithm(hostkey_namelist, &self.host_private_key) orelse {
+                    TRACE(.Info, "No mutual algorithm for server_host_key_algorithms: peer offers '{s}', we can use '{s}'", .{ hostkey_namelist, self.host_private_key.hostKeyAlgorithms() });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
+
                 const required_algos = [_]struct { name: []const u8, required: []const u8 }{
-                    .{ .name = "kex_algorithms", .required = Protocol.kex_algo_name },
-                    .{ .name = "server_host_key_algorithms", .required = Protocol.srv_hostkey_algo_name },
                     .{ .name = "encryption_algorithms_client_to_server", .required = Protocol.enc_algo_name },
                     .{ .name = "encryption_algorithms_server_to_client", .required = Protocol.enc_algo_name },
                     .{ .name = "mac_algorithms_client_to_server", .required = Protocol.mac_algo_name },
@@ -592,7 +619,7 @@ pub const Session = struct {
             @intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_INIT) => {
                 if (self.sessionState == .EcdhInitRead) {
                     const q_c = try rdr.readU32LenString();
-                    if (q_c.len != Protocol.srv_hostkey_algo.PublicKey.encoded_length) {
+                    if (q_c.len != Protocol.kex_algo.public_length) {
                         // client may have sent a hopeful q_c for wrong algo
                         // go read another packet
                         self.setIoSessionState(.ReadPktHdr);
@@ -666,38 +693,41 @@ pub const Session = struct {
 
                         TRACE(.Debug, "forreal={any} algoname={s} typed_pubkey len={d}", .{forreal, algoname, typed_pubkey.len});
 
-                        // extract raw pubkey
-                        var nb = util.NamedBlob.init(typed_pubkey);
-                        const rawpubkey = try nb.getBlob();
-
-                        // stash pubkey for AuthPkAllowed
-                        if (rawpubkey.len != Protocol.srv_hostkey_algo.PublicKey.encoded_length) {
+                        const auth_alg = Key.SignatureAlgorithm.fromName(algoname) orelse {
+                            self.setSessionState(.UserPasswordAuthDenied);
+                            self.setIoSessionState(.Idle);
+                            return;
+                        };
+                        const pubkey = Key.parsePublicKeyBlob(typed_pubkey) catch {
+                            self.setSessionState(.UserPasswordAuthDenied);
+                            self.setIoSessionState(.Idle);
+                            return;
+                        };
+                        if (auth_alg.keyAlgorithm() != pubkey.algorithm()) {
                             self.setSessionState(.UserPasswordAuthDenied);
                             self.setIoSessionState(.Idle);
                             return;
                         }
-                        @memcpy(&self.auth_pubkey_attempted, rawpubkey);
+                        try self.auth_pubkey_attempted.set(typed_pubkey);
+                        self.auth_pubkey_algorithm = auth_alg;
 
                         if (!forreal) {
                             self.setSessionState(.AuthPkAllowed);
                             self.setIoSessionState(.Idle);
                         } else {
-                            if (!std.mem.eql(u8, algoname, Protocol.srv_hostkey_algo_name)) {
+                            const typedsig = try rdr.readU32LenString();
+                            const sig_alg = Key.signatureAlgorithm(typedsig) catch {
+                                self.setSessionState(.UserPasswordAuthDenied);
+                                self.setIoSessionState(.Idle);
+                                return;
+                            };
+                            if (sig_alg != auth_alg) {
                                 self.setSessionState(.UserPasswordAuthDenied);
                                 self.setIoSessionState(.Idle);
                                 return;
                             }
 
-                            const pubkey = try Protocol.srv_hostkey_algo.PublicKey.fromBytes(rawpubkey[0..Protocol.srv_hostkey_algo.PublicKey.encoded_length].*);
-                            const typedsig = try rdr.readU32LenString();
-
-                            // extract raw sig bytes
-                            var nbsig = util.NamedBlob.init(typedsig);
-                            const rawsig = try nbsig.getBlob();
-
-                            const sig = Protocol.srv_hostkey_algo.Signature.fromBytes(rawsig[0..Protocol.srv_hostkey_algo.Signature.encoded_length].*);
-
-                            var backing_sigbuffer_buf: [512]u8 = undefined;
+                            var backing_sigbuffer_buf: [1024]u8 = undefined;
                             var sigbuffer = BufferWriter.init(&backing_sigbuffer_buf, 0);
                             try sigbuffer.writeU32LenString(&self.session_id);
                             try sigbuffer.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
@@ -705,15 +735,13 @@ pub const Session = struct {
                             try sigbuffer.writeU32LenString("ssh-connection");
                             try sigbuffer.writeU32LenString("publickey");
                             try sigbuffer.writeBoolean(true);
-                            try sigbuffer.writeU32LenString(Protocol.srv_hostkey_algo_name);
+                            try sigbuffer.writeU32LenString(algoname);
                             try sigbuffer.writeU32LenString(typed_pubkey);
 
                             TRACEDUMP(.Debug, "typed_pubkey", .{}, typed_pubkey);
-                            TRACEDUMP(.Debug, "rawpubkey", .{}, rawpubkey);
-                            TRACEDUMP(.Debug, "rawsig", .{}, rawsig);
 
                             // verify sig, as provided by user
-                            sig.verify(sigbuffer.payload, pubkey) catch {
+                            Key.verifySignature(pubkey, typedsig, sigbuffer.payload) catch {
                                 TRACE(.Info, "pubkey sig verify failed", .{});
                                 self.setSessionState(.UserPasswordAuthDenied);
                                 self.setIoSessionState(.Idle);
@@ -724,7 +752,7 @@ pub const Session = struct {
                             self.setSessionState(.CheckUserPasswordAuth);
                             misshod.requestEvent(.{ .UserAuth = .{
                                 .username = username,
-                                .auth = .{.Pubkey = typed_pubkey},
+                                .auth = .{ .Pubkey = .{ .algorithm = algoname, .blob = typed_pubkey } },
                             } }, .Idle);
                         }
                     } else if (std.mem.eql(u8, authtyp, "none")) {
@@ -756,11 +784,11 @@ pub const Session = struct {
                 const peer_window = try rdr.readU32();
                 const max_packet_size = try rdr.readU32();
 
-                if (!std.mem.eql(u8, chantype, "session")) {
+                if (!std.mem.eql(u8, chantype, Protocol.channel_type_session)) {
                     return IoError.UnimplementedService;
                 }
 
-                if (self.channel_table.allocChannel(remote_id, peer_window, max_packet_size)) |chan| {
+                if (self.channel_table.allocChannelKind(.Session, remote_id, peer_window, max_packet_size)) |chan| {
                     chan.state = .ConfirmWrite;
                     self.active_channel_id = chan.local_id;
                 } else {
@@ -777,6 +805,43 @@ pub const Session = struct {
 
                 self.setSessionState(.ChannelActive);
                 self.setIoSessionState(.Idle);
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION) => {
+                const recipient = try rdr.readU32();
+                const sender = try rdr.readU32();
+                const peer_window = try rdr.readU32();
+                const max_packet_size = try rdr.readU32();
+                if (self.channel_table.findByLocalId(recipient)) |chan| {
+                    if (chan.kind != .AgentForward or chan.state != .OpenSent) {
+                        return IoError.UnexpectedResponse;
+                    }
+                    chan.remote_id = sender;
+                    chan.peer_window = peer_window;
+                    chan.remote_max_packet_size = max_packet_size;
+                    chan.state = .Data;
+                    self.active_channel_id = null;
+                    self.setSessionState(.ChannelActive);
+                    misshod.requestEvent(.{ .AgentChannelOpen = chan.local_id }, .ReadPktHdr);
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
+            },
+            @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE) => {
+                const recipient = try rdr.readU32();
+                _ = try rdr.readU32(); // reason code
+                _ = try rdr.readU32LenString(); // description
+                _ = try rdr.readU32LenString(); // language tag
+                if (self.channel_table.findByLocalId(recipient)) |chan| {
+                    if (chan.kind == .AgentForward and chan.state == .OpenSent) {
+                        const local_id = chan.local_id;
+                        self.channel_table.freeChannel(chan.local_id);
+                        self.active_channel_id = null;
+                        misshod.requestEvent(.{ .AgentChannelClosed = local_id }, .ReadPktHdr);
+                        return;
+                    }
+                }
+                self.active_channel_id = null;
+                self.setIoSessionState(.ReadPktHdr);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST) => {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-6.2
@@ -818,6 +883,9 @@ pub const Session = struct {
                     const name = try rdr.readU32LenString();
                     const value = try rdr.readU32LenString();
                     misshod.requestEvent(.{ .ChannelRequest = .{ .channel = chan.local_id, .request = .{ .Env = .{ .name = name, .value = value } } } }, .Idle);
+                    if (!wantreply) return;
+                } else if (std.mem.eql(u8, typ, Protocol.channel_request_auth_agent)) {
+                    misshod.requestEvent(.{ .ChannelRequest = .{ .channel = chan.local_id, .request = .AgentForward } }, .Idle);
                     if (!wantreply) return;
                 } else if (std.mem.eql(u8, typ, "window-change")) {
                     // RFC 4254 §6.7
@@ -926,12 +994,19 @@ pub const Session = struct {
                 };
                 chan.close_received = true;
                 if (chan.close_sent) {
-                    self.channel_table.freeChannel(chan.local_id);
-                    self.active_channel_id = null;
-                    if (self.channel_table.activeCount() == 0) {
-                        misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                    if (chan.kind == .AgentForward) {
+                        self.active_channel_id = chan.local_id;
+                        chan.state = .Closed;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
                     } else {
-                        self.setIoSessionState(.ReadPktHdr);
+                        self.channel_table.freeChannel(chan.local_id);
+                        self.active_channel_id = null;
+                        if (self.channel_table.activeCount() == 0) {
+                            misshod.requestEvent(.{ .EndSession = .Disconnect }, .Idle);
+                        } else {
+                            self.setIoSessionState(.ReadPktHdr);
+                        }
                     }
                 } else {
                     self.active_channel_id = chan.local_id;
@@ -983,4 +1058,140 @@ fn nameListContains(namelist: []const u8, target: []const u8) bool {
         if (std.mem.eql(u8, name, target)) return true;
     }
     return false;
+}
+
+fn buildUnencryptedPacket(buf: []u8, payload: []const u8) usize {
+    const padding_length: u8 = 8;
+    const packet_length: u32 = @intCast(payload.len + padding_length + 1);
+    var hdr: Protocol.PktHdr = .{
+        .packet_length = packet_length,
+        .padding_length = padding_length,
+    };
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
+    }
+    @memcpy(buf[0..Protocol.sizeof_PktHdr], util.asPackedBytes(Protocol.PktHdr, &hdr));
+    @memcpy(buf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload.len], payload);
+    @memset(buf[Protocol.sizeof_PktHdr + payload.len .. Protocol.sizeof_PktHdr + payload.len + padding_length], 0);
+    return Protocol.sizeof_PktHdr + payload.len + padding_length;
+}
+
+test "handlePacket: auth-agent request surfaces channel request event" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannelKind(.Session, 100, 32768, 32768).?;
+    chan.state = .DataRx;
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_REQUEST));
+    try pw.writeU32(chan.local_id);
+    try pw.writeU32LenString(Protocol.channel_request_auth_agent);
+    try pw.writeBoolean(false);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ChannelRequest => |request| {
+                try std.testing.expectEqual(chan.local_id, request.channel);
+                switch (request.request) {
+                    .AgentForward => {},
+                    else => return error.TestUnexpectedResult,
+                }
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "openAgentChannel sends an agent channel open" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const channel_id = try m.openAgentChannel();
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expectEqual(.AgentForward, chan.kind);
+    try std.testing.expectEqual(ChannelState.OpenSent, chan.state);
+    try std.testing.expect(m.iostate_wr != .Idle);
+}
+
+test "handlePacket: agent channel open confirmation activates server channel" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const channel_id = try m.session.openAgentChannel();
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    chan.state = .OpenSent;
+
+    var payload_backing: [64]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try pw.writeU32(channel_id);
+    try pw.writeU32(77);
+    try pw.writeU32(32768);
+    try pw.writeU32(32768);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try std.testing.expectEqual(@as(u32, 77), chan.remote_id);
+    try std.testing.expectEqual(@as(u32, 32768), chan.peer_window);
+    try std.testing.expectEqual(ChannelState.Data, chan.state);
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .AgentChannelOpen => |id| try std.testing.expectEqual(channel_id, id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "handlePacket: agent channel open failure emits close event" {
+    const privkey = @import("privkey.zig");
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), privkey.testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const channel_id = try m.session.openAgentChannel();
+    const chan = m.session.channel_table.findByLocalId(channel_id).?;
+    chan.state = .OpenSent;
+
+    var payload_backing: [128]u8 = undefined;
+    var pw = BufferWriter.init(&payload_backing, 0);
+    try pw.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_FAILURE));
+    try pw.writeU32(channel_id);
+    try pw.writeU32(1);
+    try pw.writeU32LenString("rejected");
+    try pw.writeU32LenString("");
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, pw.payload);
+    m.session.encrypted = false;
+
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try std.testing.expect(m.session.channel_table.findByLocalId(channel_id) == null);
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .AgentChannelClosed => |id| try std.testing.expectEqual(channel_id, id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -9,4 +9,5 @@ comptime {
     _ = @import("protocol.zig");
     _ = @import("misshod.zig");
     _ = @import("channel.zig");
+    _ = @import("key.zig");
 }


### PR DESCRIPTION
## Summary
- Add opt-in SSH agent forwarding support, including agent channel handling and `mssh -A/--agent-forward` bridging to `SSH_AUTH_SOCK`.
- Add algorithm-aware key/signature support for Ed25519, ECDSA P-256, and RSA SHA-2 host/user keys.
- Update examples for Zig 0.16 compatibility and the new public-key identity API.

## Validation
- `zig build test`
- `cd mssh && zig build`
- `cd msshd && zig build`

Resolves #16
Resolves #6
