### PR TITLE
Prefer Ed25519 host keys first

### DIFF
--- a/src/key.zig
+++ b/src/key.zig
@@ -13,10 +13,10 @@ pub const rsa_key_name = "ssh-rsa";
 pub const rsa_sha2_256_name = "rsa-sha2-256";
 pub const rsa_sha2_512_name = "rsa-sha2-512";
 
-pub const client_hostkey_algorithms = rsa_sha2_512_name ++ "," ++
-    rsa_sha2_256_name ++ "," ++
+pub const client_hostkey_algorithms = ed25519_name ++ "," ++
     ecdsa_p256_name ++ "," ++
-    ed25519_name;
+    rsa_sha2_512_name ++ "," ++
+    rsa_sha2_256_name;
 
 pub const MaxRsaBits = 4096;
 pub const MaxRsaBytes = MaxRsaBits / 8;
@@ -514,6 +514,13 @@ test "nameListContains finds algorithm names exactly" {
     try std.testing.expect(nameListContains(client_hostkey_algorithms, rsa_sha2_512_name));
     try std.testing.expect(nameListContains(client_hostkey_algorithms, ed25519_name));
     try std.testing.expect(!nameListContains(client_hostkey_algorithms, "ssh-r"));
+}
+
+test "client host key preference favors modern compact keys first" {
+    try std.testing.expectEqualStrings(
+        "ssh-ed25519,ecdsa-sha2-nistp256,rsa-sha2-512,rsa-sha2-256",
+        client_hostkey_algorithms,
+    );
 }
 
 test "mpint writer trims leading zeros and pads positive values" {


### PR DESCRIPTION
## Summary
- prefer `ssh-ed25519` first for client host-key negotiation
- keep `ecdsa-sha2-nistp256`, `rsa-sha2-512`, and `rsa-sha2-256` as fallbacks
- add a regression test for the client host-key preference order

## Why this order
`ssh-ed25519` first is mostly the best security + performance + simplicity choice.

| Algorithm | Why rank it there |
| --- | --- |
| `ssh-ed25519` | Modern, small keys/signatures, fast verification, strong security, simple implementation, widely supported by current OpenSSH. Usually the best default. |
| `ecdsa-sha2-nistp256` | Also modern and fast, but uses NIST P-256, which some people prefer less than Ed25519. Good fallback. |
| `rsa-sha2-512` | Secure signature hash, but RSA keys/signatures are larger and slower. Good compatibility fallback. |
| `rsa-sha2-256` | Also acceptable; usually after SHA-512 if both are supported. |
| `ssh-rsa` | Legacy RSA with SHA-1 signatures. Should generally be avoided/disabled. |

This is not just about speed. It prefers a modern, compact, well-regarded key type first, then keeps broad compatibility. It also avoids surprising clients that previously pinned an Ed25519 host key when a server offers multiple valid host keys.

## Validation
- `zig build test`
- `zig build`
