### PR TITLE
Match host key selection preference

### DIFF
--- a/src/key.zig
+++ b/src/key.zig
@@ -18,6 +18,8 @@ pub const client_hostkey_algorithms = ed25519_name ++ "," ++
     rsa_sha2_512_name ++ "," ++
     rsa_sha2_256_name;
 
+const client_hostkey_preference = [_]SignatureAlgorithm{ .Ed25519, .EcdsaP256Sha256, .RsaSha512, .RsaSha256 };
+
 pub const MaxRsaBits = 4096;
 pub const MaxRsaBytes = MaxRsaBits / 8;
 pub const MaxPublicKeyBlobLen = 4 + ecdsa_p256_name.len + 4 + ecdsa_p256_curve_name.len + 4 + EcdsaP256.PublicKey.uncompressed_sec1_encoded_length;
@@ -378,8 +380,7 @@ pub fn writePublicKeyBlob(public_key: PublicKey, out: *Blob) KeyError![]const u8
 }
 
 pub fn selectHostKeyAlgorithm(peer_namelist: []const u8, private_key: ?*const PrivateKey) ?SignatureAlgorithm {
-    const preference = [_]SignatureAlgorithm{ .RsaSha512, .RsaSha256, .EcdsaP256Sha256, .Ed25519 };
-    for (preference) |alg| {
+    for (client_hostkey_preference) |alg| {
         if (!nameListContains(peer_namelist, alg.name())) continue;
         if (private_key) |key| {
             if (!key.supportsSignatureAlgorithm(alg)) continue;
@@ -520,6 +521,25 @@ test "client host key preference favors modern compact keys first" {
     try std.testing.expectEqualStrings(
         "ssh-ed25519,ecdsa-sha2-nistp256,rsa-sha2-512,rsa-sha2-256",
         client_hostkey_algorithms,
+    );
+}
+
+test "host key selection follows advertised client preference" {
+    try std.testing.expectEqual(
+        SignatureAlgorithm.Ed25519,
+        selectHostKeyAlgorithm("rsa-sha2-256,rsa-sha2-512,ssh-rsa,ecdsa-sha2-nistp256,ssh-ed25519", null).?,
+    );
+    try std.testing.expectEqual(
+        SignatureAlgorithm.EcdsaP256Sha256,
+        selectHostKeyAlgorithm("rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256", null).?,
+    );
+    try std.testing.expectEqual(
+        SignatureAlgorithm.RsaSha512,
+        selectHostKeyAlgorithm("rsa-sha2-256,rsa-sha2-512", null).?,
+    );
+    try std.testing.expectEqual(
+        SignatureAlgorithm.RsaSha256,
+        selectHostKeyAlgorithm("rsa-sha2-256", null).?,
     );
 }
 


### PR DESCRIPTION
## Summary
- make host-key selection use the same Ed25519-first order that the client advertises in KEXINIT
- add a regression test covering Ed25519, ECDSA, and RSA fallback selection

## Why
After PR #56 changed `client_hostkey_algorithms` to prefer `ssh-ed25519,ecdsa-sha2-nistp256,rsa-sha2-512,rsa-sha2-256`, the selection helper still used the old RSA-first order. Servers that honored the advertised Ed25519-first preference signed the exchange hash with Ed25519, but misshod expected RSA and failed with `AlgorithmNegotiationFailed`.

## Validation
- `zig build test`
- `zig build`
- `mssh azureuser@100.79.211.30 22` reaches `Connected!`
