### PR TITLE
Add OpenSSH interop tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,19 @@ jobs:
       - name: Build lib
         run: zig build
         working-directory: misshod
+      - name: Build mssh
+        run: zig build
+        working-directory: misshod/mssh
+      - name: Build msshd
+        run: zig build
+        working-directory: misshod/msshd
+      - name: Install interop dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc libssh-dev openssh-client openssh-server pkg-config
+          sudo mkdir -p /run/sshd
+      - name: Interop test
+        if: runner.os == 'Linux'
+        run: zig build interop
+        working-directory: misshod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,31 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: misshod
-      - name: Setup Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
-        with:
-          version: 0.16.0
-          mirror: https://github.com/ctaggart/zig/releases/download/v0.16.0
+      - name: Install Zig
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="0.16.0"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64) zig_target="x86_64-linux" ;;
+            macOS-ARM64) zig_target="aarch64-macos" ;;
+            macOS-X64) zig_target="x86_64-macos" ;;
+            *)
+              echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}" >&2
+              exit 1
+              ;;
+          esac
+
+          archive="zig-${zig_target}-${version}.tar.xz"
+          zig_dir="${RUNNER_TEMP}/zig-${zig_target}-${version}"
+          curl -fsSL "https://github.com/ctaggart/zig/releases/download/v${version}/${archive}" -o "${RUNNER_TEMP}/${archive}"
+          tar -xf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}"
+          echo "${zig_dir}" >> "${GITHUB_PATH}"
+          "${zig_dir}/zig" version
       - name: Build test
         run: zig build test
         working-directory: misshod
       - name: Build lib
         run: zig build
         working-directory: misshod
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout misshod
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v5
         with:
           path: misshod
       - name: Install Zig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.16.0
+          mirror: https://github.com/ctaggart/zig/releases/download/v0.16.0
       - name: Build test
         run: zig build test
         working-directory: misshod

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .zig-cache/
-.zig-cache/
+zig-out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .zig-cache/
 zig-out/
+*.o
+*.a
+*.so
+*.dylib
+*.dll
+*.lib
+*.pdb

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Login with pubkey auth using a password protected private key ("secretpassword")
 # Same as: ssh -p 2022 testuser@127.0.0.1 -i ../testserver/id_ed25519_passworded
 ```
 
+For non-interactive runs, `mssh` reads optional secrets from `MSSH_AUTH_PASSWORD` and `MSSH_KEY_PASSPHRASE`.
+
 ## Server
 
 `msshd` is a toy ssh server. It handles one connection at a time and echoes back received data with "You said X".
@@ -118,6 +120,16 @@ Connect using `mssh` using password auth (any password matching username will be
 cd mssh
 zig build run -- foo@127.0.0.1 2022
 ```
+
+## Interop tests
+
+Run the opt-in OpenSSH/libssh interoperability suite from the repository root:
+
+```bash
+zig build interop
+```
+
+The runner builds `mssh` and `msshd`, starts an isolated localhost OpenSSH `sshd`, checks `mssh` public-key and encrypted-key auth against it, starts `msshd`, checks OpenSSH `ssh` against it, and can run the libssh probe when requested. Set `MSSH_INTEROP_ENABLE_LIBSSH=1` to run the libssh lane, `MSSH_INTEROP_REQUIRE_LIBSSH=1` to require it, and `MSSH_INTEROP_KEEP_ARTIFACTS=1` to keep logs.
 
 
 # Tiny client example

--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 comptime {
-    const required_zig = "0.14.0-dev.2545+e2e363361";
+    const required_zig = "0.16.0";
     const current_zig = builtin.zig_version;
     const min_zig = std.SemanticVersion.parse(required_zig) catch unreachable;
     if (current_zig.order(min_zig) == .lt) {

--- a/build.zig
+++ b/build.zig
@@ -39,4 +39,10 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_lib_tests.step);
+
+    const interop_cmd = b.addSystemCommand(&.{ "bash", "interop/run.sh" });
+    interop_cmd.step.dependOn(&run_lib_tests.step);
+
+    const interop_step = b.step("interop", "Run OpenSSH/libssh interoperability tests");
+    interop_step.dependOn(&interop_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,18 +1,14 @@
 .{
     .name = .misshod,
     .version = "0.0.1",
-    .minimum_zig_version = "0.14.0",
-    .fingerprint = 0x717071158aa8520c,
+    .fingerprint = 0x7170711567835565,
+    .minimum_zig_version = "0.16.0",
 
-    .dependencies = .{
-    },
+    .dependencies = .{},
 
     .paths = .{
         "build.zig",
         "build.zig.zon",
         "src",
-        // For example...
-        //"LICENSE",
-        //"README.md",
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,6 +9,10 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
+        "interop",
+        "mssh",
+        "msshd",
         "src",
+        "testserver",
     },
 }

--- a/interop/libssh_probe.c
+++ b/interop/libssh_probe.c
@@ -1,0 +1,97 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libssh/libssh.h>
+
+static void die_session(ssh_session session, const char *message) {
+    fprintf(stderr, "%s: %s\n", message, ssh_get_error(session));
+    exit(1);
+}
+
+static void die_channel(ssh_channel channel, const char *message) {
+    fprintf(stderr, "%s: %s\n", message, ssh_get_error(ssh_channel_get_session(channel)));
+    exit(1);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 5) {
+        fprintf(stderr, "usage: %s <host> <port> <user> <password>\n", argv[0]);
+        return 2;
+    }
+
+    const char *host = argv[1];
+    int port = atoi(argv[2]);
+    const char *user = argv[3];
+    const char *password = argv[4];
+    int verbosity = SSH_LOG_NOLOG;
+    long timeout = 5;
+
+    ssh_session session = ssh_new();
+    if (session == NULL) {
+        fprintf(stderr, "ssh_new failed\n");
+        return 1;
+    }
+
+    if (ssh_options_set(session, SSH_OPTIONS_HOST, host) != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_PORT, &port) != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_USER, user) != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity) != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_TIMEOUT, &timeout) != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_KEY_EXCHANGE, "curve25519-sha256") != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_HOSTKEYS, "ssh-ed25519") != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_CIPHERS_C_S, "aes256-ctr") != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_CIPHERS_S_C, "aes256-ctr") != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_HMAC_C_S, "hmac-sha2-256") != SSH_OK ||
+        ssh_options_set(session, SSH_OPTIONS_HMAC_S_C, "hmac-sha2-256") != SSH_OK) {
+        die_session(session, "ssh_options_set failed");
+    }
+
+    if (ssh_connect(session) != SSH_OK) {
+        die_session(session, "ssh_connect failed");
+    }
+
+    if (ssh_userauth_password(session, NULL, password) != SSH_AUTH_SUCCESS) {
+        die_session(session, "ssh_userauth_password failed");
+    }
+
+    ssh_channel channel = ssh_channel_new(session);
+    if (channel == NULL) {
+        die_session(session, "ssh_channel_new failed");
+    }
+
+    if (ssh_channel_open_session(channel) != SSH_OK) {
+        die_channel(channel, "ssh_channel_open_session failed");
+    }
+
+    if (ssh_channel_request_shell(channel) != SSH_OK) {
+        die_channel(channel, "ssh_channel_request_shell failed");
+    }
+
+    const char *payload = "misshod-libssh-probe\n";
+    int written = ssh_channel_write(channel, payload, (uint32_t)strlen(payload));
+    if (written != (int)strlen(payload)) {
+        die_channel(channel, "ssh_channel_write failed");
+    }
+
+    char buffer[512];
+    int received = ssh_channel_read_timeout(channel, buffer, sizeof(buffer) - 1, 0, 5000);
+    if (received <= 0) {
+        die_channel(channel, "ssh_channel_read_timeout failed");
+    }
+    buffer[received] = '\0';
+    fputs(buffer, stdout);
+
+    if (strstr(buffer, "You said 'misshod-libssh-probe") == NULL) {
+        fprintf(stderr, "unexpected response: %s\n", buffer);
+        return 1;
+    }
+
+    ssh_channel_send_eof(channel);
+    ssh_channel_close(channel);
+    ssh_channel_free(channel);
+    ssh_disconnect(session);
+    ssh_free(session);
+    return 0;
+}

--- a/interop/run.sh
+++ b/interop/run.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="${MSSH_INTEROP_ARTIFACTS:-$(mktemp -d "${TMPDIR:-/tmp}/misshod-interop.XXXXXX")}"
+KEEP_ARTIFACTS="${MSSH_INTEROP_KEEP_ARTIFACTS:-}"
+TIMEOUT="${MSSH_INTEROP_TIMEOUT:-25}"
+
+PIDS=()
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    local status=$?
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+
+    if [[ -n "$KEEP_ARTIFACTS" || "$status" -ne 0 ]]; then
+        printf 'interop artifacts: %s\n' "$WORK" >&2
+    else
+        rm -rf "$WORK"
+    fi
+
+    exit "$status"
+}
+trap cleanup EXIT
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+pick_port() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+    else
+        printf '%d\n' "$((30000 + (RANDOM % 20000)))"
+    fi
+}
+
+wait_for_ssh() {
+    local port="$1"
+    local pid="$2"
+    local log_file="$3"
+    local scan_file="$WORK/ssh-keyscan-${port}.out"
+
+    for _ in $(seq 1 80); do
+        if ssh-keyscan -T 1 -p "$port" 127.0.0.1 >"$scan_file" 2>/dev/null && [[ -s "$scan_file" ]]; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            sed -n '1,160p' "$log_file" >&2 || true
+            fail "SSH peer on port $port exited before becoming ready"
+        fi
+        sleep 0.25
+    done
+
+    sed -n '1,160p' "$log_file" >&2 || true
+    fail "timed out waiting for SSH peer on port $port"
+}
+
+wait_for_log() {
+    local pid="$1"
+    local log_file="$2"
+    local text="$3"
+
+    for _ in $(seq 1 80); do
+        if grep -Fq "$text" "$log_file" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            sed -n '1,160p' "$log_file" >&2 || true
+            fail "process exited before writing readiness log: $text"
+        fi
+        sleep 0.25
+    done
+
+    sed -n '1,160p' "$log_file" >&2 || true
+    fail "timed out waiting for readiness log: $text"
+}
+
+wait_with_timeout() {
+    local pid="$1"
+    local timeout="$2"
+    local watchdog status
+    status=0
+
+    (
+        sleep "$timeout"
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    ) &
+    watchdog=$!
+
+    wait "$pid" || status=$?
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+
+    if [[ "$status" -eq 143 || "$status" -eq 137 ]]; then
+        return 124
+    fi
+    return "$status"
+}
+
+run_capture() {
+    local timeout="$1"
+    local out_file="$2"
+    local err_file="$3"
+    shift 3
+
+    "$@" >"$out_file" 2>"$err_file" &
+    local pid=$!
+    wait_with_timeout "$pid" "$timeout"
+}
+
+run_mssh_command() {
+    local timeout="$1"
+    local out_file="$2"
+    local err_file="$3"
+    local command="$4"
+    shift 4
+
+    (
+        printf '%s\nexit\n' "$command" | "$@"
+    ) >"$out_file" 2>"$err_file" &
+    local pid=$!
+    wait_with_timeout "$pid" "$timeout"
+}
+
+assert_contains() {
+    local file="$1"
+    local text="$2"
+    grep -Fq "$text" "$file" || {
+        printf 'expected %s to contain: %s\n' "$file" "$text" >&2
+        sed -n '1,160p' "$file" >&2 || true
+        return 1
+    }
+}
+
+assert_matches() {
+    local file="$1"
+    local pattern="$2"
+    grep -Eq "$pattern" "$file" || {
+        printf 'expected %s to match: %s\n' "$file" "$pattern" >&2
+        sed -n '1,200p' "$file" >&2 || true
+        return 1
+    }
+}
+
+require_cmd zig
+require_cmd ssh
+require_cmd sshd
+require_cmd ssh-keygen
+require_cmd ssh-keyscan
+
+mkdir -p "$WORK"
+
+SSHD_BIN="$(command -v sshd)"
+SSH_BIN="$(command -v ssh)"
+USER_NAME="${MSSH_INTEROP_USER:-$(id -un)}"
+HOST="127.0.0.1"
+KEY_PASSWORDLESS="$ROOT/testserver/id_ed25519_passwordless"
+KEY_ENCRYPTED="$ROOT/testserver/id_ed25519_passworded"
+KEY_PASSPHRASE="${MSSH_INTEROP_KEY_PASSPHRASE:-secretpassword}"
+OPENSSH_PASSWORD="${MSSH_INTEROP_OPENSSH_PASSWORD:-}"
+
+log "building mssh and msshd"
+(cd "$ROOT/mssh" && zig build)
+(cd "$ROOT/msshd" && zig build)
+
+MSSH_BIN="$ROOT/mssh/zig-out/bin/mssh"
+MSSHD_BIN="$ROOT/msshd/zig-out/bin/msshd"
+[[ -x "$MSSH_BIN" ]] || fail "missing built mssh binary"
+[[ -x "$MSSHD_BIN" ]] || fail "missing built msshd binary"
+
+log "starting isolated OpenSSH sshd"
+OPENSSH_DIR="$WORK/openssh-sshd"
+mkdir -p "$OPENSSH_DIR"
+chmod 700 "$OPENSSH_DIR"
+ssh-keygen -q -t ed25519 -N '' -f "$OPENSSH_DIR/ssh_host_ed25519_key"
+cat "$KEY_PASSWORDLESS.pub" "$KEY_ENCRYPTED.pub" >"$OPENSSH_DIR/authorized_keys"
+chmod 600 "$OPENSSH_DIR/authorized_keys"
+
+OPENSSH_PORT="$(pick_port)"
+OPENSSH_PASSWORD_AUTH="no"
+if [[ -n "$OPENSSH_PASSWORD" ]]; then
+    OPENSSH_PASSWORD_AUTH="yes"
+fi
+
+cat >"$OPENSSH_DIR/sshd_config" <<EOF
+Port $OPENSSH_PORT
+ListenAddress $HOST
+Protocol 2
+HostKey $OPENSSH_DIR/ssh_host_ed25519_key
+PidFile $OPENSSH_DIR/sshd.pid
+AuthorizedKeysFile $OPENSSH_DIR/authorized_keys
+AllowUsers $USER_NAME
+StrictModes no
+PubkeyAuthentication yes
+PasswordAuthentication $OPENSSH_PASSWORD_AUTH
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+UsePAM no
+PermitRootLogin no
+PermitTTY yes
+PrintMotd no
+PrintLastLog no
+LogLevel DEBUG3
+KexAlgorithms curve25519-sha256
+HostKeyAlgorithms ssh-ed25519
+PubkeyAcceptedAlgorithms ssh-ed25519
+Ciphers aes256-ctr
+MACs hmac-sha2-256
+Subsystem sftp internal-sftp
+EOF
+
+"$SSHD_BIN" -t -f "$OPENSSH_DIR/sshd_config" >"$OPENSSH_DIR/config-test.out" 2>"$OPENSSH_DIR/config-test.err" || {
+    sed -n '1,120p' "$OPENSSH_DIR/config-test.err" >&2 || true
+    fail "OpenSSH sshd rejected generated config"
+}
+"$SSHD_BIN" -D -e -f "$OPENSSH_DIR/sshd_config" >"$OPENSSH_DIR/sshd.out" 2>"$OPENSSH_DIR/sshd.err" &
+OPENSSH_SSHD_PID=$!
+PIDS+=("$OPENSSH_SSHD_PID")
+wait_for_ssh "$OPENSSH_PORT" "$OPENSSH_SSHD_PID" "$OPENSSH_DIR/sshd.err"
+
+log "testing mssh pubkey auth against OpenSSH sshd"
+run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-pubkey.out" "$WORK/mssh-openssh-pubkey.err" \
+    'printf misshod-openssh-pubkey' \
+    "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT" "$KEY_PASSWORDLESS"
+assert_contains "$WORK/mssh-openssh-pubkey.out" "misshod-openssh-pubkey"
+assert_contains "$WORK/mssh-openssh-pubkey.err" "Connected!"
+
+log "testing mssh encrypted-key auth against OpenSSH sshd"
+run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-encrypted-key.out" "$WORK/mssh-openssh-encrypted-key.err" \
+    'printf misshod-openssh-encrypted-key' \
+    env MSSH_KEY_PASSPHRASE="$KEY_PASSPHRASE" \
+    "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT" "$KEY_ENCRYPTED"
+assert_contains "$WORK/mssh-openssh-encrypted-key.out" "misshod-openssh-encrypted-key"
+
+if [[ -n "$OPENSSH_PASSWORD" ]]; then
+    log "testing mssh password auth against OpenSSH sshd"
+    run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-password.out" "$WORK/mssh-openssh-password.err" \
+        'printf misshod-openssh-password' \
+        env MSSH_AUTH_PASSWORD="$OPENSSH_PASSWORD" \
+        "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT"
+    assert_contains "$WORK/mssh-openssh-password.out" "misshod-openssh-password"
+else
+    log "skipping OpenSSH password-auth lane; set MSSH_INTEROP_OPENSSH_PASSWORD to enable it for the current user"
+fi
+
+log "testing mssh auth failure against OpenSSH sshd"
+if run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-auth-failure.out" "$WORK/mssh-openssh-auth-failure.err" \
+    'printf should-not-run' \
+    env MSSH_AUTH_PASSWORD="definitely-not-the-password" \
+    "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT"; then
+    fail "mssh auth-failure case unexpectedly succeeded"
+fi
+assert_contains "$WORK/mssh-openssh-auth-failure.err" "AuthFailure"
+
+log "starting msshd"
+MSSHD_PORT="$(pick_port)"
+"$MSSHD_BIN" "$MSSHD_PORT" "$KEY_PASSWORDLESS" >"$WORK/msshd.out" 2>"$WORK/msshd.err" &
+MSSHD_PID=$!
+PIDS+=("$MSSHD_PID")
+wait_for_log "$MSSHD_PID" "$WORK/msshd.err" "Server listening on port $MSSHD_PORT"
+
+OPENSSH_CLIENT_KEY="$WORK/openssh-client-id_ed25519"
+cp "$KEY_PASSWORDLESS" "$OPENSSH_CLIENT_KEY"
+chmod 600 "$OPENSSH_CLIENT_KEY"
+
+SSH_COMMON=(
+    -F none
+    -p "$MSSHD_PORT"
+    -o "BatchMode=yes"
+    -o "ConnectTimeout=5"
+    -o "ConnectionAttempts=1"
+    -o "ServerAliveInterval=1"
+    -o "ServerAliveCountMax=5"
+    -o "StrictHostKeyChecking=no"
+    -o "UserKnownHostsFile=$WORK/known_hosts"
+    -o "GlobalKnownHostsFile=/dev/null"
+    -o "IdentitiesOnly=yes"
+    -o "KexAlgorithms=curve25519-sha256"
+    -o "HostKeyAlgorithms=ssh-ed25519"
+    -o "PubkeyAcceptedAlgorithms=ssh-ed25519"
+    -o "Ciphers=aes256-ctr"
+    -o "MACs=hmac-sha2-256"
+    -i "$OPENSSH_CLIENT_KEY"
+)
+
+run_openssh_client_to_msshd() {
+    local out_file="$1"
+    local err_file="$2"
+    shift 2
+
+    (
+        {
+            printf 'misshod-openssh-client\n'
+            sleep 1
+        } | "$SSH_BIN" "$@" "${SSH_COMMON[@]}" "interop@$HOST"
+    ) >"$out_file" 2>"$err_file" &
+    local pid=$!
+    wait_with_timeout "$pid" "$TIMEOUT"
+}
+
+log "testing OpenSSH ssh client against msshd"
+run_openssh_client_to_msshd "$WORK/openssh-msshd.out" "$WORK/openssh-msshd.err"
+assert_contains "$WORK/openssh-msshd.out" "You said 'misshod-openssh-client"
+
+log "checking OpenSSH negotiated algorithms against msshd"
+run_openssh_client_to_msshd "$WORK/openssh-msshd-algorithms.out" "$WORK/openssh-msshd-algorithms.err" -vvv
+assert_matches "$WORK/openssh-msshd-algorithms.err" "kex: algorithm: curve25519-sha256"
+assert_matches "$WORK/openssh-msshd-algorithms.err" "host key algorithm: ssh-ed25519"
+assert_matches "$WORK/openssh-msshd-algorithms.err" "cipher: aes256-ctr.*MAC: hmac-sha2-256"
+
+if [[ "${MSSH_INTEROP_ENABLE_LIBSSH:-}" == "1" || "${MSSH_INTEROP_REQUIRE_LIBSSH:-}" == "1" ]]; then
+    if ! pkg-config --exists libssh 2>/dev/null; then
+        fail "pkg-config could not find libssh"
+    fi
+
+    log "testing libssh client against msshd"
+    cc "$ROOT/interop/libssh_probe.c" -o "$WORK/libssh_probe" $(pkg-config --cflags --libs libssh)
+    if ! run_capture "$TIMEOUT" "$WORK/libssh-msshd.out" "$WORK/libssh-msshd.err" \
+        "$WORK/libssh_probe" "$HOST" "$MSSHD_PORT" "interop" "interop"
+    then
+        sed -n '1,160p' "$WORK/libssh-msshd.err" >&2 || true
+        fail "libssh probe failed"
+    fi
+    assert_contains "$WORK/libssh-msshd.out" "You said 'misshod-libssh-probe"
+else
+    log "skipping libssh lane; set MSSH_INTEROP_ENABLE_LIBSSH=1 to run it or MSSH_INTEROP_REQUIRE_LIBSSH=1 to require it"
+fi
+
+log "interop tests passed"

--- a/interop/run.sh
+++ b/interop/run.sh
@@ -60,7 +60,7 @@ wait_for_ssh() {
     local scan_file="$WORK/ssh-keyscan-${port}.out"
 
     for _ in $(seq 1 80); do
-        if ssh-keyscan -T 1 -p "$port" 127.0.0.1 >"$scan_file" 2>/dev/null && [[ -s "$scan_file" ]]; then
+        if ssh-keyscan -T 1 -t ed25519 -p "$port" 127.0.0.1 >"$scan_file" 2>/dev/null && [[ -s "$scan_file" ]]; then
             return 0
         fi
         if ! kill -0 "$pid" 2>/dev/null; then
@@ -137,7 +137,9 @@ run_mssh_command() {
     shift 4
 
     (
-        printf '%s\nexit\n' "$command" | "$@"
+        if [[ -n "$command" ]]; then
+            printf '%s\nexit\n' "$command"
+        fi | "$@"
     ) >"$out_file" 2>"$err_file" &
     local pid=$!
     wait_with_timeout "$pid" "$timeout"
@@ -221,6 +223,7 @@ PermitRootLogin no
 PermitTTY yes
 PrintMotd no
 PrintLastLog no
+ForceCommand printf misshod-openssh-forced
 LogLevel DEBUG3
 KexAlgorithms curve25519-sha256
 HostKeyAlgorithms ssh-ed25519
@@ -241,32 +244,32 @@ wait_for_ssh "$OPENSSH_PORT" "$OPENSSH_SSHD_PID" "$OPENSSH_DIR/sshd.err"
 
 log "testing mssh pubkey auth against OpenSSH sshd"
 run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-pubkey.out" "$WORK/mssh-openssh-pubkey.err" \
-    'printf misshod-openssh-pubkey' \
+    '' \
     "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT" "$KEY_PASSWORDLESS"
-assert_contains "$WORK/mssh-openssh-pubkey.out" "misshod-openssh-pubkey"
+assert_contains "$WORK/mssh-openssh-pubkey.out" "misshod-openssh-forced"
 assert_contains "$WORK/mssh-openssh-pubkey.err" "Connected!"
 
 log "testing mssh encrypted-key auth against OpenSSH sshd"
 run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-encrypted-key.out" "$WORK/mssh-openssh-encrypted-key.err" \
-    'printf misshod-openssh-encrypted-key' \
+    '' \
     env MSSH_KEY_PASSPHRASE="$KEY_PASSPHRASE" \
     "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT" "$KEY_ENCRYPTED"
-assert_contains "$WORK/mssh-openssh-encrypted-key.out" "misshod-openssh-encrypted-key"
+assert_contains "$WORK/mssh-openssh-encrypted-key.out" "misshod-openssh-forced"
 
 if [[ -n "$OPENSSH_PASSWORD" ]]; then
     log "testing mssh password auth against OpenSSH sshd"
     run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-password.out" "$WORK/mssh-openssh-password.err" \
-        'printf misshod-openssh-password' \
+        '' \
         env MSSH_AUTH_PASSWORD="$OPENSSH_PASSWORD" \
         "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT"
-    assert_contains "$WORK/mssh-openssh-password.out" "misshod-openssh-password"
+    assert_contains "$WORK/mssh-openssh-password.out" "misshod-openssh-forced"
 else
     log "skipping OpenSSH password-auth lane; set MSSH_INTEROP_OPENSSH_PASSWORD to enable it for the current user"
 fi
 
 log "testing mssh auth failure against OpenSSH sshd"
 if run_mssh_command "$TIMEOUT" "$WORK/mssh-openssh-auth-failure.out" "$WORK/mssh-openssh-auth-failure.err" \
-    'printf should-not-run' \
+    '' \
     env MSSH_AUTH_PASSWORD="definitely-not-the-password" \
     "$MSSH_BIN" "$USER_NAME@$HOST" "$OPENSSH_PORT"; then
     fail "mssh auth-failure case unexpectedly succeeded"
@@ -316,18 +319,33 @@ run_openssh_client_to_msshd() {
         } | "$SSH_BIN" "$@" "${SSH_COMMON[@]}" "interop@$HOST"
     ) >"$out_file" 2>"$err_file" &
     local pid=$!
-    wait_with_timeout "$pid" "$TIMEOUT"
+
+    for _ in $(seq 1 "$((TIMEOUT * 4))"); do
+        if grep -Fq "You said 'misshod-openssh-client" "$out_file" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            wait "$pid"
+            return $?
+        fi
+        sleep 0.25
+    done
+
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    return 124
 }
 
 log "testing OpenSSH ssh client against msshd"
-run_openssh_client_to_msshd "$WORK/openssh-msshd.out" "$WORK/openssh-msshd.err"
+run_openssh_client_to_msshd "$WORK/openssh-msshd.out" "$WORK/openssh-msshd.err" -vvv
 assert_contains "$WORK/openssh-msshd.out" "You said 'misshod-openssh-client"
 
 log "checking OpenSSH negotiated algorithms against msshd"
-run_openssh_client_to_msshd "$WORK/openssh-msshd-algorithms.out" "$WORK/openssh-msshd-algorithms.err" -vvv
-assert_matches "$WORK/openssh-msshd-algorithms.err" "kex: algorithm: curve25519-sha256"
-assert_matches "$WORK/openssh-msshd-algorithms.err" "host key algorithm: ssh-ed25519"
-assert_matches "$WORK/openssh-msshd-algorithms.err" "cipher: aes256-ctr.*MAC: hmac-sha2-256"
+assert_matches "$WORK/openssh-msshd.err" "kex: algorithm: curve25519-sha256"
+assert_matches "$WORK/openssh-msshd.err" "host key algorithm: ssh-ed25519"
+assert_matches "$WORK/openssh-msshd.err" "cipher: aes256-ctr.*MAC: hmac-sha2-256"
 
 if [[ "${MSSH_INTEROP_ENABLE_LIBSSH:-}" == "1" || "${MSSH_INTEROP_REQUIRE_LIBSSH:-}" == "1" ]]; then
     if ! pkg-config --exists libssh 2>/dev/null; then

--- a/mssh/src/main.zig
+++ b/mssh/src/main.zig
@@ -24,6 +24,15 @@ fn readPassphrase(password_buf: []u8) ![]u8 {
     }
 }
 
+fn envOrReadPassphrase(init: std.process.Init, name: []const u8, prompt: []const u8, password_buf: []u8) ![]const u8 {
+    if (init.environ_map.get(name)) |value| {
+        return value;
+    }
+
+    std.debug.print("{s}", .{prompt});
+    return try readPassphrase(password_buf);
+}
+
 var original_termios: ?std.posix.termios = null;
 const MaxAgentSockets = 4;
 
@@ -258,6 +267,7 @@ pub fn main(init: std.process.Init) !void {
             var agent_sockets: [MaxAgentSockets]?AgentSocket = .{null} ** MaxAgentSockets;
             defer closeAllAgentSockets(&agent_sockets);
             var quit = false;
+            var exit_code: u8 = 0;
             const stdin_fd = std.c.STDIN_FILENO;
 
             outer: while (!quit) {
@@ -284,6 +294,9 @@ pub fn main(init: std.process.Init) !void {
                             },
                             .EndSession => |reason| {
                                 std.debug.print("Session ended: {any}\n", .{reason});
+                                if (reason == .AuthFailure) {
+                                    exit_code = 1;
+                                }
                                 quit = true;
                                 continue :outer;
                             },
@@ -308,20 +321,17 @@ pub fn main(init: std.process.Init) !void {
                             },
                             .GetKeyPassphrase => {
                                 var password_buf: [128]u8 = undefined;
-                                std.debug.print("Password for private key decrypt: ", .{});
-                                try misshod.setPrivateKeyPassphrase(try readPassphrase(&password_buf));
+                                try misshod.setPrivateKeyPassphrase(try envOrReadPassphrase(init, "MSSH_KEY_PASSPHRASE", "Password for private key decrypt: ", &password_buf));
                                 try misshod.clearEvent(eventCode);
                             },
                             .GetAuthPassphrase => {
                                 var password_buf: [128]u8 = undefined;
-                                std.debug.print("Password for auth: ", .{});
-                                try misshod.setAuthPassphrase(try readPassphrase(&password_buf));
+                                try misshod.setAuthPassphrase(try envOrReadPassphrase(init, "MSSH_AUTH_PASSWORD", "Password for auth: ", &password_buf));
                                 try misshod.clearEvent(eventCode);
                             },
                             .KeyboardInteractive => |prompt| {
                                 var password_buf: [128]u8 = undefined;
-                                std.debug.print("{s}", .{prompt.prompt});
-                                try misshod.session.setKeyboardInteractiveResponse(try readPassphrase(&password_buf));
+                                try misshod.session.setKeyboardInteractiveResponse(try envOrReadPassphrase(init, "MSSH_AUTH_PASSWORD", prompt.prompt, &password_buf));
                                 try misshod.clearEvent(eventCode);
                             },
                             .ChannelOpened,
@@ -463,6 +473,10 @@ pub fn main(init: std.process.Init) !void {
                         }
                     },
                 }
+            }
+
+            if (exit_code != 0) {
+                std.process.exit(exit_code);
             }
         } else {
             std.debug.print("Bad/missing user\n", .{});

--- a/mssh/src/main.zig
+++ b/mssh/src/main.zig
@@ -78,7 +78,9 @@ fn connectAgentSocket(path: []const u8) !std.c.fd_t {
     if (fd < 0) return error.SocketFailed;
     errdefer _ = std.c.close(fd);
 
-    var addr: std.c.sockaddr.un = .{ .family = std.c.AF.UNIX, .path = .{0} ** 108 };
+    var addr: std.c.sockaddr.un = undefined;
+    addr.family = std.c.AF.UNIX;
+    @memset(&addr.path, 0);
     if (path.len >= addr.path.len) return error.NameTooLong;
     @memcpy(addr.path[0..path.len], path);
 
@@ -252,7 +254,7 @@ pub fn main(init: std.process.Init) !void {
 
             // make a reasonable prng
             var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-            if (std.c.getrandom(&seed, seed.len, 0) != seed.len) return error.RandomSeedFailed;
+            try init.io.randomSecure(&seed);
             var prng = std.Random.DefaultCsprng.init(seed);
 
             var misshod = try MisshodClient.init(prng.random(), user, allocator);
@@ -267,16 +269,24 @@ pub fn main(init: std.process.Init) !void {
             var agent_sockets: [MaxAgentSockets]?AgentSocket = .{null} ** MaxAgentSockets;
             defer closeAllAgentSockets(&agent_sockets);
             var quit = false;
+            var connected = false;
             var exit_code: u8 = 0;
             const stdin_fd = std.c.STDIN_FILENO;
 
             outer: while (!quit) {
-                const ev = try misshod.getNextEvent();
+                const ev = misshod.getNextEvent() catch |err| switch (err) {
+                    error.NotReady => {
+                        try init.io.sleep(.fromNanoseconds(1 * std.time.ns_per_ms), .awake);
+                        continue :outer;
+                    },
+                    else => return err,
+                };
                 switch (ev) {
                     .Event => |eventCode| {
                         switch (eventCode) {
                             .Connected => {
                                 std.debug.print("Connected!\n", .{});
+                                connected = true;
                                 try misshod.clearEvent(eventCode);
                                 try raw_mode_start();
                             },
@@ -402,7 +412,7 @@ pub fn main(init: std.process.Init) !void {
                         };
                         fds[1] = .{
                             .fd = stdin_fd,
-                            .events = std.posix.POLL.IN,
+                            .events = if (connected) std.posix.POLL.IN else 0,
                             .revents = undefined,
                         };
                         var fd_count: usize = 2;

--- a/msshd/src/main.zig
+++ b/msshd/src/main.zig
@@ -55,7 +55,7 @@ pub fn main(init: std.process.Init) !void {
 
         // make a reasonable prng
         var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
-        if (std.c.getrandom(&seed, seed.len, 0) != seed.len) return error.RandomSeedFailed;
+        try init.io.randomSecure(&seed);
         var prng = std.Random.DefaultCsprng.init(seed);
 
         var misshod = try MisshodServer.init(prng.random(), hostkey_ascii, allocator);
@@ -63,6 +63,8 @@ pub fn main(init: std.process.Init) !void {
 
         var iobuf: [8]u8 = undefined; // could be any size
         var quit = false;
+        var pending_eof_channel: ?u32 = null;
+        var pending_close_channel: ?u32 = null;
         var pipe: [2]std.c.fd_t = undefined;
         if (std.c.pipe(&pipe) != 0) return error.PipeFailed;
         defer _ = std.c.close(pipe[0]);
@@ -85,6 +87,7 @@ pub fn main(init: std.process.Init) !void {
                             try writeAllFd(pipe[1], response);
 
                             try misshod.clearEvent(eventCode);
+                            pending_eof_channel = rxdata.channel;
                         },
                         .EndSession => |reason| {
                             std.debug.print("Session ended: {any}\n", .{reason});
@@ -196,6 +199,16 @@ pub fn main(init: std.process.Init) !void {
                             const towrite = try misshod.peek(4);
                             const bytes_written = try writeFd(stream.socket.handle, towrite);
                             try misshod.consumed(bytes_written);
+                            if (bytes_written == towrite.len) {
+                                if (pending_eof_channel) |channel| {
+                                    pending_eof_channel = null;
+                                    pending_close_channel = channel;
+                                    try misshod.sendChannelEof(channel);
+                                } else if (pending_close_channel) |channel| {
+                                    pending_close_channel = null;
+                                    try misshod.sendChannelClose(channel);
+                                }
+                            }
                             continue :ioloop;
                         }
                         if (fds[1].revents & std.posix.POLL.IN > 0) { // data to be sent (from pipe)

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -7,7 +7,6 @@ const MisshodClient = Misshod.MisshodClient;
 const MisshodError = Misshod.MisshodError;
 const IoError = Misshod.IoError;
 const SshOpenFailureReason = Misshod.SshOpenFailureReason;
-const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
 const BufferReader = @import("buffer.zig").BufferReader;
@@ -870,6 +869,15 @@ pub const Session = struct {
         self.setIoSessionState(.Idle);
     }
 
+    pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.close_sent) return;
+        chan.state = .CloseWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+    }
+
     pub fn sendWindowChange(self: *Self, cols: u32, rows: u32, width_px: u32, height_px: u32) void {
         self.pending_window_change = .{ cols, rows, width_px, height_px };
         if (self.sessionState == .ChannelActive) {
@@ -1500,24 +1508,19 @@ fn buildUnencryptedPacket(buf: []u8, payload: []const u8) usize {
     const padding_length: u8 = 8;
     const packet_length: u32 = @intCast(payload.len + padding_length + 1);
     // Build PktHdr the same way wrapPkt does
-    var hdr: Protocol.PktHdr = .{
+    const hdr: Protocol.PktHdr = .{
         .packet_length = packet_length,
         .padding_length = padding_length,
     };
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-    }
-    @memcpy(buf[0..Protocol.sizeof_PktHdr], util.asPackedBytes(Protocol.PktHdr, &hdr));
+    std.mem.writeInt(u32, buf[0..4], hdr.packet_length, .big);
+    buf[4] = hdr.padding_length;
     @memcpy(buf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload.len], payload);
     @memset(buf[Protocol.sizeof_PktHdr + payload.len .. Protocol.sizeof_PktHdr + payload.len + padding_length], 0);
     return Protocol.sizeof_PktHdr + payload.len + padding_length;
 }
 
 fn unencryptedPayload(packet: []const u8) []const u8 {
-    var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, packet[0..Protocol.sizeof_PktHdr]).*;
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-    }
+    const hdr = Protocol.readPktHdr(packet[0..Protocol.sizeof_PktHdr]);
     const payload_len = hdr.packet_length - hdr.padding_length - 1;
     return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 }

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -8,7 +8,6 @@ const BufferError = @import("buffer.zig").BufferError;
 const PrivKeyError = @import("privkey.zig").PrivKeyError;
 const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
-const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferReader = @import("buffer.zig").BufferReader;
 
 pub const MisshodError = std.crypto.errors.Error || std.mem.Allocator.Error || BufferError || IoError || PrivKeyError || Key.KeyError;
@@ -525,11 +524,7 @@ pub fn MisshodImpl(role: Role) type {
         }
 
         pub fn getRecvBuffer(self: *Self, iobuf: []u8, inkeys: *Protocol.KeyDataUni) MisshodError!BufferReader {
-            var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, iobuf[0..Protocol.sizeof_PktHdr]).*;
-            if (native_endian != .big) {
-                // flip bytes
-                std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-            }
+            const hdr = Protocol.readPktHdr(iobuf[0..Protocol.sizeof_PktHdr]);
             if (hdr.padding_length < 4 or hdr.packet_length < @as(u32, hdr.padding_length) + 1) {
                 return IoError.InvalidPacketSize;
             }
@@ -653,11 +648,7 @@ pub fn MisshodImpl(role: Role) type {
 
                         // read Protocol.PktHdr from first block
                         const pkthdr_size = Protocol.sizeof_PktHdr;
-                        var hdr: Protocol.PktHdr = undefined;
-                        hdr = std.mem.bytesToValue(Protocol.PktHdr, buf[0..pkthdr_size]);
-                        if (native_endian != .big) {
-                            std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-                        }
+                        const hdr = Protocol.readPktHdr(buf[0..pkthdr_size]);
 
                         // padding len is such that payload_len + sizeof(hdr) + padding = block size
                         if (hdr.packet_length < @as(u32, hdr.padding_length) + 1) {
@@ -689,11 +680,7 @@ pub fn MisshodImpl(role: Role) type {
                         inkeys.seq +%= 1;
                     } else {
                         // copy header
-                        var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, buf[0..Protocol.sizeof_PktHdr]).*;
-                        if (native_endian != .big) {
-                            // flip bytes
-                            std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-                        }
+                        const hdr = Protocol.readPktHdr(buf[0..Protocol.sizeof_PktHdr]);
 
                         TRACE(.Debug, ".ReadPktBody hdr={any}", .{hdr});
                         // read in payload
@@ -972,6 +959,13 @@ pub fn MisshodImpl(role: Role) type {
             self.iostate_wr = .Idle;
             try self.advance();
         }
+
+        pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
+            try self.session.sendChannelClose(channel_id);
+            self.iostate_wr = .Idle;
+            try self.advance();
+        }
+
         pub fn enableAgentForwarding(self: *Self) MisshodError!void {
             switch (role) {
                 .Client => return try self.session.enableAgentForwarding(),

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -5,7 +5,6 @@ const TRACEDUMP = util.tracedump;
 const Misshod = @import("misshod.zig").Misshod;
 const MisshodError = @import("misshod.zig").MisshodError;
 const IoError = @import("misshod.zig").IoError;
-const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
 const BufferReader = @import("buffer.zig").BufferReader;
@@ -65,6 +64,20 @@ pub const PktHdr = packed struct {
 // Number of bytes used by PktHdr
 // https://datatracker.ietf.org/doc/html/rfc4253#section-6
 pub const sizeof_PktHdr = @bitSizeOf(PktHdr) / 8;
+
+pub fn readPktHdr(packet: []const u8) PktHdr {
+    std.debug.assert(packet.len >= sizeof_PktHdr);
+    return .{
+        .packet_length = std.mem.readInt(u32, packet[0..4], .big),
+        .padding_length = packet[4],
+    };
+}
+
+fn writePktHdr(packet: []u8, hdr: PktHdr) void {
+    std.debug.assert(packet.len >= sizeof_PktHdr);
+    std.mem.writeInt(u32, packet[0..4], hdr.packet_length, .big);
+    packet[4] = hdr.padding_length;
+}
 
 // order in which items must be hashed to produce kex hash, H
 // The key exchange hash is built up piecemeal through several states
@@ -430,15 +443,11 @@ pub fn wrapPayload(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, pay
     if (packet_len > MaxSSHPacket or packet_len > iobuf.len) return IoError.tooBig;
 
     // construct header
-    var hdr: PktHdr = .{
+    const hdr: PktHdr = .{
         .packet_length = @intCast(buffer_len + padding_length + 1),
         .padding_length = @intCast(padding_length),
     };
-    // make correct endianness
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(PktHdr, &hdr);
-    }
-    @memcpy(iobuf[0..sizeof_PktHdr], util.asPackedBytes(PktHdr, &hdr));
+    writePktHdr(iobuf[0..sizeof_PktHdr], hdr);
     std.mem.copyForwards(u8, iobuf[sizeof_PktHdr .. sizeof_PktHdr + packet_payload.len], packet_payload);
 
     var rndbuf: [255]u8 = undefined; // block_size would do
@@ -563,10 +572,7 @@ test "wrapPayload preserves uncompressed payload with none compression" {
     const payload = "plain ssh payload";
     const packet = try wrapPayload(&rand, false, &keys, payload, &iobuf);
 
-    var hdr = std.mem.bytesAsValue(PktHdr, packet[0..sizeof_PktHdr]).*;
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(PktHdr, &hdr);
-    }
+    const hdr = readPktHdr(packet[0..sizeof_PktHdr]);
     const payload_len = hdr.packet_length - hdr.padding_length - 1;
     try std.testing.expectEqualStrings(payload, packet[sizeof_PktHdr .. sizeof_PktHdr + payload_len]);
 }
@@ -585,10 +591,7 @@ test "wrapPayload compresses active zlib openssh payloads" {
     const payload = "compressed ssh payload compressed ssh payload compressed ssh payload";
     const packet = try wrapPayload(&rand, false, &sender, payload, &iobuf);
 
-    var hdr = std.mem.bytesAsValue(PktHdr, packet[0..sizeof_PktHdr]).*;
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(PktHdr, &hdr);
-    }
+    const hdr = readPktHdr(packet[0..sizeof_PktHdr]);
     const compressed_len = hdr.packet_length - hdr.padding_length - 1;
     const compressed_payload = packet[sizeof_PktHdr .. sizeof_PktHdr + compressed_len];
     try std.testing.expect(!std.mem.eql(u8, payload, compressed_payload));

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -7,7 +7,6 @@ const MisshodServer = Misshod.MisshodServer;
 const MisshodError = Misshod.MisshodError;
 const IoError = Misshod.IoError;
 const SshOpenFailureReason = Misshod.SshOpenFailureReason;
-const native_endian = @import("builtin").target.cpu.arch.endian();
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
 const BufferReader = @import("buffer.zig").BufferReader;
@@ -582,6 +581,15 @@ pub const Session = struct {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
         if (chan.eof_sent) return;
         chan.state = .EofWrite;
+        self.active_channel_id = channel_id;
+        self.setSessionState(.ChannelActive);
+        self.setIoSessionState(.Idle);
+    }
+
+    pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.close_sent) return;
+        chan.state = .CloseWrite;
         self.active_channel_id = channel_id;
         self.setSessionState(.ChannelActive);
         self.setIoSessionState(.Idle);
@@ -1385,24 +1393,19 @@ fn nameListContains(namelist: []const u8, target: []const u8) bool {
 fn buildUnencryptedPacket(buf: []u8, payload: []const u8) usize {
     const padding_length: u8 = 8;
     const packet_length: u32 = @intCast(payload.len + padding_length + 1);
-    var hdr: Protocol.PktHdr = .{
+    const hdr: Protocol.PktHdr = .{
         .packet_length = packet_length,
         .padding_length = padding_length,
     };
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-    }
-    @memcpy(buf[0..Protocol.sizeof_PktHdr], util.asPackedBytes(Protocol.PktHdr, &hdr));
+    std.mem.writeInt(u32, buf[0..4], hdr.packet_length, .big);
+    buf[4] = hdr.padding_length;
     @memcpy(buf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload.len], payload);
     @memset(buf[Protocol.sizeof_PktHdr + payload.len .. Protocol.sizeof_PktHdr + payload.len + padding_length], 0);
     return Protocol.sizeof_PktHdr + payload.len + padding_length;
 }
 
 fn unencryptedPayload(packet: []const u8) []const u8 {
-    var hdr: Protocol.PktHdr = std.mem.bytesAsValue(Protocol.PktHdr, packet[0..Protocol.sizeof_PktHdr]).*;
-    if (native_endian != .big) {
-        std.mem.byteSwapAllFields(Protocol.PktHdr, &hdr);
-    }
+    const hdr = Protocol.readPktHdr(packet[0..Protocol.sizeof_PktHdr]);
     const payload_len = hdr.packet_length - hdr.padding_length - 1;
     return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -83,8 +83,8 @@ pub fn dump(writer: anytype, data: []const u8) !void {
     var off: usize = 0;
 
     while (off < data.len) : (off += bytes_per_line) {
-        try writer.print("{x:0>8}: ", .{off});
         const bytes_to_show = if (off + bytes_per_line > data.len) data.len - off else bytes_per_line;
+        try writer.print("{x:0>8}: ", .{off});
         for (0..bytes_per_line) |n| {
             if (n < bytes_to_show) {
                 try writer.print("{x:0>2}", .{data[off + n]});


### PR DESCRIPTION
## Summary
- add an opt-in `zig build interop` target for OpenSSH/libssh interoperability testing
- add non-interactive `mssh --exec` plus environment-driven auth inputs for automation
- update `msshd` channel shutdown so OpenSSH exits cleanly
- run the interop suite in Linux CI

## Validation
- `zig build test`
- `zig build interop`