### PR TITLE
Support delayed zlib compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ It aims to be:
 
  - Public key auth
  - Password auth
- - Supports exactly one of each of the required protocols
+ - Supports a focused set of SSH transport algorithms
     - hmac-sha2-256 (hmac)
     - curve25519-sha256 (key exchange)
     - ssh-ed25519 (key)
     - aes256-ctr (cipher)
+    - zlib@openssh.com (delayed compression)
 
 # Building
 
-MiSSHod requires [Zig 0.16.0](https://ziglang.org/download/).
+MiSSHod requires [Zig 0.16.0](https://ziglang.org/download/) and system zlib.
 
 ## Client
 

--- a/build.zig
+++ b/build.zig
@@ -17,14 +17,19 @@ pub fn build(b: *std.Build) void {
 
     const mod = b.addModule("misshod", .{
         .root_source_file = b.path("src/misshod.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
     });
-    _ = mod;
+    mod.linkSystemLibrary("z", .{});
 
     const test_mod = b.createModule(.{
         .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
+    test_mod.linkSystemLibrary("z", .{});
 
     const lib_tests = b.addTest(.{
         .root_module = test_mod,

--- a/mssh/build.zig
+++ b/mssh/build.zig
@@ -22,6 +22,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    exe_mod.linkSystemLibrary("z", .{});
 
     const misshod_dep = b.dependency("misshod", .{
         .target = target,

--- a/msshd/build.zig
+++ b/msshd/build.zig
@@ -22,6 +22,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    exe_mod.linkSystemLibrary("z", .{});
 
     const misshod_dep = b.dependency("misshod", .{
         .target = target,

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -178,6 +178,11 @@ pub const Session = struct {
         return self.allocateClientChannel(mode, .Session, .{});
     }
 
+    fn activateDelayedCompression(self: *Self) MisshodError!void {
+        try self.keydata.c2s.compression.activateDeflate();
+        try self.keydata.s2c.compression.activateInflate();
+    }
+
     pub fn advanceSession(self: *Self, misshod: *MisshodClient) MisshodError!void {
         const outkeys = &self.keydata.c2s;
 
@@ -198,8 +203,8 @@ pub const Session = struct {
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc s2c
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac c2s
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac s2c
-                try pkt.writeU32LenString("none"); // compression c2s
-                try pkt.writeU32LenString("none"); // compression s2c
+                try pkt.writeU32LenString(Protocol.compression_algorithms); // compression c2s
+                try pkt.writeU32LenString(Protocol.compression_algorithms); // compression s2c
                 try pkt.writeU32LenString(""); // lang c2s
                 try pkt.writeU32LenString(""); // lang s2c
 
@@ -265,7 +270,12 @@ pub const Session = struct {
                 // https://datatracker.ietf.org/doc/html/rfc4253#section-7.2
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.keydata.c2s.compression.applyPendingAlgorithm();
+                if (self.is_rekeying) {
+                    try self.keydata.c2s.compression.activateDeflate();
+                }
+                misshod.requestWrite(wrapped, .Idle);
                 if (self.is_rekeying) {
                     self.is_rekeying = false;
                     self.setSessionState(.ChannelActive);
@@ -1148,10 +1158,21 @@ pub const Session = struct {
                     }
                 }
 
-                // skip remaining lists (compression, languages) - we accept any
-                for (0..4) |_| {
-                    _ = try rdr.readU32LenString();
-                }
+                const compression_c2s_namelist = try rdr.readU32LenString();
+                const compression_s2c_namelist = try rdr.readU32LenString();
+                const compression_c2s = Protocol.selectCompressionAlgorithm(Protocol.compression_algorithms, compression_c2s_namelist) orelse {
+                    TRACE(.Info, "No mutual algorithm for compression_algorithms_client_to_server: peer offers '{s}', we can use '{s}'", .{ compression_c2s_namelist, Protocol.compression_algorithms });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
+                const compression_s2c = Protocol.selectCompressionAlgorithm(Protocol.compression_algorithms, compression_s2c_namelist) orelse {
+                    TRACE(.Info, "No mutual algorithm for compression_algorithms_server_to_client: peer offers '{s}', we can use '{s}'", .{ compression_s2c_namelist, Protocol.compression_algorithms });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
+                self.keydata.c2s.compression.queueAlgorithm(compression_c2s);
+                self.keydata.s2c.compression.queueAlgorithm(compression_s2c);
+
+                _ = try rdr.readU32LenString(); // language c2s
+                _ = try rdr.readU32LenString(); // language s2c
 
                 const first_kex_packet_follows = try rdr.readBoolean();
                 TRACE(.Debug, "first_kex_packet_follows = {any}\n", .{first_kex_packet_follows});
@@ -1222,6 +1243,10 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS) => {
                 if (self.sessionState == .NewKeysRead) {
+                    self.keydata.s2c.compression.applyPendingAlgorithm();
+                    if (self.is_rekeying) {
+                        try self.keydata.s2c.compression.activateInflate();
+                    }
                     self.setSessionState(.NewKeysWrite);
                     self.setIoSessionState(.Idle);
                 } else {
@@ -1245,6 +1270,7 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS) => {
                 // don't care what state we were in, we've been let in
+                try self.activateDelayedCompression();
                 self.setIoSessionState(.Idle);
                 self.setSessionState(.ChannelOpenReq);
             },

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -277,6 +277,7 @@ pub fn MisshodImpl(role: Role) type {
         // full-duplex: separate read and write buffers
         iobuf_rd: [Protocol.MaxSSHPacket]u8 = undefined,
         iobuf_wr: [Protocol.MaxSSHPacket]u8 = undefined,
+        iobuf_decompressed: [Protocol.MaxPayload]u8 = undefined,
         rd_nbytes: usize,
         rd_off: usize,
         wr_nbytes: usize,
@@ -298,6 +299,7 @@ pub fn MisshodImpl(role: Role) type {
             self.session.deinit();
             std.crypto.secureZero(u8, &self.iobuf_rd);
             std.crypto.secureZero(u8, &self.iobuf_wr);
+            std.crypto.secureZero(u8, &self.iobuf_decompressed);
         }
 
         // for session use
@@ -528,14 +530,20 @@ pub fn MisshodImpl(role: Role) type {
                 // flip bytes
                 std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
             }
-            const payload_len = hdr.packet_length - hdr.padding_length - 1;
+            if (hdr.padding_length < 4 or hdr.packet_length < @as(u32, hdr.padding_length) + 1) {
+                return IoError.InvalidPacketSize;
+            }
+            const payload_len: usize = @intCast(hdr.packet_length - @as(u32, hdr.padding_length) - 1);
+            if (payload_len > Protocol.MaxPayload) return IoError.InvalidPacketSize;
+            const pkt_len = Protocol.sizeof_PktHdr + payload_len + hdr.padding_length;
+            if (pkt_len > iobuf.len) return IoError.InvalidPacketSize;
             const payload = iobuf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 
             if (!self.session.encrypted) {
-                return BufferReader.init(payload);
+                const decompressed = try inkeys.compression.decompressPayload(payload, &self.iobuf_decompressed);
+                return BufferReader.init(decompressed);
             } else {
                 TRACEDUMP(.Debug, "all buf", .{}, iobuf);
-                const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
                 if (pkt_len > Protocol.AesCtrT.block_size) { // if there's more to be decrypted after first block
                     const remaining_pkt_bytes = pkt_len - Protocol.AesCtrT.block_size;
                     var dec: [Protocol.MaxSSHPacket]u8 = undefined;
@@ -549,20 +557,20 @@ pub fn MisshodImpl(role: Role) type {
 
                 // verify mac
                 if (iobuf.len < Protocol.mac_algo.key_length) {
-                    return error.InvalidPacketSize; // too small to have a mac
+                    return IoError.InvalidPacketSize; // too small to have a mac
                 }
                 const rxmac = iobuf[pkt_len..iobuf.len]; // at the end
                 var calcmac: [Protocol.mac_algo.key_length]u8 = undefined;
                 var m = Protocol.mac_algo.init(inkeys.mackey[0..Protocol.mac_algo.key_length]);
                 const seq = std.mem.nativeTo(u32, inkeys.seq - 1, .big); // seq has already been incremented
                 m.update(std.mem.asBytes(&seq));
-                m.update(iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]); // plaintext
+                m.update(iobuf[0..pkt_len]); // plaintext
                 m.final(&calcmac);
 
                 TRACEDUMP(.Debug, "rxmac", .{}, rxmac);
                 TRACEDUMP(.Debug, "mackey", .{}, inkeys.mackey[0..Protocol.mac_algo.key_length]);
                 TRACEDUMP(.Debug, "macseq", .{}, std.mem.asBytes(&seq));
-                TRACEDUMP(.Debug, "macdata", .{}, iobuf[0 .. iobuf.len - Protocol.mac_algo.key_length]);
+                TRACEDUMP(.Debug, "macdata", .{}, iobuf[0..pkt_len]);
                 TRACEDUMP(.Debug, "calcmac", .{}, std.mem.asBytes(&calcmac));
 
                 if (!std.mem.eql(u8, &calcmac, rxmac)) {
@@ -570,7 +578,9 @@ pub fn MisshodImpl(role: Role) type {
                 }
 
                 // remove mac and return buffer containing just plaintext payload
-                return BufferReader.init(iobuf[Protocol.sizeof_PktHdr .. iobuf.len - Protocol.mac_algo.key_length]);
+                const decrypted_payload = iobuf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
+                const decompressed = try inkeys.compression.decompressPayload(decrypted_payload, &self.iobuf_decompressed);
+                return BufferReader.init(decompressed);
             }
         }
 
@@ -650,13 +660,19 @@ pub fn MisshodImpl(role: Role) type {
                         }
 
                         // padding len is such that payload_len + sizeof(hdr) + padding = block size
-                        const payload_len = hdr.packet_length - (hdr.padding_length + 1);
+                        if (hdr.packet_length < @as(u32, hdr.padding_length) + 1) {
+                            return IoError.InvalidPacketSize;
+                        }
+                        const payload_len: usize = @intCast(hdr.packet_length - (@as(u32, hdr.padding_length) + 1));
                         if (hdr.padding_length < 4) {
+                            return IoError.InvalidPacketSize;
+                        }
+                        if (payload_len > Protocol.MaxPayload) {
                             return IoError.InvalidPacketSize;
                         }
                         const pkt_len = payload_len + (Protocol.sizeof_PktHdr) + hdr.padding_length;
                         // avoid reading obviously bad packet sizes
-                        if (pkt_len < 8 or pkt_len > Protocol.MaxSSHPacket) {
+                        if (pkt_len < 8 or pkt_len > Protocol.MaxSSHPacket or pkt_len % Protocol.AesCtrT.block_size != 0) {
                             TRACE(.Info, "Bad pkt size {d}\n", .{pkt_len});
                             return IoError.InvalidPacketSize;
                         }
@@ -681,8 +697,11 @@ pub fn MisshodImpl(role: Role) type {
 
                         TRACE(.Debug, ".ReadPktBody hdr={any}", .{hdr});
                         // read in payload
-                        const payload_len = hdr.packet_length - hdr.padding_length - 1;
-                        std.debug.assert(payload_len <= Protocol.MaxPayload);
+                        if (hdr.padding_length < 4 or hdr.packet_length < @as(u32, hdr.padding_length) + 1) {
+                            return IoError.InvalidPacketSize;
+                        }
+                        const payload_len: usize = @intCast(hdr.packet_length - @as(u32, hdr.padding_length) - 1);
+                        if (payload_len > Protocol.MaxPayload) return IoError.InvalidPacketSize;
 
                         self.requestRead(buf.len, payload_len + hdr.padding_length, .{ .ReadPktCompletion = self.iobuf_rd[0 .. buf.len + payload_len + hdr.padding_length] });
                         inkeys.seq +%= 1;
@@ -1760,6 +1779,14 @@ test "full handshake round-trip then channel data exchange" {
     try std.testing.expect(connected_client);
     try std.testing.expect(connected_server);
     try std.testing.expect(client_rx_data);
+    try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, client.session.keydata.c2s.compression.algorithm);
+    try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, client.session.keydata.s2c.compression.algorithm);
+    try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, server.session.keydata.c2s.compression.algorithm);
+    try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, server.session.keydata.s2c.compression.algorithm);
+    try std.testing.expect(client.session.keydata.c2s.compression.active);
+    try std.testing.expect(client.session.keydata.s2c.compression.active);
+    try std.testing.expect(server.session.keydata.c2s.compression.active);
+    try std.testing.expect(server.session.keydata.s2c.compression.active);
 }
 
 test "client channelWriteComplete uses direct write when read is active" {

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -13,6 +13,9 @@ const Hasher = @import("hasher.zig").Hasher;
 const AesCtr = @import("aesctr.zig").AesCtr;
 const decodePrivKey = @import("privkey.zig").decodePrivKey;
 const PrivKeyError = @import("privkey.zig").PrivKeyError;
+const zlib = @cImport({
+    @cInclude("zlib.h");
+});
 
 pub const CommDir = enum {
     ClientToServer,
@@ -111,6 +114,10 @@ pub const enc_algo = std.crypto.core.aes.Aes256;
 pub const enc_algo_name = "aes256-ctr";
 pub const AesCtrT = AesCtr(enc_algo);
 
+pub const compression_none = "none";
+pub const compression_zlib_openssh = "zlib@openssh.com";
+pub const compression_algorithms = compression_zlib_openssh ++ "," ++ compression_none;
+
 pub const channel_type_session = "session";
 pub const channel_type_auth_agent_openssh = "auth-agent@openssh.com";
 pub const channel_type_auth_agent = "auth-agent";
@@ -134,12 +141,185 @@ pub const IoSessionState = union(enum) {
     ReadPktCompletion: []const u8,
 };
 
+pub const CompressionAlgorithm = enum {
+    None,
+    ZlibOpenSsh,
+
+    pub fn name(self: CompressionAlgorithm) []const u8 {
+        return switch (self) {
+            .None => compression_none,
+            .ZlibOpenSsh => compression_zlib_openssh,
+        };
+    }
+
+    pub fn fromName(name_bytes: []const u8) ?CompressionAlgorithm {
+        if (std.mem.eql(u8, name_bytes, compression_none)) return .None;
+        if (std.mem.eql(u8, name_bytes, compression_zlib_openssh)) return .ZlibOpenSsh;
+        return null;
+    }
+};
+
+pub fn selectCompressionAlgorithm(client_namelist: []const u8, server_namelist: []const u8) ?CompressionAlgorithm {
+    var client_iter = util.NameListTokenizer.init(client_namelist);
+    while (client_iter.next()) |client_name| {
+        const algorithm = CompressionAlgorithm.fromName(client_name) orelse continue;
+        var server_iter = util.NameListTokenizer.init(server_namelist);
+        while (server_iter.next()) |server_name| {
+            if (std.mem.eql(u8, client_name, server_name)) return algorithm;
+        }
+    }
+    return null;
+}
+
+pub const CompressionState = struct {
+    const Self = @This();
+
+    algorithm: CompressionAlgorithm = .None,
+    pending_algorithm: ?CompressionAlgorithm = null,
+    active: bool = false,
+    deflate_initialized: bool = false,
+    inflate_initialized: bool = false,
+    deflate_stream: zlib.z_stream = std.mem.zeroes(zlib.z_stream),
+    inflate_stream: zlib.z_stream = std.mem.zeroes(zlib.z_stream),
+
+    pub fn queueAlgorithm(self: *Self, algorithm: CompressionAlgorithm) void {
+        self.pending_algorithm = algorithm;
+    }
+
+    pub fn applyPendingAlgorithm(self: *Self) void {
+        if (self.pending_algorithm) |algorithm| {
+            self.endStreams();
+            self.algorithm = algorithm;
+            self.active = false;
+            self.pending_algorithm = null;
+        }
+    }
+
+    pub fn activateDeflate(self: *Self) MisshodError!void {
+        switch (self.algorithm) {
+            .None => {},
+            .ZlibOpenSsh => {
+                if (!self.deflate_initialized) {
+                    try self.initDeflate();
+                }
+                self.active = true;
+            },
+        }
+    }
+
+    pub fn activateInflate(self: *Self) MisshodError!void {
+        switch (self.algorithm) {
+            .None => {},
+            .ZlibOpenSsh => {
+                if (!self.inflate_initialized) {
+                    try self.initInflate();
+                }
+                self.active = true;
+            },
+        }
+    }
+
+    pub fn compressPayload(self: *Self, input: []const u8, output: []u8) MisshodError![]const u8 {
+        if (!self.active or self.algorithm == .None) return input;
+        if (input.len > MaxPayload or output.len == 0) return IoError.tooBig;
+
+        switch (self.algorithm) {
+            .None => return input,
+            .ZlibOpenSsh => {
+                if (!self.deflate_initialized) {
+                    try self.initDeflate();
+                }
+                self.deflate_stream.next_in = @ptrCast(@constCast(input.ptr));
+                self.deflate_stream.avail_in = @intCast(input.len);
+                self.deflate_stream.next_out = @ptrCast(output.ptr);
+                self.deflate_stream.avail_out = @intCast(output.len);
+
+                const rc = zlib.deflate(&self.deflate_stream, zlib.Z_SYNC_FLUSH);
+                if (rc != zlib.Z_OK) return IoError.UnexpectedResponse;
+                if (self.deflate_stream.avail_in != 0 or self.deflate_stream.avail_out == 0) return IoError.tooBig;
+
+                return output[0 .. output.len - self.deflate_stream.avail_out];
+            },
+        }
+    }
+
+    pub fn decompressPayload(self: *Self, input: []const u8, output: []u8) MisshodError![]const u8 {
+        if (!self.active or self.algorithm == .None) return input;
+        if (output.len == 0) return IoError.tooBig;
+
+        switch (self.algorithm) {
+            .None => return input,
+            .ZlibOpenSsh => {
+                if (!self.inflate_initialized) {
+                    try self.initInflate();
+                }
+                self.inflate_stream.next_in = @ptrCast(@constCast(input.ptr));
+                self.inflate_stream.avail_in = @intCast(input.len);
+                self.inflate_stream.next_out = @ptrCast(output.ptr);
+                self.inflate_stream.avail_out = @intCast(output.len);
+
+                const rc = zlib.inflate(&self.inflate_stream, zlib.Z_SYNC_FLUSH);
+                if (rc != zlib.Z_OK) {
+                    if (rc == zlib.Z_BUF_ERROR and self.inflate_stream.avail_out == 0) return IoError.tooBig;
+                    return IoError.InvalidPacketSize;
+                }
+                if (self.inflate_stream.avail_in != 0) return IoError.tooBig;
+
+                return output[0 .. output.len - self.inflate_stream.avail_out];
+            },
+        }
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.endStreams();
+        self.algorithm = .None;
+        self.pending_algorithm = null;
+        self.active = false;
+    }
+
+    fn initDeflate(self: *Self) MisshodError!void {
+        self.deflate_stream = std.mem.zeroes(zlib.z_stream);
+        const rc = zlib.deflateInit_(&self.deflate_stream, zlib.Z_DEFAULT_COMPRESSION, zlib.ZLIB_VERSION, @sizeOf(zlib.z_stream));
+        if (rc != zlib.Z_OK) return IoError.UnexpectedResponse;
+        self.deflate_initialized = true;
+    }
+
+    fn initInflate(self: *Self) MisshodError!void {
+        self.inflate_stream = std.mem.zeroes(zlib.z_stream);
+        const rc = zlib.inflateInit_(&self.inflate_stream, zlib.ZLIB_VERSION, @sizeOf(zlib.z_stream));
+        if (rc != zlib.Z_OK) return IoError.UnexpectedResponse;
+        self.inflate_initialized = true;
+    }
+
+    fn endStreams(self: *Self) void {
+        if (self.deflate_initialized) {
+            _ = zlib.deflateEnd(&self.deflate_stream);
+            self.deflate_initialized = false;
+        }
+        if (self.inflate_initialized) {
+            _ = zlib.inflateEnd(&self.inflate_stream);
+            self.inflate_initialized = false;
+        }
+        self.deflate_stream = std.mem.zeroes(zlib.z_stream);
+        self.inflate_stream = std.mem.zeroes(zlib.z_stream);
+    }
+};
+
 pub const KeyDataUni = struct {
     iv: [MaxIVLen]u8 = undefined,
     key: [MaxKeyLen]u8 = undefined,
     mackey: [MaxKeyLen]u8 = undefined,
     seq: u32,
     aesctr: AesCtrT = undefined,
+    compression: CompressionState = .{},
+
+    pub fn clear(self: *KeyDataUni) void {
+        std.crypto.secureZero(u8, &self.iv);
+        std.crypto.secureZero(u8, &self.key);
+        std.crypto.secureZero(u8, &self.mackey);
+        self.compression.deinit();
+        self.seq = 0;
+    }
 };
 
 pub const KeyDataBi = struct {
@@ -156,12 +336,8 @@ pub const KeyDataBi = struct {
     }
 
     pub fn clear(self: *Self) void {
-        std.crypto.secureZero(u8, &self.c2s.iv);
-        std.crypto.secureZero(u8, &self.c2s.key);
-        std.crypto.secureZero(u8, &self.c2s.mackey);
-        std.crypto.secureZero(u8, &self.s2c.iv);
-        std.crypto.secureZero(u8, &self.s2c.key);
-        std.crypto.secureZero(u8, &self.s2c.mackey);
+        self.c2s.clear();
+        self.s2c.clear();
     }
 
     // generate session keys from shared secret
@@ -233,13 +409,26 @@ pub const KeyDataBi = struct {
 };
 
 pub fn wrapPkt(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, buffer: *BufferWriter, iobuf: []u8) MisshodError![]const u8 {
+    return wrapPayload(rand, encrypted, keysuni, buffer.active(), iobuf);
+}
+
+pub fn wrapPayload(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, payload: []const u8, iobuf: []u8) MisshodError![]const u8 {
     // https://datatracker.ietf.org/doc/html/rfc4253#section-6
+    if (payload.len > MaxPayload) return IoError.tooBig;
+
+    var compressed_payload_buf: [MaxPayload]u8 = undefined;
+    const packet_payload = try keysuni.compression.compressPayload(payload, &compressed_payload_buf);
+    if (packet_payload.len > MaxPayload) return IoError.tooBig;
+
     // pad such that whole packet (payload + hdr) is multiple of block_size
-    const buffer_len = buffer.active().len;
+    const buffer_len = packet_payload.len;
     var padding_length: u8 = @intCast(AesCtrT.block_size - (buffer_len + sizeof_PktHdr) % AesCtrT.block_size);
     if (padding_length < 4) {
         padding_length += @intCast(AesCtrT.block_size);
     }
+    const packet_len = sizeof_PktHdr + buffer_len + padding_length;
+    if (packet_len > MaxSSHPacket or packet_len > iobuf.len) return IoError.tooBig;
+
     // construct header
     var hdr: PktHdr = .{
         .packet_length = @intCast(buffer_len + padding_length + 1),
@@ -249,45 +438,44 @@ pub fn wrapPkt(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, buffer:
     if (native_endian != .big) {
         std.mem.byteSwapAllFields(PktHdr, &hdr);
     }
-    // insert hdr into hole
-    @memcpy(buffer.payload[0..sizeof_PktHdr], util.asPackedBytes(PktHdr, &hdr));
+    @memcpy(iobuf[0..sizeof_PktHdr], util.asPackedBytes(PktHdr, &hdr));
+    std.mem.copyForwards(u8, iobuf[sizeof_PktHdr .. sizeof_PktHdr + packet_payload.len], packet_payload);
 
-    // append padding, NOTE, will change buffer.payload.len (stored in hdr above)
     var rndbuf: [255]u8 = undefined; // block_size would do
     rand.bytes(rndbuf[0..padding_length]);
-    _ = try buffer.writeBytes(rndbuf[0..padding_length]);
+    @memcpy(iobuf[sizeof_PktHdr + packet_payload.len .. packet_len], rndbuf[0..padding_length]);
 
     if (encrypted) {
+        if (packet_len + mac_algo.key_length > iobuf.len) return IoError.tooBig;
         var out: [MaxSSHPacket]u8 = undefined;
 
-        TRACEDUMP(.Debug, "sendbuffer enc:plaintext", .{}, buffer.payload);
-        keysuni.aesctr.encrypt(buffer.payload, out[0..buffer.payload.len]);
+        TRACEDUMP(.Debug, "sendbuffer enc:plaintext", .{}, iobuf[0..packet_len]);
+        keysuni.aesctr.encrypt(iobuf[0..packet_len], out[0..packet_len]);
 
         var mac: [mac_algo.key_length]u8 = undefined;
         var m = mac_algo.init(keysuni.mackey[0..mac_algo.key_length]);
         const seq = std.mem.nativeTo(u32, keysuni.seq, .big);
         m.update(std.mem.asBytes(&seq));
-        m.update(buffer.payload); // plaintext
+        m.update(iobuf[0..packet_len]); // plaintext
         m.final(&mac);
 
         TRACEDUMP(.Debug, "mackey", .{}, keysuni.mackey[0..mac_algo.key_length]);
         TRACEDUMP(.Debug, "macseq", .{}, std.mem.asBytes(&seq));
-        TRACEDUMP(.Debug, "macdata", .{}, buffer.payload);
+        TRACEDUMP(.Debug, "macdata", .{}, iobuf[0..packet_len]);
 
-        // new bufferwriter, to append mac to out
-        var out_buffer = BufferWriter.init(&out, buffer.payload.len); // append
-        try out_buffer.writeBytes(&mac);
+        @memcpy(out[packet_len .. packet_len + mac_algo.key_length], &mac);
+        const out_len = packet_len + mac_algo.key_length;
 
-        // everything is now encrypted and in out_buffer with mac, copy back to self.writebuf before sending
-        @memcpy(iobuf[0..out_buffer.payload.len], out_buffer.payload);
+        // Copy encrypted packet plus MAC back to the caller's output buffer.
+        @memcpy(iobuf[0..out_len], out[0..out_len]);
 
-        TRACEDUMP(.Debug, "enc send", .{}, iobuf[0..out_buffer.payload.len]);
+        TRACEDUMP(.Debug, "enc send", .{}, iobuf[0..out_len]);
 
         keysuni.seq +%= 1;
-        return iobuf[0..out_buffer.payload.len];
+        return iobuf[0..out_len];
     } else {
         keysuni.seq +%= 1;
-        return iobuf[0..buffer.payload.len];
+        return iobuf[0..packet_len];
     }
 }
 
@@ -324,6 +512,90 @@ test "agent forwarding channel type aliases" {
     try std.testing.expect(isAgentChannelType(channel_type_auth_agent_openssh));
     try std.testing.expect(isAgentChannelType(channel_type_auth_agent));
     try std.testing.expect(!isAgentChannelType(channel_type_session));
+}
+
+test "compression algorithm selection follows client preference" {
+    try std.testing.expectEqual(CompressionAlgorithm.ZlibOpenSsh, selectCompressionAlgorithm(compression_algorithms, compression_algorithms).?);
+    try std.testing.expectEqual(CompressionAlgorithm.None, selectCompressionAlgorithm("none,zlib@openssh.com", compression_algorithms).?);
+    try std.testing.expectEqual(CompressionAlgorithm.None, selectCompressionAlgorithm(compression_algorithms, "none").?);
+    try std.testing.expect(selectCompressionAlgorithm("zstd@openssh.com", compression_algorithms) == null);
+}
+
+test "zlib openssh compression streams round trip flushed packets" {
+    var compressor = CompressionState{ .algorithm = .ZlibOpenSsh };
+    defer compressor.deinit();
+    var decompressor = CompressionState{ .algorithm = .ZlibOpenSsh };
+    defer decompressor.deinit();
+
+    try compressor.activateDeflate();
+    try decompressor.activateInflate();
+
+    var compressed: [MaxPayload]u8 = undefined;
+    var decompressed: [MaxPayload]u8 = undefined;
+
+    const payload1 = "hello hello hello hello hello";
+    const compressed1 = try compressor.compressPayload(payload1, &compressed);
+    const decompressed1 = try decompressor.decompressPayload(compressed1, &decompressed);
+    try std.testing.expectEqualStrings(payload1, decompressed1);
+
+    const payload2 = "second packet reuses the same zlib stream";
+    const compressed2 = try compressor.compressPayload(payload2, &compressed);
+    const decompressed2 = try decompressor.decompressPayload(compressed2, &decompressed);
+    try std.testing.expectEqualStrings(payload2, decompressed2);
+}
+
+test "zlib openssh decompression rejects invalid data" {
+    var decompressor = CompressionState{ .algorithm = .ZlibOpenSsh };
+    defer decompressor.deinit();
+    try decompressor.activateInflate();
+
+    var output: [MaxPayload]u8 = undefined;
+    try std.testing.expectError(IoError.InvalidPacketSize, decompressor.decompressPayload("not a zlib stream", &output));
+}
+
+test "wrapPayload preserves uncompressed payload with none compression" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var keys = KeyDataUni{ .seq = 0 };
+    defer keys.clear();
+    var rand = prng.random();
+
+    var iobuf: [MaxSSHPacket]u8 = undefined;
+    const payload = "plain ssh payload";
+    const packet = try wrapPayload(&rand, false, &keys, payload, &iobuf);
+
+    var hdr = std.mem.bytesAsValue(PktHdr, packet[0..sizeof_PktHdr]).*;
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(PktHdr, &hdr);
+    }
+    const payload_len = hdr.packet_length - hdr.padding_length - 1;
+    try std.testing.expectEqualStrings(payload, packet[sizeof_PktHdr .. sizeof_PktHdr + payload_len]);
+}
+
+test "wrapPayload compresses active zlib openssh payloads" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var sender = KeyDataUni{ .seq = 0, .compression = .{ .algorithm = .ZlibOpenSsh } };
+    defer sender.clear();
+    var receiver = KeyDataUni{ .seq = 0, .compression = .{ .algorithm = .ZlibOpenSsh } };
+    defer receiver.clear();
+    try sender.compression.activateDeflate();
+    try receiver.compression.activateInflate();
+    var rand = prng.random();
+
+    var iobuf: [MaxSSHPacket]u8 = undefined;
+    const payload = "compressed ssh payload compressed ssh payload compressed ssh payload";
+    const packet = try wrapPayload(&rand, false, &sender, payload, &iobuf);
+
+    var hdr = std.mem.bytesAsValue(PktHdr, packet[0..sizeof_PktHdr]).*;
+    if (native_endian != .big) {
+        std.mem.byteSwapAllFields(PktHdr, &hdr);
+    }
+    const compressed_len = hdr.packet_length - hdr.padding_length - 1;
+    const compressed_payload = packet[sizeof_PktHdr .. sizeof_PktHdr + compressed_len];
+    try std.testing.expect(!std.mem.eql(u8, payload, compressed_payload));
+
+    var decompressed: [MaxPayload]u8 = undefined;
+    const restored = try receiver.compression.decompressPayload(compressed_payload, &decompressed);
+    try std.testing.expectEqualStrings(payload, restored);
 }
 
 test "KeyDataBi.clear zeros all key material" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -156,6 +156,11 @@ pub const Session = struct {
         }
     }
 
+    fn activateDelayedCompression(self: *Self) MisshodError!void {
+        try self.keydata.s2c.compression.activateDeflate();
+        try self.keydata.c2s.compression.activateInflate();
+    }
+
     pub fn advanceSession(self: *Self, misshod: *MisshodServer) MisshodError!void {
         const outkeys = &self.keydata.s2c;
 
@@ -179,8 +184,8 @@ pub const Session = struct {
                 try pkt.writeU32LenString(Protocol.enc_algo_name); // enc s2c
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac c2s
                 try pkt.writeU32LenString(Protocol.mac_algo_name); // mac s2c
-                try pkt.writeU32LenString("none"); // compression c2s
-                try pkt.writeU32LenString("none"); // compression s2c
+                try pkt.writeU32LenString(Protocol.compression_algorithms); // compression c2s
+                try pkt.writeU32LenString(Protocol.compression_algorithms); // compression s2c
                 try pkt.writeU32LenString(""); // lang c2s
                 try pkt.writeU32LenString(""); // lang s2c
 
@@ -254,7 +259,12 @@ pub const Session = struct {
                 // https://datatracker.ietf.org/doc/html/rfc4253#section-7.2
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.keydata.s2c.compression.applyPendingAlgorithm();
+                if (self.is_rekeying) {
+                    try self.keydata.s2c.compression.activateDeflate();
+                }
+                misshod.requestWrite(wrapped, .Idle);
                 self.setSessionState(.NewKeysRead);
             },
             .NewKeysRead => {
@@ -284,8 +294,10 @@ pub const Session = struct {
             .UserAuthAccepted => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS));
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                try self.activateDelayedCompression();
                 self.setSessionState(.Authenticated);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                misshod.requestWrite(wrapped, .Idle);
             },
             .AuthPkAllowed => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
@@ -953,10 +965,21 @@ pub const Session = struct {
                     }
                 }
 
-                // skip remaining lists (compression, languages)
-                for (0..4) |_| {
-                    _ = try rdr.readU32LenString();
-                }
+                const compression_c2s_namelist = try rdr.readU32LenString();
+                const compression_s2c_namelist = try rdr.readU32LenString();
+                const compression_c2s = Protocol.selectCompressionAlgorithm(compression_c2s_namelist, Protocol.compression_algorithms) orelse {
+                    TRACE(.Info, "No mutual algorithm for compression_algorithms_client_to_server: peer offers '{s}', we can use '{s}'", .{ compression_c2s_namelist, Protocol.compression_algorithms });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
+                const compression_s2c = Protocol.selectCompressionAlgorithm(compression_s2c_namelist, Protocol.compression_algorithms) orelse {
+                    TRACE(.Info, "No mutual algorithm for compression_algorithms_server_to_client: peer offers '{s}', we can use '{s}'", .{ compression_s2c_namelist, Protocol.compression_algorithms });
+                    return IoError.AlgorithmNegotiationFailed;
+                };
+                self.keydata.c2s.compression.queueAlgorithm(compression_c2s);
+                self.keydata.s2c.compression.queueAlgorithm(compression_s2c);
+
+                _ = try rdr.readU32LenString(); // language c2s
+                _ = try rdr.readU32LenString(); // language s2c
 
                 const first_kex_packet_follows = try rdr.readBoolean();
                 TRACE(.Debug, "first_kex_packet_follows = {any}\n", .{first_kex_packet_follows});
@@ -989,6 +1012,10 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS) => {
                 if (self.sessionState == .NewKeysRead) {
+                    self.keydata.c2s.compression.applyPendingAlgorithm();
+                    if (self.is_rekeying) {
+                        try self.keydata.c2s.compression.activateInflate();
+                    }
                     self.encrypted = true;
                     if (self.is_rekeying) {
                         self.is_rekeying = false;


### PR DESCRIPTION
## Summary
- negotiate `zlib@openssh.com` delayed compression with `none` fallback
- compress/decompress at the SSH packet boundary with per-direction state
- link system zlib and document the dependency

Closes #4

## Tests
- `zig build test`
- `zig test src/test.zig -lc -lz`
- `cd mssh && zig build`
- `cd msshd && zig build`