### PR TITLE
Add staged SSH none authentication

### DIFF
--- a/mssh/src/main.zig
+++ b/mssh/src/main.zig
@@ -284,6 +284,13 @@ pub fn main(init: std.process.Init) !void {
                 switch (ev) {
                     .Event => |eventCode| {
                         switch (eventCode) {
+                            .ServerIdentification => {
+                                try misshod.clearEvent(eventCode);
+                            },
+                            .AuthMethodStarted => |method| {
+                                std.debug.print("Trying authentication method: {s}\n", .{method.name()});
+                                try misshod.clearEvent(eventCode);
+                            },
                             .Connected => {
                                 std.debug.print("Connected!\n", .{});
                                 connected = true;
@@ -303,9 +310,18 @@ pub fn main(init: std.process.Init) !void {
                                 try misshod.clearEvent(eventCode);
                             },
                             .EndSession => |reason| {
-                                std.debug.print("Session ended: {any}\n", .{reason});
-                                if (reason == .AuthFailure) {
-                                    exit_code = 1;
+                                switch (reason) {
+                                    .AuthFailure => |failure| {
+                                        std.debug.print(
+                                            "AuthFailure: stage {d} after {s} (partial_success={any})\n",
+                                            .{ failure.auth_stage, failure.attempted_method.name(), failure.partial_success },
+                                        );
+                                        for (failure.supportedMethods()) |method| {
+                                            std.debug.print("  server method: {s}\n", .{method.name()});
+                                        }
+                                        exit_code = 1;
+                                    },
+                                    else => std.debug.print("Session ended: {any}\n", .{reason}),
                                 }
                                 quit = true;
                                 continue :outer;

--- a/src/channel.zig
+++ b/src/channel.zig
@@ -66,17 +66,27 @@ pub const ChannelKind = enum {
     AgentForward,
 };
 
+pub const ChannelControl = enum {
+    Eof,
+    Close,
+};
+
 pub const Channel = struct {
     const Self = @This();
 
     kind: ChannelKind,
     local_id: u32,
     remote_id: u32,
+    remote_id_known: bool,
     peer_window: u32,
     remote_max_packet_size: u32,
     local_window: u32,
     write_buf: [Protocol.MaxChannelDataLen]u8 = undefined,
     write_buf_nbytes: usize,
+    tx_in_flight_len: usize,
+    eof_pending: bool,
+    close_pending: bool,
+    control_in_flight: ?ChannelControl,
     eof_sent: bool,
     eof_received: bool,
     close_sent: bool,
@@ -89,18 +99,30 @@ pub const Channel = struct {
     state: ChannelState,
 
     pub fn init(local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
-        return Self.initKind(.Session, local_id, remote_id, peer_window, remote_max_packet_size);
+        return Self.initKind(.Session, local_id, remote_id, true, peer_window, remote_max_packet_size);
     }
 
-    pub fn initKind(kind: ChannelKind, local_id: u32, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) Self {
+    pub fn initKind(
+        kind: ChannelKind,
+        local_id: u32,
+        remote_id: u32,
+        remote_id_known: bool,
+        peer_window: u32,
+        remote_max_packet_size: u32,
+    ) Self {
         return Self{
             .kind = kind,
             .local_id = local_id,
             .remote_id = remote_id,
+            .remote_id_known = remote_id_known,
             .peer_window = peer_window,
             .remote_max_packet_size = remote_max_packet_size,
-            .local_window = Protocol.MaxPayload,
+            .local_window = Protocol.MaxChannelDataLen,
             .write_buf_nbytes = 0,
+            .tx_in_flight_len = 0,
+            .eof_pending = false,
+            .close_pending = false,
+            .control_in_flight = null,
             .eof_sent = false,
             .eof_received = false,
             .close_sent = false,
@@ -118,6 +140,22 @@ pub const Channel = struct {
         std.crypto.secureZero(u8, &self.write_buf);
     }
 
+    pub fn consumeWriteBuffer(self: *Self, sent: usize) void {
+        std.debug.assert(sent <= self.write_buf_nbytes);
+        const remaining = self.write_buf_nbytes - sent;
+        if (remaining > 0) {
+            std.mem.copyForwards(u8, self.write_buf[0..remaining], self.write_buf[sent..self.write_buf_nbytes]);
+        }
+        std.crypto.secureZero(u8, self.write_buf[remaining..self.write_buf_nbytes]);
+        self.write_buf_nbytes = remaining;
+    }
+
+    pub fn discardWriteBuffer(self: *Self) void {
+        std.crypto.secureZero(u8, self.write_buf[0..self.write_buf_nbytes]);
+        self.write_buf_nbytes = 0;
+        self.tx_in_flight_len = 0;
+    }
+
     /// Decrement local_window by the amount of data received.
     pub fn consumeLocalWindow(self: *Self, len: u32) void {
         self.local_window -|= len; // saturating subtract
@@ -125,12 +163,12 @@ pub const Channel = struct {
 
     /// Returns true if local_window has dropped below the replenish threshold.
     pub fn needsWindowAdjust(self: *const Self) bool {
-        return self.local_window < Protocol.MaxPayload / 2;
+        return self.local_window < Protocol.MaxChannelDataLen / 2;
     }
 
-    /// Returns the number of bytes to add to bring local_window back to MaxPayload.
+    /// Returns the number of bytes to add to restore the advertised receive window.
     pub fn windowAdjustAmount(self: *const Self) u32 {
-        return Protocol.MaxPayload - self.local_window;
+        return @as(u32, @intCast(Protocol.MaxChannelDataLen)) - self.local_window;
     }
 };
 
@@ -142,14 +180,39 @@ pub const ChannelTable = struct {
     last_serviced_slot: usize = 0,
 
     pub fn allocChannel(self: *Self, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) ?*Channel {
-        return self.allocChannelKind(.Session, remote_id, peer_window, remote_max_packet_size);
+        return self.allocChannelKindKnown(.Session, remote_id, true, peer_window, remote_max_packet_size);
     }
 
-    pub fn allocChannelKind(self: *Self, kind: ChannelKind, remote_id: u32, peer_window: u32, remote_max_packet_size: u32) ?*Channel {
+    pub fn allocOutboundChannel(self: *Self) ?*Channel {
+        return self.allocChannelKindKnown(.Session, 0, false, 0, 0);
+    }
+
+    pub fn allocOutboundChannelKind(self: *Self, kind: ChannelKind) ?*Channel {
+        return self.allocChannelKindKnown(kind, 0, false, 0, 0);
+    }
+
+    pub fn allocChannelKind(
+        self: *Self,
+        kind: ChannelKind,
+        remote_id: u32,
+        peer_window: u32,
+        remote_max_packet_size: u32,
+    ) ?*Channel {
+        return self.allocChannelKindKnown(kind, remote_id, true, peer_window, remote_max_packet_size);
+    }
+
+    fn allocChannelKindKnown(
+        self: *Self,
+        kind: ChannelKind,
+        remote_id: u32,
+        remote_id_known: bool,
+        peer_window: u32,
+        remote_max_packet_size: u32,
+    ) ?*Channel {
         const local_id = self.next_local_id;
         for (&self.channels) |*slot| {
             if (slot.* == null) {
-                slot.* = Channel.initKind(kind, local_id, remote_id, peer_window, remote_max_packet_size);
+                slot.* = Channel.initKind(kind, local_id, remote_id, remote_id_known, peer_window, remote_max_packet_size);
                 self.next_local_id +%= 1;
                 return &(slot.*.?);
             }
@@ -221,7 +284,31 @@ pub const ChannelTable = struct {
         while (i < MaxChannels) : (i += 1) {
             const slot_idx = (self.last_serviced_slot + 1 + i) % MaxChannels;
             if (self.channels[slot_idx]) |*ch| {
-                if (isRunnable(ch.state)) {
+                const tx_ready = ch.remote_id_known and ch.write_buf_nbytes > 0 and ch.tx_in_flight_len == 0 and ch.peer_window > 0;
+                const control_ready = ch.remote_id_known and ch.write_buf_nbytes == 0 and ch.tx_in_flight_len == 0 and
+                    ch.control_in_flight == null and
+                    ((ch.eof_pending and !ch.eof_sent) or (ch.close_pending and !ch.close_sent));
+                const terminal_close_ready = ch.remote_id_known and ch.tx_in_flight_len == 0 and ch.close_pending and !ch.close_sent;
+                if (tx_ready or control_ready or terminal_close_ready or isRunnable(ch.state)) {
+                    self.last_serviced_slot = slot_idx;
+                    return ch;
+                }
+            }
+        }
+        return null;
+    }
+
+    pub fn findNextDeferredWrite(self: *Self) ?*Channel {
+        var i: usize = 0;
+        while (i < MaxChannels) : (i += 1) {
+            const slot_idx = (self.last_serviced_slot + 1 + i) % MaxChannels;
+            if (self.channels[slot_idx]) |*ch| {
+                const tx_ready = ch.remote_id_known and ch.write_buf_nbytes > 0 and ch.tx_in_flight_len == 0 and ch.peer_window > 0;
+                const control_ready = ch.remote_id_known and ch.write_buf_nbytes == 0 and ch.tx_in_flight_len == 0 and
+                    ch.control_in_flight == null and
+                    ((ch.eof_pending and !ch.eof_sent) or (ch.close_pending and !ch.close_sent));
+                const terminal_close_ready = ch.remote_id_known and ch.tx_in_flight_len == 0 and ch.close_pending and !ch.close_sent;
+                if (tx_ready or control_ready or terminal_close_ready or (ch.close_received and !ch.close_sent)) {
                     self.last_serviced_slot = slot_idx;
                     return ch;
                 }
@@ -291,7 +378,7 @@ test "Channel init sets default values" {
     try std.testing.expectEqual(@as(u32, 42), ch.remote_id);
     try std.testing.expectEqual(@as(u32, 65535), ch.peer_window);
     try std.testing.expectEqual(@as(u32, 32768), ch.remote_max_packet_size);
-    try std.testing.expectEqual(Protocol.MaxPayload, ch.local_window);
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, ch.local_window);
     try std.testing.expectEqual(@as(usize, 0), ch.write_buf_nbytes);
     try std.testing.expect(!ch.eof_sent);
     try std.testing.expect(!ch.eof_received);
@@ -466,29 +553,29 @@ test "consumeLocalWindow saturates at zero" {
     try std.testing.expectEqual(@as(u32, 0), ch.local_window);
 }
 
-test "needsWindowAdjust triggers below half MaxPayload" {
+test "needsWindowAdjust triggers below half advertised window" {
     var ch = Channel.init(0, 1, 32768, 32768);
     // At full window — no adjust needed
     try std.testing.expect(!ch.needsWindowAdjust());
 
     // Just above threshold — no adjust
-    ch.local_window = Protocol.MaxPayload / 2;
+    ch.local_window = Protocol.MaxChannelDataLen / 2;
     try std.testing.expect(!ch.needsWindowAdjust());
 
     // Below threshold — adjust needed
-    ch.local_window = Protocol.MaxPayload / 2 - 1;
+    ch.local_window = Protocol.MaxChannelDataLen / 2 - 1;
     try std.testing.expect(ch.needsWindowAdjust());
 }
 
-test "windowAdjustAmount replenishes to MaxPayload" {
+test "windowAdjustAmount replenishes advertised window" {
     var ch = Channel.init(0, 1, 32768, 32768);
     ch.local_window = 100;
     const adjust = ch.windowAdjustAmount();
-    try std.testing.expectEqual(Protocol.MaxPayload - 100, adjust);
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen - 100, adjust);
 
-    // After applying the adjust, window should be MaxPayload
+    // After applying the adjust, window should match the advertised window.
     ch.local_window += adjust;
-    try std.testing.expectEqual(Protocol.MaxPayload, ch.local_window);
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, ch.local_window);
 }
 
 test "EofWrite is a runnable state" {

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -19,6 +19,8 @@ const PrivKeyError = @import("privkey.zig").PrivKeyError;
 const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
+const ChannelControl = @import("channel.zig").ChannelControl;
+const MaxChannels = @import("channel.zig").MaxChannels;
 const ChannelTable = @import("channel.zig").ChannelTable;
 const ChannelState = @import("channel.zig").ChannelState;
 const ClientChannelOpenMode = @import("channel.zig").ClientChannelOpenMode;
@@ -389,7 +391,7 @@ pub const Session = struct {
         tcpip_open: TcpipOpen,
     ) MisshodError!*Channel {
         if (mode == .AutoShell and channel_type != .Session) return IoError.UnexpectedResponse;
-        const chan = self.channel_table.allocChannel(0, 0, 0) orelse return IoError.tooManyChannels;
+        const chan = self.channel_table.allocOutboundChannel() orelse return IoError.tooManyChannels;
         chan.client_open_mode = mode;
         chan.channel_type = channel_type;
         chan.tcpip_open = tcpip_open;
@@ -729,6 +731,24 @@ pub const Session = struct {
         const chan = ch.?;
         self.active_channel_id = chan.local_id;
 
+        if ((chan.close_received or chan.close_pending) and chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+        }
+        const can_send_data = switch (chan.state) {
+            .Data, .DataRx, .DataTx, .DataTxComplete => true,
+            else => false,
+        };
+        if (can_send_data and !chan.eof_sent and !chan.close_sent and !chan.close_pending and !chan.close_received and
+            chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0 and chan.peer_window > 0)
+        {
+            _ = try self.startChannelWrite(chan, misshod, outkeys);
+            return;
+        }
+        if (chan.write_buf_nbytes == 0 and chan.tx_in_flight_len == 0 and chan.control_in_flight == null) {
+            if (try self.startPendingChannelControl(chan, misshod, outkeys)) return;
+        }
+
         switch (chan.state) {
             .OpenWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
@@ -736,8 +756,8 @@ pub const Session = struct {
                 // https://datatracker.ietf.org/doc/html/rfc4254#section-5.1
                 try pkt.writeU32LenString(chan.channel_type.name()); // https://datatracker.ietf.org/doc/html/rfc4250#section-4.9.1
                 try pkt.writeU32(chan.local_id); // sender channel
-                try pkt.writeU32(Protocol.MaxPayload); // initial window size
-                try pkt.writeU32(Protocol.MaxPayload); // maximum packet size
+                try pkt.writeU32(Protocol.MaxChannelDataLen); // initial window size
+                try pkt.writeU32(Protocol.MaxChannelDataLen); // maximum channel data size
                 if (chan.channel_type.hasTcpipOpenPayload()) {
                     try pkt.writeU32LenString(chan.tcpip_open.host);
                     try pkt.writeU32(chan.tcpip_open.port);
@@ -857,8 +877,6 @@ pub const Session = struct {
                     try pkt.writeU32(wc[2]); // width_px
                     try pkt.writeU32(wc[3]); // height_px
                     misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                } else if (chan.write_buf_nbytes > 0) {
-                    chan.state = .DataTx;
                 } else if (chan.needsWindowAdjust()) {
                     // RFC 4254 §5.2 — replenish receive window
                     var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
@@ -880,45 +898,28 @@ pub const Session = struct {
             },
             .DataRx => {
                 self.active_channel_id = null;
-                self.setIoSessionState(.ReadPktHdr);
+                if (self.channel_table.findNextRunnable()) |next| {
+                    self.active_channel_id = next.local_id;
+                    try self.advanceChannel(misshod, outkeys);
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
             },
             .DataTx => {
-                const max_send = @min(chan.remote_max_packet_size, @as(u32, @intCast(chan.write_buf_nbytes)));
-                const send_len = @min(max_send, chan.peer_window);
-                if (send_len == 0) {
-                    chan.state = .DataRx;
-                    self.active_channel_id = null;
-                    self.setIoSessionState(.ReadPktHdr);
-                    return;
-                }
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
-                try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32LenString(chan.write_buf[0..send_len]);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                chan.peer_window -= @intCast(send_len);
-                chan.state = .DataTxComplete;
+                chan.state = .Data;
             },
             .DataTxComplete => {
-                chan.write_buf_nbytes = 0;
                 chan.state = .Data;
             },
             .EofWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF));
-                try pkt.writeU32(chan.remote_id);
-                chan.eof_sent = true;
+                chan.eof_pending = true;
                 chan.state = .DataRx;
-                self.active_channel_id = null;
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                _ = try self.startPendingChannelControl(chan, misshod, outkeys);
             },
             .CloseWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
-                try pkt.writeU32(chan.remote_id);
-                chan.close_sent = true;
-                chan.state = .Closed;
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                chan.close_pending = true;
+                chan.state = .DataRx;
+                _ = try self.startPendingChannelControl(chan, misshod, outkeys);
             },
             .Closed => {
                 const local_id = chan.local_id;
@@ -938,8 +939,8 @@ pub const Session = struct {
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
                 try pkt.writeU32(chan.remote_id);
                 try pkt.writeU32(chan.local_id);
-                try pkt.writeU32(Protocol.MaxPayload);
-                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
                 chan.state = if (chan.kind == .AgentForward or chan.channel_type == .Session) .Connected else .Data;
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
@@ -963,7 +964,7 @@ pub const Session = struct {
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
         if (self.channel_table.findByLocalId(channel_id)) |chan| {
-            if (chan.eof_sent) return &.{};
+            if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return &.{};
             if (chan.write_buf_nbytes > 0) {
                 return &.{};
             } else {
@@ -1095,15 +1096,15 @@ pub const Session = struct {
 
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
+        if (chan.write_buf_nbytes != 0 or chan.tx_in_flight_len != 0) return IoError.UnexpectedResponse;
         chan.write_buf_nbytes = nbytes;
         self.active_channel_id = channel_id;
 
         if (chan.state == .DataRx) {
-            chan.state = .Data;
             self.setSessionState(.ChannelActive);
             self.setIoSessionState(.Idle);
         }
@@ -1112,42 +1113,182 @@ pub const Session = struct {
     // Full-duplex: build and send channel data packet directly without going through state machine
     pub fn directChannelWrite(self: *Self, channel_id: u32, nbytes: usize, misshod: *MisshodClient) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
+        if (chan.write_buf_nbytes != 0 or chan.tx_in_flight_len != 0) return IoError.UnexpectedResponse;
         chan.write_buf_nbytes = nbytes;
-        const outkeys = &self.keydata.c2s;
+        _ = try self.startChannelWrite(chan, misshod, &self.keydata.c2s);
+    }
+
+    fn startChannelWrite(
+        self: *Self,
+        chan: *Channel,
+        misshod: *MisshodClient,
+        outkeys: *Protocol.KeyDataUni,
+    ) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or !chan.remote_id_known or chan.close_pending or
+            chan.tx_in_flight_len != 0 or chan.write_buf_nbytes == 0)
+        {
+            return false;
+        }
         const max_send = @min(chan.remote_max_packet_size, @as(u32, @intCast(chan.write_buf_nbytes)));
         const send_len = @min(max_send, chan.peer_window);
-        if (send_len == 0) {
-            return;
-        }
+        if (send_len == 0) return false;
         var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
         try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
         try pkt.writeU32(chan.remote_id);
         try pkt.writeU32LenString(chan.write_buf[0..send_len]);
-        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+        misshod.requestWrite(
+            try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr),
+            .{ .ChannelWriteComplete = chan.local_id },
+        );
         chan.peer_window -= @intCast(send_len);
-        chan.write_buf_nbytes = 0;
+        chan.tx_in_flight_len = send_len;
+        return true;
     }
 
-    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+    pub fn completeChannelWrite(self: *Self, channel_id: u32, misshod: *MisshodClient) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return;
-        chan.state = .EofWrite;
-        self.active_channel_id = channel_id;
-        self.setSessionState(.ChannelActive);
-        self.setIoSessionState(.Idle);
+        if (chan.tx_in_flight_len == 0) return IoError.UnexpectedResponse;
+        chan.consumeWriteBuffer(chan.tx_in_flight_len);
+        chan.tx_in_flight_len = 0;
+        if (chan.close_received) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+            _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        const received_packet_pending = switch (self.ioSessionState) {
+            .ReadPktCompletion => true,
+            else => false,
+        };
+        if (received_packet_pending) return;
+        if (chan.close_pending) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+            const queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s);
+            if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        var queued = false;
+        if (chan.write_buf_nbytes > 0) {
+            queued = try self.startChannelWrite(chan, misshod, &self.keydata.c2s);
+        } else {
+            queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s);
+        }
+        if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
     }
 
-    pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
+    fn startPendingChannelControl(
+        self: *Self,
+        chan: *Channel,
+        misshod: *MisshodClient,
+        outkeys: *Protocol.KeyDataUni,
+    ) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or !chan.remote_id_known or
+            misshod.iostate_wr != .Idle or chan.write_buf_nbytes != 0 or
+            chan.tx_in_flight_len != 0 or chan.control_in_flight != null)
+        {
+            return false;
+        }
+        const control: ChannelControl = if (chan.close_received and !chan.close_sent)
+            .Close
+        else if (chan.close_pending and !chan.close_sent)
+            .Close
+        else if (chan.eof_pending and !chan.eof_sent)
+            .Eof
+        else
+            return false;
+
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(switch (control) {
+            .Eof => Protocol.MsgId.SSH_MSG_CHANNEL_EOF,
+            .Close => Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE,
+        }));
+        try pkt.writeU32(chan.remote_id);
+        misshod.requestWrite(
+            try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr),
+            .{ .ChannelControlComplete = chan.local_id },
+        );
+        chan.control_in_flight = control;
+        switch (control) {
+            .Eof => {
+                chan.eof_pending = false;
+                chan.eof_sent = true;
+            },
+            .Close => {
+                chan.close_pending = false;
+                chan.close_sent = true;
+                chan.eof_pending = false;
+            },
+        }
+        return true;
+    }
+
+    pub fn dispatchDeferredChannelWrite(self: *Self, misshod: *MisshodClient) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or misshod.iostate_wr != .Idle) return false;
+        for (0..MaxChannels) |_| {
+            const chan = self.channel_table.findNextDeferredWrite() orelse return false;
+            if ((chan.close_received or chan.close_pending) and chan.tx_in_flight_len == 0) {
+                chan.discardWriteBuffer();
+                chan.eof_pending = false;
+            }
+            if (!chan.eof_sent and !chan.close_sent and !chan.close_pending and !chan.close_received and
+                chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0 and chan.peer_window > 0)
+            {
+                return try self.startChannelWrite(chan, misshod, &self.keydata.c2s);
+            }
+            if (chan.write_buf_nbytes == 0 and chan.tx_in_flight_len == 0) {
+                if (try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s)) return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn completeChannelControl(self: *Self, channel_id: u32, misshod: *MisshodClient) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.close_sent) return;
-        chan.state = .CloseWrite;
-        self.active_channel_id = channel_id;
-        self.setSessionState(.ChannelActive);
-        self.setIoSessionState(.Idle);
+        const control = chan.control_in_flight orelse return IoError.UnexpectedResponse;
+        chan.control_in_flight = null;
+        if (control == .Close) {
+            if (chan.close_received) {
+                chan.state = .Closed;
+                self.active_channel_id = chan.local_id;
+                self.setSessionState(.ChannelActive);
+            }
+            const received_packet_pending = switch (self.ioSessionState) {
+                .ReadPktCompletion => true,
+                else => false,
+            };
+            if (!received_packet_pending) _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        const received_packet_pending = switch (self.ioSessionState) {
+            .ReadPktCompletion => true,
+            else => false,
+        };
+        if (!received_packet_pending) {
+            const queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s);
+            if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
+        }
+    }
+
+    pub fn sendChannelEof(self: *Self, channel_id: u32, misshod: *MisshodClient) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending) return;
+        if (chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
+        chan.eof_pending = true;
+        _ = try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s);
+    }
+
+    pub fn sendChannelClose(self: *Self, channel_id: u32, misshod: *MisshodClient) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.close_sent or chan.close_pending) return;
+        chan.close_pending = true;
+        chan.eof_pending = false;
+        if (chan.tx_in_flight_len == 0) chan.discardWriteBuffer();
+        _ = try self.startPendingChannelControl(chan, misshod, &self.keydata.c2s);
     }
 
     pub fn sendWindowChange(self: *Self, cols: u32, rows: u32, width_px: u32, height_px: u32) void {
@@ -1610,6 +1751,7 @@ pub const Session = struct {
                 const max_packet_size = try rdr.readU32(); // maximum packet size
                 if (self.channel_table.findByLocalId(recipient)) |chan| {
                     chan.remote_id = sender;
+                    chan.remote_id_known = true;
                     chan.peer_window = peer_window;
                     chan.remote_max_packet_size = max_packet_size;
                     switch (chan.client_open_mode) {
@@ -1712,6 +1854,12 @@ pub const Session = struct {
                 const channelnum = try rdr.readU32();
                 if (self.channel_table.findByLocalId(channelnum)) |chan| {
                     chan.eof_received = true;
+                    if (chan.write_buf_nbytes > 0 or chan.eof_pending or chan.close_pending) {
+                        self.active_channel_id = chan.local_id;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
+                        return;
+                    }
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
@@ -1722,6 +1870,8 @@ pub const Session = struct {
                     return;
                 };
                 chan.close_received = true;
+                chan.discardWriteBuffer();
+                chan.eof_pending = false;
                 if (chan.close_sent) {
                     if (chan.kind == .AgentForward) {
                         self.active_channel_id = chan.local_id;
@@ -1739,7 +1889,8 @@ pub const Session = struct {
                     }
                 } else {
                     self.active_channel_id = chan.local_id;
-                    chan.state = .CloseWrite;
+                    chan.close_pending = true;
+                    chan.state = .DataRx;
                     self.setSessionState(.ChannelActive);
                     self.setIoSessionState(.Idle);
                 }
@@ -1766,6 +1917,12 @@ pub const Session = struct {
                 if (self.channel_table.findByLocalId(channelnum)) |chan| {
                     const bytes_to_add = try rdr.readU32();
                     chan.peer_window +|= bytes_to_add;
+                    if (chan.write_buf_nbytes > 0) {
+                        self.active_channel_id = chan.local_id;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
+                        return;
+                    }
                 } else {
                     _ = try rdr.readU32();
                 }
@@ -1816,6 +1973,17 @@ fn decryptFirstBlockForTest(packet: []u8, keys: *Protocol.KeyDataUni) void {
     @memcpy(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
     keys.aesctr.encrypt(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
     keys.seq +%= 1;
+}
+
+fn consumeProducedChannelDataForTest(m: *MisshodClient, destination: []u8, offset: usize) !usize {
+    const packet = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA), try rdr.readU8());
+    _ = try rdr.readU32();
+    const data = try rdr.readU32LenString();
+    @memcpy(destination[offset .. offset + data.len], data);
+    try m.consumed(packet.len);
+    return data.len;
 }
 
 fn buildAuthFailurePacket(m: *MisshodClient, methods: []const u8, partial_success: bool) !usize {
@@ -2234,6 +2402,82 @@ test "server initiated client rekey sends and hashes client KEXINIT before serve
     );
 }
 
+test "client rekey gates deferred channel traffic until NEWKEYS completes" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+    try m.session.setPeerProtocolVersion("SSH-2.0-test_server");
+
+    const channel_a = m.session.channel_table.allocChannel(10, 2000, 1000).?;
+    channel_a.state = .DataRx;
+    const channel_b = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    channel_b.state = .DataRx;
+    for (channel_a.write_buf[0..2000], 0..) |*byte, index| byte.* = @truncate(index);
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(channel_a.local_id, 2000);
+    try m.sendChannelEof(channel_b.local_id);
+
+    var server_payload_buf: [512]u8 = undefined;
+    var server_payload = BufferWriter.init(&server_payload_buf, 0);
+    try writeKexInitPayload(&server_payload);
+    const server_packet_len = buildUnencryptedPacket(&m.iobuf_rd, server_payload.active());
+    m.iostate_rd = .Idle;
+    m.session.setIoSessionState(.{ .ReadPktCompletion = m.iobuf_rd[0..server_packet_len] });
+
+    var first_fragment: [1000]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &first_fragment, 0);
+    try std.testing.expect(m.session.is_rekeying);
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_pending);
+
+    const client_kexinit = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT),
+        unencryptedPayload(client_kexinit)[0],
+    );
+    try m.consumed(client_kexinit.len);
+    const ecdh_init = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_INIT),
+        unencryptedPayload(ecdh_init)[0],
+    );
+    try m.consumed(ecdh_init.len);
+
+    m.iostate_rd = .Idle;
+    m.session.session_id = .{0x11} ** Protocol.hash_algo.digest_length;
+    m.session.shared_secret_k = .{0x22} ** Protocol.kex_algo.shared_length;
+    m.session.negotiated_compression_c2s = .None;
+    m.session.negotiated_compression_s2c = .None;
+    try m.session.installExchangeKeys(.{0x33} ** Protocol.hash_algo.digest_length);
+    const new_c2s_key = m.session.pending_c2s_keys.?.key;
+    m.session.setSessionState(.NewKeysWrite);
+    m.session.setIoSessionState(.Idle);
+    try m.session.advanceSession(&m);
+
+    const newkeys = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS),
+        unencryptedPayload(newkeys)[0],
+    );
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_pending);
+    try m.consumed(newkeys.len);
+
+    try std.testing.expectEqualSlices(u8, &new_c2s_key, &m.session.keydata.c2s.key);
+    var resumed_data = try m.peek(Protocol.MaxSSHPacket);
+    if (channel_a.tx_in_flight_len == 0) {
+        try std.testing.expectEqual(ChannelControl.Eof, channel_b.control_in_flight.?);
+        try m.consumed(resumed_data.len);
+        resumed_data = try m.peek(Protocol.MaxSSHPacket);
+    }
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.tx_in_flight_len);
+    try m.consumed(resumed_data.len);
+    try std.testing.expectEqual(@as(usize, 0), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_sent);
+}
+
 test "client rekey preserves initial session id for key derivation" {
     var prng = std.Random.DefaultPrng.init(42);
     var session = try Session.init(prng.random(), "testuser", std.testing.allocator);
@@ -2376,8 +2620,8 @@ test "openSessionChannel writes channel open for new raw session channel" {
     try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
     try std.testing.expectEqualStrings("session", try rdr.readU32LenString());
     try std.testing.expectEqual(channel_id, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
 }
 
 test "openDirectTcpipChannel writes direct-tcpip open payload" {
@@ -2397,8 +2641,8 @@ test "openDirectTcpipChannel writes direct-tcpip open payload" {
     try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
     try std.testing.expectEqualStrings("direct-tcpip", try rdr.readU32LenString());
     try std.testing.expectEqual(channel_id, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
     try std.testing.expectEqualStrings("example.com", try rdr.readU32LenString());
     try std.testing.expectEqual(@as(u32, 443), try rdr.readU32());
     try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
@@ -2550,6 +2794,56 @@ test "openSessionChannel can open another raw channel after confirmation" {
     try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
     try std.testing.expectEqualStrings("session", try rdr.readU32LenString());
     try std.testing.expectEqual(second_id, try rdr.readU32());
+}
+
+test "unconfirmed client channel defers close until remote id is known" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const existing = m.session.channel_table.allocChannel(0, 1000, 1000).?;
+    existing.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    const channel_id = try m.openSessionChannel();
+    const pending = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expect(!pending.remote_id_known);
+
+    try m.sendChannelClose(channel_id);
+    try std.testing.expect(pending.close_pending);
+    try std.testing.expect(pending.control_in_flight == null);
+
+    const open_packet = try m.peek(Protocol.MaxSSHPacket);
+    var open_reader = BufferReader.init(unencryptedPayload(open_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try open_reader.readU8());
+    try m.consumed(open_packet.len);
+    try std.testing.expect(!pending.remote_id_known);
+    try std.testing.expect(pending.control_in_flight == null);
+
+    var confirmation_payload_buf: [32]u8 = undefined;
+    var confirmation = BufferWriter.init(&confirmation_payload_buf, 0);
+    try confirmation.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try confirmation.writeU32(channel_id);
+    try confirmation.writeU32(77);
+    try confirmation.writeU32(1000);
+    try confirmation.writeU32(1000);
+    const confirmation_len = buildUnencryptedPacket(&m.iobuf_rd, confirmation.active());
+    m.iostate_rd = .Idle;
+    try m.session.handlePacket(m.iobuf_rd[0..confirmation_len], &m);
+    const opened = try m.getNextEvent();
+    switch (opened) {
+        .Event => |event| switch (event) {
+            .ChannelOpened => |opened_id| try std.testing.expectEqual(channel_id, opened_id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try m.clearEvent(.{ .ChannelOpened = channel_id });
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(@as(u32, 77), try close_reader.readU32());
+    try std.testing.expect(pending.remote_id_known);
 }
 
 test "handlePacket: SSH_MSG_DEBUG with always_display=true" {
@@ -2706,6 +3000,39 @@ test "handlePacket: agent channel data surfaces AgentData event" {
     }
 }
 
+test "client receives exactly advertised maximum channel data" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(42, 32768, Protocol.MaxChannelDataLen).?;
+    chan.state = .DataRx;
+
+    var channel_data: [Protocol.MaxChannelDataLen]u8 = undefined;
+    for (&channel_data, 0..) |*byte, index| byte.* = @truncate(index);
+    var payload_backing: [Protocol.MaxPayload]u8 = undefined;
+    var payload = BufferWriter.init(&payload_backing, 0);
+    try payload.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
+    try payload.writeU32(chan.local_id);
+    try payload.writeU32LenString(&channel_data);
+
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, payload.active());
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .RxData => |data| {
+                try std.testing.expectEqual(@as(usize, Protocol.MaxChannelDataLen), data.len);
+                try std.testing.expectEqualSlices(u8, &channel_data, data);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(u32, 0), chan.local_window);
+}
+
 test "handlePacket: SSH_MSG_CHANNEL_CLOSE when not yet sent triggers close reply" {
     var prng = std.Random.DefaultPrng.init(42);
     var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
@@ -2725,7 +3052,9 @@ test "handlePacket: SSH_MSG_CHANNEL_CLOSE when not yet sent triggers close reply
 
     try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
     try std.testing.expectEqual(SessionState.ChannelActive, m.session.sessionState);
-    try std.testing.expectEqual(ChannelState.CloseWrite, chan.state);
+    try std.testing.expectEqual(ChannelState.DataRx, chan.state);
+    try std.testing.expect(chan.close_pending);
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
 }
 
 test "handlePacket: SSH_MSG_CHANNEL_CLOSE when already sent emits disconnect" {
@@ -2832,6 +3161,218 @@ test "client channel write buffer is MaxChannelDataLen" {
     _ = session.channel_table.allocChannel(0, 0, 0);
     const buf = try session.getChannelWriteBuffer(0);
     try std.testing.expectEqual(Protocol.MaxChannelDataLen, buf.len);
+}
+
+test "client direct write retains suffix across peer packet and window limits" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(77, 1500, 1000).?;
+    chan.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    const total_len: usize = 2500;
+    for (chan.write_buf[0..total_len], 0..) |*byte, index| byte.* = @truncate(index);
+
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(chan.local_id, total_len);
+    try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+    try std.testing.expectEqual(@as(usize, total_len), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(usize, 1000), chan.tx_in_flight_len);
+    try std.testing.expectEqual(@as(usize, 0), (try m.getChannelWriteBuffer(chan.local_id)).len);
+    try std.testing.expectError(IoError.cannotAcceptWrite, m.channelWriteComplete(chan.local_id, 1));
+    try m.sendChannelEof(chan.local_id);
+    try std.testing.expect(chan.eof_pending);
+    try std.testing.expect(!chan.eof_sent);
+
+    var inbound_payload_buf: [32]u8 = undefined;
+    var inbound_payload = BufferWriter.init(&inbound_payload_buf, 0);
+    try inbound_payload.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EXTENDED_DATA));
+    try inbound_payload.writeU32(chan.local_id);
+    try inbound_payload.writeU32(1);
+    try inbound_payload.writeU32LenString("peer-data");
+    const inbound_packet_len = buildUnencryptedPacket(&m.iobuf_rd, inbound_payload.active());
+    m.iostate_rd = .Idle;
+    m.session.setIoSessionState(.{ .ReadPktCompletion = m.iobuf_rd[0..inbound_packet_len] });
+
+    var received: [total_len]u8 = undefined;
+    var received_len: usize = 0;
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+    try std.testing.expectEqual(@as(usize, 1000), received_len);
+    try std.testing.expectEqual(@as(usize, 1500), chan.write_buf_nbytes);
+
+    const inbound_event = try m.getNextEvent();
+    switch (inbound_event) {
+        .Event => |event| switch (event) {
+            .RxExtendedData => |data| {
+                try std.testing.expectEqual(@as(u32, 1), data.data_type);
+                try std.testing.expectEqualStrings("peer-data", data.data);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try m.clearEvent(.{ .RxExtendedData = .{ .data_type = 1, .data = "peer-data" } });
+
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+    try std.testing.expectEqual(@as(usize, 1500), received_len);
+    try std.testing.expectEqual(@as(usize, 1000), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(u32, 0), chan.peer_window);
+    try std.testing.expectEqual(@as(usize, 0), chan.tx_in_flight_len);
+
+    m.iostate_rd = .Idle;
+    var adjust_payload_buf: [16]u8 = undefined;
+    var adjust_payload = BufferWriter.init(&adjust_payload_buf, 0);
+    try adjust_payload.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
+    try adjust_payload.writeU32(chan.local_id);
+    try adjust_payload.writeU32(2000);
+    const adjust_packet_len = buildUnencryptedPacket(&m.iobuf_rd, adjust_payload.active());
+    try m.session.handlePacket(m.iobuf_rd[0..adjust_packet_len], &m);
+    try m.advance();
+    try m.advance();
+
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+    try std.testing.expectEqual(total_len, received_len);
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(u32, 1000), chan.peer_window);
+    for (received, 0..) |byte, index| try std.testing.expectEqual(@as(u8, @truncate(index)), byte);
+
+    const eof_packet = try m.peek(Protocol.MaxSSHPacket);
+    var eof_reader = BufferReader.init(unencryptedPayload(eof_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF), try eof_reader.readU8());
+    try std.testing.expectEqual(chan.remote_id, try eof_reader.readU32());
+    try std.testing.expect(chan.eof_sent);
+    try std.testing.expect(!chan.eof_pending);
+    try m.consumed(eof_packet.len);
+    try std.testing.expectEqual(@as(usize, 0), (try m.getChannelWriteBuffer(chan.local_id)).len);
+    try std.testing.expectError(IoError.UnexpectedResponse, m.channelWriteComplete(chan.local_id, 1));
+}
+
+test "peer close pending during fragment discards suffix before close reply" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(77, 2500, 1000).?;
+    chan.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    for (chan.write_buf[0..2500], 0..) |*byte, index| byte.* = @truncate(index);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(chan.local_id, 2500);
+
+    var close_payload_buf: [8]u8 = undefined;
+    var close_payload = BufferWriter.init(&close_payload_buf, 0);
+    try close_payload.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
+    try close_payload.writeU32(chan.local_id);
+    const close_packet_len = buildUnencryptedPacket(&m.iobuf_rd, close_payload.active());
+    m.iostate_rd = .Idle;
+    m.session.setIoSessionState(.{ .ReadPktCompletion = m.iobuf_rd[0..close_packet_len] });
+
+    var first_fragment: [1000]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &first_fragment, 0);
+
+    const close_reply = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_reply));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(chan.remote_id, try close_reader.readU32());
+    try std.testing.expect(chan.close_received);
+    try std.testing.expect(chan.close_sent);
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), chan.tx_in_flight_len);
+    const local_id = chan.local_id;
+    try m.consumed(close_reply.len);
+    try std.testing.expect(m.session.channel_table.findByLocalId(local_id) == null);
+}
+
+test "local close discards window-blocked suffix after in-flight fragment" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(77, 1000, 1000).?;
+    chan.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    for (chan.write_buf[0..2000], 0..) |*byte, index| byte.* = @truncate(index);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(chan.local_id, 2000);
+    try m.sendChannelClose(chan.local_id);
+    try std.testing.expect(chan.close_pending);
+    try std.testing.expectEqual(@as(u32, 0), chan.peer_window);
+
+    var first_fragment: [1000]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &first_fragment, 0);
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(chan.remote_id, try close_reader.readU32());
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), chan.tx_in_flight_len);
+    try std.testing.expectEqual(ChannelControl.Close, chan.control_in_flight.?);
+}
+
+test "client completion schedules pending control on another channel" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const channel_a = m.session.channel_table.allocChannel(10, 1000, 1000).?;
+    channel_a.state = .DataRx;
+    const channel_b = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    channel_b.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    const data_len: usize = 100;
+    for (channel_a.write_buf[0..data_len], 0..) |*byte, index| byte.* = @truncate(index);
+
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(channel_a.local_id, data_len);
+    try m.sendChannelClose(channel_b.local_id);
+    try std.testing.expect(channel_b.close_pending);
+
+    var received: [data_len]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &received, 0);
+    try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+    try std.testing.expect(m.iostate_rd != .Idle);
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(channel_b.remote_id, try close_reader.readU32());
+}
+
+test "client close completion dispatches next channel control during active read" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const first = m.session.channel_table.allocChannel(10, 1000, 1000).?;
+    first.state = .DataRx;
+    const second = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    second.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+
+    try m.sendChannelClose(first.local_id);
+    try m.sendChannelEof(second.local_id);
+    try std.testing.expectEqual(ChannelControl.Close, first.control_in_flight.?);
+    try std.testing.expect(second.eof_pending);
+
+    const first_close = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(first_close));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try m.consumed(first_close.len);
+
+    try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+    try std.testing.expect(m.iostate_rd != .Idle);
+    const second_eof = try m.peek(Protocol.MaxSSHPacket);
+    var eof_reader = BufferReader.init(unencryptedPayload(second_eof));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF), try eof_reader.readU8());
+    try std.testing.expectEqual(second.remote_id, try eof_reader.readU32());
 }
 
 test "channelWriteComplete rejects oversized writes" {

--- a/src/client_session.zig
+++ b/src/client_session.zig
@@ -6,6 +6,8 @@ const Misshod = @import("misshod.zig");
 const MisshodClient = Misshod.MisshodClient;
 const MisshodError = Misshod.MisshodError;
 const IoError = Misshod.IoError;
+const AuthMethod = Misshod.AuthMethod;
+const AuthFailureInfo = Misshod.AuthFailureInfo;
 const SshOpenFailureReason = Misshod.SshOpenFailureReason;
 const BufferWriter = @import("buffer.zig").BufferWriter;
 const BufferError = @import("buffer.zig").BufferError;
@@ -36,12 +38,17 @@ pub const SessionState = enum {
     AuthServReq,
     AuthServRsp,
     AuthStart,
+    NoneAuthReq,
     GetPrivateKeyCompleted,
     PubkeyAuthDecodeKeyPasswordless,
     PubkeyAuthDecodeKeyPassword,
+    PubkeyAuthStart,
     PubkeyAuthReq,
+    AuthMethodQueued,
     AuthRsp,
+    PasswordAuthStart,
     PasswordAuthReq,
+    KeyboardInteractiveAuthStart,
     KeyboardInteractiveAuthReq,
     KeyboardInteractiveInfoRsp,
     ChannelOpenReq,
@@ -59,6 +66,9 @@ const PendingGlobalRequest = struct {
     bind_address: []const u8,
     bind_port: u32,
 };
+
+const MaxAuthAttemptsPerMethod: u8 = 1;
+const MaxAuthAttemptsTotal: u8 = 8;
 
 pub const Session = struct {
     const Self = @This();
@@ -79,6 +89,7 @@ pub const Session = struct {
     username: []const u8,
     rand: std.Random = undefined,
     encrypted: bool,
+    inbound_encrypted: bool,
     channel_table: ChannelTable,
     active_channel_id: ?u32,
     pending_window_change: ?[4]u32,
@@ -94,11 +105,25 @@ pub const Session = struct {
     auto_exec_command: ?[]u8,
     kbd_interactive_response: ?[]u8, // allocated
     is_rekeying: bool,
+    client_version: ?[]u8,
+    server_version: ?[]u8,
+    pre_identification_lines: usize,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
     auth_passphrase: ?[]u8, //allocated
     private_key: ?Key.PrivateKey,
+    try_none_auth: bool,
+    auth_attempts_total: u8,
+    auth_stage: u8,
+    auth_stage_attempts_by_method: [4]u8,
+    current_auth_method: ?AuthMethod,
+    last_auth_failure: ?AuthFailureInfo,
+    pending_c2s_keys: ?Protocol.KeyDataUni,
+    pending_s2c_keys: ?Protocol.KeyDataUni,
+    negotiated_compression_c2s: Protocol.CompressionAlgorithm,
+    negotiated_compression_s2c: Protocol.CompressionAlgorithm,
+    pending_server_kexinit: ?[]u8,
 
     pub fn init(rand: std.Random, username: []const u8, allocator: std.mem.Allocator) !Self {
         return .{
@@ -108,6 +133,7 @@ pub const Session = struct {
             .allocator = allocator,
             .username = username,
             .encrypted = false,
+            .inbound_encrypted = false,
             .keydata = Protocol.KeyDataBi.init(),
             .kex_hasher = Hasher(Protocol.hash_algo).init(), // for hashing H
             .selected_hostkey_algorithm = null,
@@ -129,6 +155,20 @@ pub const Session = struct {
             .auto_exec_command = null,
             .kbd_interactive_response = null,
             .is_rekeying = false,
+            .client_version = try allocator.dupe(u8, Protocol.version),
+            .server_version = null,
+            .pre_identification_lines = 0,
+            .try_none_auth = false,
+            .auth_attempts_total = 0,
+            .auth_stage = 0,
+            .auth_stage_attempts_by_method = .{0} ** 4,
+            .current_auth_method = null,
+            .last_auth_failure = null,
+            .pending_c2s_keys = null,
+            .pending_s2c_keys = null,
+            .negotiated_compression_c2s = .None,
+            .negotiated_compression_s2c = .None,
+            .pending_server_kexinit = null,
         };
     }
 
@@ -139,6 +179,10 @@ pub const Session = struct {
         self.clearAndFreeOptional(&self.auto_pty_term);
         self.clearAndFreeOptional(&self.auto_exec_command);
         self.clearAndFreeOptional(&self.kbd_interactive_response);
+        self.clearAndFreeOptional(&self.client_version);
+        self.clearAndFreeOptional(&self.server_version);
+        self.clearAndFreeOptional(&self.pending_server_kexinit);
+        self.clearPendingKeys();
         if (self.hostkey_ks) |ks| {
             std.crypto.secureZero(u8, ks);
             self.allocator.free(ks);
@@ -170,6 +214,172 @@ pub const Session = struct {
     pub fn setSessionState(self: *Self, newState: SessionState) void {
         TRACE(.Debug, "sessionState {any} -> {any}", .{ self.sessionState, newState });
         self.sessionState = newState;
+    }
+
+    pub fn setPeerProtocolVersion(self: *Self, version: []const u8) MisshodError!void {
+        self.clearAndFreeOptional(&self.server_version);
+        self.server_version = try self.allocator.dupe(u8, version);
+    }
+
+    pub fn setTryNoneAuth(self: *Self, enabled: bool) MisshodError!void {
+        if (self.auth_attempts_total != 0) return IoError.UnexpectedResponse;
+        self.try_none_auth = enabled;
+    }
+
+    fn authMethodIndex(method: AuthMethod) usize {
+        return @intFromEnum(method);
+    }
+
+    fn ensureAuthMethodAvailable(self: *const Self, method: AuthMethod) MisshodError!void {
+        const method_index = authMethodIndex(method);
+        if (self.auth_attempts_total >= MaxAuthAttemptsTotal or
+            self.auth_stage_attempts_by_method[method_index] >= MaxAuthAttemptsPerMethod)
+        {
+            return IoError.UnexpectedResponse;
+        }
+    }
+
+    fn commitAuthRequest(
+        self: *Self,
+        misshod: *MisshodClient,
+        method: AuthMethod,
+        packet: []const u8,
+    ) void {
+        const method_index = authMethodIndex(method);
+        self.auth_attempts_total += 1;
+        self.auth_stage_attempts_by_method[method_index] += 1;
+        self.current_auth_method = method;
+        misshod.requestWrite(packet, .Idle);
+        self.setSessionState(.AuthMethodQueued);
+    }
+
+    fn rememberAuthFailure(
+        self: *Self,
+        attempted_method: AuthMethod,
+        methods: []const u8,
+        partial_success: bool,
+    ) AuthFailureInfo {
+        const failure = AuthFailureInfo.parse(
+            attempted_method,
+            methods,
+            partial_success,
+            self.auth_stage,
+        );
+        self.last_auth_failure = failure;
+        return failure;
+    }
+
+    fn lastAuthFailure(self: *const Self) ?AuthFailureInfo {
+        return self.last_auth_failure;
+    }
+
+    fn skipAuthMethod(self: *Self, method: AuthMethod) void {
+        self.auth_stage_attempts_by_method[authMethodIndex(method)] = MaxAuthAttemptsPerMethod;
+    }
+
+    fn beginNextAuthStage(self: *Self) void {
+        self.auth_stage += 1;
+        self.auth_stage_attempts_by_method = .{0} ** 4;
+    }
+
+    fn resetKexHasherForRekey(self: *Self) void {
+        self.kex_hasher = Hasher(Protocol.hash_algo).init();
+        self.kex_hash_order = .Init;
+        self.kex_hash_order = self.kex_hash_order.check(.V_C);
+        self.kex_hasher.writeU32LenString(self.client_version.?);
+        self.kex_hash_order = self.kex_hash_order.check(.V_S);
+        self.kex_hasher.writeU32LenString(self.server_version.?);
+    }
+
+    fn clearPendingKeys(self: *Self) void {
+        if (self.pending_c2s_keys) |*keys| keys.clear();
+        if (self.pending_s2c_keys) |*keys| keys.clear();
+        self.pending_c2s_keys = null;
+        self.pending_s2c_keys = null;
+    }
+
+    fn installExchangeKeys(self: *Self, kexhash: [Protocol.hash_algo.digest_length]u8) MisshodError!void {
+        if (!self.is_rekeying) @memcpy(&self.session_id, &kexhash);
+        self.clearPendingKeys();
+        var pending = Protocol.KeyDataBi.init();
+        defer pending.clear();
+        try pending.genKeys(kexhash, self.shared_secret_k, self.session_id);
+        pending.c2s.compression.queueAlgorithm(self.negotiated_compression_c2s);
+        pending.s2c.compression.queueAlgorithm(self.negotiated_compression_s2c);
+        self.pending_c2s_keys = pending.c2s;
+        self.pending_s2c_keys = pending.s2c;
+        pending.c2s = .{ .seq = 0 };
+        pending.s2c = .{ .seq = 0 };
+    }
+
+    fn activatePendingC2sKeys(self: *Self) MisshodError!void {
+        var next = self.pending_c2s_keys orelse return IoError.UnexpectedResponse;
+        self.pending_c2s_keys = null;
+        next.seq = self.keydata.c2s.seq;
+        next.compression.applyPendingAlgorithm();
+        if (self.is_rekeying) try next.compression.activateDeflate();
+        self.keydata.c2s.clear();
+        self.keydata.c2s = next;
+        self.encrypted = true;
+    }
+
+    fn activatePendingS2cKeys(self: *Self) MisshodError!void {
+        var next = self.pending_s2c_keys orelse return IoError.UnexpectedResponse;
+        self.pending_s2c_keys = null;
+        next.seq = self.keydata.s2c.seq;
+        next.compression.applyPendingAlgorithm();
+        if (self.is_rekeying) try next.compression.activateInflate();
+        self.keydata.s2c.clear();
+        self.keydata.s2c = next;
+        self.inbound_encrypted = true;
+    }
+
+    fn preparePasswordAuth(self: *Self, misshod: *MisshodClient) void {
+        if (self.auth_passphrase == null) {
+            self.setSessionState(.PasswordAuthStart);
+            misshod.requestEvent(.GetAuthPassphrase, .Idle);
+        } else {
+            self.setSessionState(.PasswordAuthStart);
+        }
+    }
+
+    fn continueAuthentication(
+        self: *Self,
+        misshod: *MisshodClient,
+        failure: AuthFailureInfo,
+    ) MisshodError!void {
+        if (self.auth_attempts_total >= MaxAuthAttemptsTotal) {
+            misshod.requestEvent(.{ .EndSession = .{ .AuthFailure = failure } }, .Idle);
+            return;
+        }
+
+        const methods = [_]AuthMethod{
+            .PublicKey,
+            .Password,
+            .KeyboardInteractive,
+        };
+        for (methods) |method| {
+            const method_index = authMethodIndex(method);
+            if (self.auth_stage_attempts_by_method[method_index] >= MaxAuthAttemptsPerMethod) continue;
+            if (!failure.hasMethod(method)) continue;
+
+            switch (method) {
+                .PublicKey => {
+                    if (self.privkey_ascii == null) {
+                        self.setSessionState(.GetPrivateKeyCompleted);
+                        misshod.requestEvent(.GetPrivateKey, .Idle);
+                    } else {
+                        self.setSessionState(.PubkeyAuthDecodeKeyPasswordless);
+                    }
+                },
+                .Password => self.preparePasswordAuth(misshod),
+                .KeyboardInteractive => self.setSessionState(.KeyboardInteractiveAuthStart),
+                .None => unreachable,
+            }
+            return;
+        }
+
+        misshod.requestEvent(.{ .EndSession = .{ .AuthFailure = failure } }, .Idle);
     }
 
     fn allocateClientChannel(
@@ -229,7 +439,14 @@ pub const Session = struct {
                 self.kex_hasher.writeU32LenString(pkt.active());
 
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                self.setSessionState(.KexInitRead);
+                if (self.pending_server_kexinit) |server_kexinit| {
+                    self.kex_hash_order = self.kex_hash_order.check(.I_S);
+                    self.kex_hasher.writeU32LenString(server_kexinit);
+                    self.clearAndFreeOptional(&self.pending_server_kexinit);
+                    self.setSessionState(.EcdhInitWrite);
+                } else {
+                    self.setSessionState(.KexInitRead);
+                }
             },
             .KexInitRead => {
                 self.setIoSessionState(.ReadPktHdr);
@@ -284,18 +501,14 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
                 const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
-                self.keydata.c2s.compression.applyPendingAlgorithm();
-                if (self.is_rekeying) {
-                    try self.keydata.c2s.compression.activateDeflate();
-                }
                 misshod.requestWrite(wrapped, .Idle);
+                try self.activatePendingC2sKeys();
                 if (self.is_rekeying) {
                     self.is_rekeying = false;
                     self.setSessionState(.ChannelActive);
                 } else {
                     self.setSessionState(.AuthServReq);
                 }
-                self.encrypted = true;
             },
             .AuthServReq => {
                 // https://datatracker.ietf.org/doc/html/rfc4253
@@ -309,20 +522,34 @@ pub const Session = struct {
                 self.setIoSessionState(.ReadPktHdr);
             },
             .AuthStart => {
-                // if we have no private key yet, ask for one
-                // triggers caller to call setPrivateKey(), but they may not
-                if (self.privkey_ascii == null) {
+                if (self.try_none_auth) {
+                    self.setSessionState(.NoneAuthReq);
+                } else if (self.privkey_ascii == null) {
                     misshod.requestEvent(.GetPrivateKey, .Idle);
                     self.setSessionState(.GetPrivateKeyCompleted);
+                } else {
+                    self.setSessionState(.PubkeyAuthDecodeKeyPasswordless);
                 }
+            },
+            .NoneAuthReq => {
+                try self.ensureAuthMethodAvailable(.None);
+                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
+                try pkt.writeU32LenString(self.username);
+                try pkt.writeU32LenString("ssh-connection");
+                try pkt.writeU32LenString("none");
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.commitAuthRequest(misshod, .None, wrapped);
             },
             .GetPrivateKeyCompleted => {
                 TRACE(.Debug, "self.privkey_ascii = {any}", .{self.privkey_ascii});
                 if (self.privkey_ascii != null) {
                     self.setSessionState(.PubkeyAuthDecodeKeyPasswordless);
+                } else if (self.lastAuthFailure()) |failure| {
+                    self.skipAuthMethod(.PublicKey);
+                    try self.continueAuthentication(misshod, failure);
                 } else {
-                    misshod.requestEvent(.GetAuthPassphrase, .Idle);
-                    self.setSessionState(.PasswordAuthReq);
+                    self.preparePasswordAuth(misshod);
                 }
             },
             .PubkeyAuthDecodeKeyPasswordless => {
@@ -347,15 +574,18 @@ pub const Session = struct {
                         }
                     };
                     // key decoded ok, so must have been passwordless
-                    self.setSessionState(.PubkeyAuthReq);
+                    self.setSessionState(.PubkeyAuthStart);
                 } else {
                     // no key available
                     // try password auth
-                    misshod.requestEvent(.GetAuthPassphrase, .Idle);
-                    self.setSessionState(.PasswordAuthReq);
+                    self.preparePasswordAuth(misshod);
                 }
             },
+            .PubkeyAuthStart => {
+                self.setSessionState(.PubkeyAuthReq);
+            },
             .PubkeyAuthReq => {
+                try self.ensureAuthMethodAvailable(.PublicKey);
                 // https://datatracker.ietf.org/doc/html/rfc4252#section-7
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
@@ -391,8 +621,8 @@ pub const Session = struct {
                 TRACEDUMP(.Debug, "sigbytes", .{}, sig);
                 try pkt.writeU32LenString(sig);
 
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                self.setSessionState(.AuthRsp);
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.commitAuthRequest(misshod, .PublicKey, wrapped);
             },
             .PubkeyAuthDecodeKeyPassword => {
                 // attempt decode with passphrase
@@ -402,16 +632,23 @@ pub const Session = struct {
                     self.private_key = null;
                 }
                 self.private_key = decodeOpenSshPrivateKey(self.privkey_ascii.?, self.privkey_passphrase) catch {
-                    if (self.auth_passphrase == null) {
-                        misshod.requestEvent(.GetAuthPassphrase, .Idle);
+                    self.skipAuthMethod(.PublicKey);
+                    if (self.lastAuthFailure()) |failure| {
+                        try self.continueAuthentication(misshod, failure);
+                    } else {
+                        self.preparePasswordAuth(misshod);
                     }
-                    self.setSessionState(.PasswordAuthReq);
                     return;
                 };
                 // key decode ok, continue with pubkey
-                self.setSessionState(.PubkeyAuthReq);
+                self.setSessionState(.PubkeyAuthStart);
+            },
+            .PasswordAuthStart => {
+                if (self.auth_passphrase == null) return IoError.UnexpectedResponse;
+                self.setSessionState(.PasswordAuthReq);
             },
             .PasswordAuthReq => {
+                try self.ensureAuthMethodAvailable(.Password);
                 std.debug.assert(self.auth_passphrase != null);
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
@@ -422,10 +659,14 @@ pub const Session = struct {
                 try pkt.writeU32LenString("password");
                 try pkt.writeBoolean(false);
                 try pkt.writeU32LenString(self.auth_passphrase.?);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                self.setSessionState(.AuthRsp);
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.commitAuthRequest(misshod, .Password, wrapped);
+            },
+            .KeyboardInteractiveAuthStart => {
+                self.setSessionState(.KeyboardInteractiveAuthReq);
             },
             .KeyboardInteractiveAuthReq => {
+                try self.ensureAuthMethodAvailable(.KeyboardInteractive);
                 // RFC 4256 §3.1 - send keyboard-interactive auth request
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST));
@@ -434,8 +675,8 @@ pub const Session = struct {
                 try pkt.writeU32LenString("keyboard-interactive");
                 try pkt.writeU32LenString(""); // language tag
                 try pkt.writeU32LenString(""); // submethods
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                self.setSessionState(.AuthRsp);
+                const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
+                self.commitAuthRequest(misshod, .KeyboardInteractive, wrapped);
             },
             .KeyboardInteractiveInfoRsp => {
                 // RFC 4256 §3.4 - send response to info request
@@ -450,6 +691,11 @@ pub const Session = struct {
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
                 self.clearAndFreeOptional(&self.kbd_interactive_response);
                 self.setSessionState(.AuthRsp);
+            },
+            .AuthMethodQueued => {
+                const method = self.current_auth_method orelse return IoError.UnexpectedResponse;
+                self.setSessionState(.AuthRsp);
+                misshod.requestEvent(.{ .AuthMethodStarted = method }, .Idle);
             },
             .AuthRsp => { // for password or pubkey
                 self.setIoSessionState(.ReadPktHdr);
@@ -981,10 +1227,11 @@ pub const Session = struct {
 
     // special case as we write direct to stream before entering binary pkt mode
     pub fn writeProtocolVersion(self: *Self, buf: []u8) []const u8 {
-        const vers = std.fmt.bufPrint(buf, "{s}\r\n", .{Protocol.version}) catch unreachable;
-        TRACE(.Debug, "TX: version '{s}'", .{Protocol.version});
+        const client_version = self.client_version.?;
+        const vers = std.fmt.bufPrint(buf, "{s}\r\n", .{client_version}) catch unreachable;
+        TRACE(.Debug, "TX: version '{s}'", .{client_version});
         self.kex_hash_order = self.kex_hash_order.check(.V_C);
-        self.kex_hasher.writeU32LenString(Protocol.version);
+        self.kex_hasher.writeU32LenString(client_version);
         return vers;
     }
 
@@ -1167,17 +1414,14 @@ pub const Session = struct {
                     }
                     // RFC 4253 §9 - peer-initiated re-keying
                     TRACE(.Info, "Re-keying initiated by peer", .{});
-                    self.kex_hasher = Hasher(Protocol.hash_algo).init();
-                    self.kex_hash_order = .Init;
-                    self.kex_hash_order = self.kex_hash_order.check(.V_C);
-                    self.kex_hasher.writeU32LenString(Protocol.version);
-                    self.kex_hash_order = self.kex_hash_order.check(.V_S);
-                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.resetKexHasherForRekey();
                     self.is_rekeying = true;
+                    self.clearAndFreeOptional(&self.pending_server_kexinit);
+                    self.pending_server_kexinit = try self.allocator.dupe(u8, rdr.payload[(rdr.off - 1)..]);
+                } else {
+                    self.kex_hash_order = self.kex_hash_order.check(.I_S);
+                    self.kex_hasher.writeU32LenString(rdr.payload[(rdr.off - 1)..]); // from before the msgid
                 }
-
-                self.kex_hash_order = self.kex_hash_order.check(.I_S);
-                self.kex_hasher.writeU32LenString(rdr.payload[(rdr.off - 1)..]); // from before the msgid
 
                 // https://datatracker.ietf.org/doc/html/rfc4253#section-7.1
                 const cookie = try rdr.readBytes(16);
@@ -1218,8 +1462,8 @@ pub const Session = struct {
                     TRACE(.Info, "No mutual algorithm for compression_algorithms_server_to_client: peer offers '{s}', we can use '{s}'", .{ compression_s2c_namelist, Protocol.compression_algorithms });
                     return IoError.AlgorithmNegotiationFailed;
                 };
-                self.keydata.c2s.compression.queueAlgorithm(compression_c2s);
-                self.keydata.s2c.compression.queueAlgorithm(compression_s2c);
+                self.negotiated_compression_c2s = compression_c2s;
+                self.negotiated_compression_s2c = compression_s2c;
 
                 _ = try rdr.readU32LenString(); // language c2s
                 _ = try rdr.readU32LenString(); // language s2c
@@ -1229,7 +1473,7 @@ pub const Session = struct {
                 _ = try rdr.readU32(); // reserved, ignore
 
                 if (self.sessionState == .KexInitRead or is_rekey) {
-                    self.setSessionState(.EcdhInitWrite);
+                    self.setSessionState(if (is_rekey) .KexInitWrite else .EcdhInitWrite);
                     self.setIoSessionState(.Idle);
                 } else {
                     self.setIoSessionState(.ReadPktHdr);
@@ -1273,8 +1517,6 @@ pub const Session = struct {
                     self.kex_hasher.final(&kexhash, null);
                     TRACEDUMP(.Debug, "kexhash: (len={d})", .{kexhash.len}, &kexhash);
 
-                    @memcpy(&self.session_id, &kexhash); // store as session_id
-
                     const selected_sig_alg = self.selected_hostkey_algorithm orelse return IoError.UnexpectedResponse;
                     const sig_alg = try Key.signatureAlgorithm(sig_exch_hash);
                     if (sig_alg != selected_sig_alg) return IoError.AlgorithmNegotiationFailed;
@@ -1282,8 +1524,7 @@ pub const Session = struct {
                     if (pubkey.algorithm() != selected_sig_alg.keyAlgorithm()) return IoError.AlgorithmNegotiationFailed;
                     try Key.verifySignature(pubkey, sig_exch_hash, &kexhash);
 
-                    // generate keys
-                    try self.keydata.genKeys(kexhash, self.shared_secret_k, self.session_id);
+                    try self.installExchangeKeys(kexhash);
 
                     self.setSessionState(.CheckHostKey);
                     self.setIoSessionState(.Idle);
@@ -1293,10 +1534,7 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS) => {
                 if (self.sessionState == .NewKeysRead) {
-                    self.keydata.s2c.compression.applyPendingAlgorithm();
-                    if (self.is_rekeying) {
-                        try self.keydata.s2c.compression.activateInflate();
-                    }
+                    try self.activatePendingS2cKeys();
                     self.setSessionState(.NewKeysWrite);
                     self.setIoSessionState(.Idle);
                 } else {
@@ -1319,13 +1557,19 @@ pub const Session = struct {
                 misshod.requestEvent(.{ .Banner = banner }, .ReadPktHdr);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS) => {
-                // don't care what state we were in, we've been let in
+                if (self.current_auth_method == null) return IoError.UnexpectedResponse;
                 try self.activateDelayedCompression();
                 self.setIoSessionState(.Idle);
                 self.setSessionState(.ChannelOpenReq);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_FAILURE) => {
-                misshod.requestEvent(.{ .EndSession = .AuthFailure }, .Idle);
+                const methods = try rdr.readU32LenString();
+                const partial_success = try rdr.readBoolean();
+                const attempted_method = self.current_auth_method orelse return IoError.UnexpectedResponse;
+                const failure = self.rememberAuthFailure(attempted_method, methods, partial_success);
+                if (partial_success) self.beginNextAuthStage();
+                self.setIoSessionState(.Idle);
+                try self.continueAuthentication(misshod, failure);
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_PK_OK) => {
                 // RFC 4256 §3.3 - SSH_MSG_USERAUTH_INFO_REQUEST (same msg id as PK_OK)
@@ -1567,6 +1811,73 @@ fn unencryptedPayload(packet: []const u8) []const u8 {
     return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 }
 
+fn decryptFirstBlockForTest(packet: []u8, keys: *Protocol.KeyDataUni) void {
+    var encrypted_block: [Protocol.AesCtrT.block_size]u8 = undefined;
+    @memcpy(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
+    keys.aesctr.encrypt(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
+    keys.seq +%= 1;
+}
+
+fn buildAuthFailurePacket(m: *MisshodClient, methods: []const u8, partial_success: bool) !usize {
+    var payload_backing: [256]u8 = undefined;
+    var payload = BufferWriter.init(&payload_backing, 0);
+    try payload.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_FAILURE));
+    try payload.writeU32LenString(methods);
+    try payload.writeBoolean(partial_success);
+    return buildUnencryptedPacket(&m.iobuf_rd, payload.active());
+}
+
+fn writeKexInitPayload(writer: *BufferWriter) !void {
+    try writer.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT));
+    const cookie: [16]u8 = .{0x5a} ** 16;
+    try writer.writeBytes(&cookie);
+    try writer.writeU32LenString(Protocol.kex_algo_name);
+    try writer.writeU32LenString(Protocol.srv_hostkey_algo_name);
+    try writer.writeU32LenString(Protocol.enc_algo_name);
+    try writer.writeU32LenString(Protocol.enc_algo_name);
+    try writer.writeU32LenString(Protocol.mac_algo_name);
+    try writer.writeU32LenString(Protocol.mac_algo_name);
+    try writer.writeU32LenString(Protocol.compression_algorithms);
+    try writer.writeU32LenString(Protocol.compression_algorithms);
+    try writer.writeU32LenString("");
+    try writer.writeU32LenString("");
+    try writer.writeBoolean(false);
+    try writer.writeU32(0);
+}
+
+fn expectQueuedAuthMethodStarted(m: *MisshodClient, expected_method: AuthMethod) !void {
+    var ready_opt: ?Misshod.MisshodEvent(.Client) = null;
+    for (0..4) |_| {
+        ready_opt = m.getNextEvent() catch |err| switch (err) {
+            error.NotReady => continue,
+            else => return err,
+        };
+        break;
+    }
+    const ready = ready_opt orelse return error.TestUnexpectedResult;
+    switch (ready) {
+        .ReadyToProduce, .ReadyToConsumeAndProduce => {},
+        else => return error.TestUnexpectedResult,
+    }
+
+    const data = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(data));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_REQUEST), try rdr.readU8());
+    try std.testing.expectEqualStrings("testuser", try rdr.readU32LenString());
+    try std.testing.expectEqualStrings("ssh-connection", try rdr.readU32LenString());
+    try std.testing.expectEqualStrings(expected_method.name(), try rdr.readU32LenString());
+    try m.consumed(data.len);
+
+    const started = try m.getNextEvent();
+    switch (started) {
+        .Event => |code| switch (code) {
+            .AuthMethodStarted => |method| try std.testing.expectEqual(expected_method, method),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
 fn expectProducedChannelRequest(m: *MisshodClient, expected_type: []const u8) !void {
     const data = try m.peek(Protocol.MaxSSHPacket);
     var rdr = BufferReader.init(unencryptedPayload(data));
@@ -1604,6 +1915,429 @@ fn expectProducedExecRequest(m: *MisshodClient, expected_command: []const u8) !v
     try std.testing.expectEqualStrings("exec", try rdr.readU32LenString());
     try std.testing.expect(!(try rdr.readBoolean()));
     try std.testing.expectEqualStrings(expected_command, try rdr.readU32LenString());
+}
+
+test "none auth queues request before method-started event" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    try m.setTryNoneAuth(true);
+    m.session.encrypted = false;
+    m.session.setSessionState(.AuthStart);
+    m.session.setIoSessionState(.Idle);
+
+    try expectQueuedAuthMethodStarted(&m, .None);
+    try m.clearEvent(.{ .AuthMethodStarted = .None });
+    const next = try m.getNextEvent();
+    switch (next) {
+        .ReadyToConsume => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "none auth success advances without requesting credentials" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.current_auth_method = .None;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.None)] = 1;
+    m.session.setSessionState(.AuthRsp);
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    var payload = [_]u8{@intFromEnum(Protocol.MsgId.SSH_MSG_USERAUTH_SUCCESS)};
+    const pkt_len = buildUnencryptedPacket(&m.iobuf_rd, &payload);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try std.testing.expectEqual(SessionState.ChannelOpenReq, m.session.sessionState);
+    try std.testing.expect(m.session.privkey_ascii == null);
+    try std.testing.expect(m.session.auth_passphrase == null);
+}
+
+test "none rejection falls back through missing key to password" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.try_none_auth = true;
+    m.session.current_auth_method = .None;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.None)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "publickey,password,keyboard-interactive", false);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const key_event = try m.getNextEvent();
+    const key_code = switch (key_event) {
+        .Event => |code| code,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(key_code == .GetPrivateKey);
+    try m.clearEvent(key_code);
+
+    const password_event = try m.getNextEvent();
+    const password_code = switch (password_event) {
+        .Event => |code| code,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(password_code == .GetAuthPassphrase);
+    try m.setAuthPassphrase("secret");
+    try m.clearEvent(password_code);
+
+    try expectQueuedAuthMethodStarted(&m, .Password);
+}
+
+test "public key rejection with partial success falls back to password" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    try m.setAuthPassphrase("secret");
+    m.session.current_auth_method = .PublicKey;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.PublicKey)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "password,keyboard-interactive", true);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try expectQueuedAuthMethodStarted(&m, .Password);
+}
+
+test "partial success starts a new stage and permits public key again" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    try m.setPrivateKey(@import("privkey.zig").testkey_valid);
+    m.session.current_auth_method = .PublicKey;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.PublicKey)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "publickey", true);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try expectQueuedAuthMethodStarted(&m, .PublicKey);
+    try std.testing.expectEqual(@as(u8, 1), m.session.auth_stage);
+    try std.testing.expectEqual(@as(u8, 2), m.session.auth_attempts_total);
+    try std.testing.expectEqual(
+        @as(u8, 1),
+        m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.PublicKey)],
+    );
+}
+
+test "none is not retried after partial success" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.try_none_auth = true;
+    try m.setAuthPassphrase("secret");
+    m.session.current_auth_method = .None;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.None)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "none,password", true);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    try expectQueuedAuthMethodStarted(&m, .Password);
+    try std.testing.expectEqual(@as(u8, 1), m.session.auth_stage);
+    try std.testing.expectEqual(@as(u8, 2), m.session.auth_attempts_total);
+    try std.testing.expectEqual(
+        @as(u8, 0),
+        m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.None)],
+    );
+}
+
+test "partial success cannot exceed total authentication request cap" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.current_auth_method = .PublicKey;
+    m.session.auth_attempts_total = MaxAuthAttemptsTotal;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.PublicKey)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "publickey", true);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .EndSession => |reason| switch (reason) {
+                .AuthFailure => |failure| {
+                    try std.testing.expect(failure.partial_success);
+                    try std.testing.expect(failure.hasMethod(.PublicKey));
+                    try std.testing.expectEqual(@as(u8, 0), failure.auth_stage);
+                },
+                else => return error.TestUnexpectedResult,
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(MaxAuthAttemptsTotal, m.session.auth_attempts_total);
+    try std.testing.expectEqual(@as(u8, 1), m.session.auth_stage);
+}
+
+test "password rejection falls back to keyboard interactive" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.current_auth_method = .Password;
+    m.session.auth_attempts_total = 1;
+    m.session.auth_stage_attempts_by_method[@intFromEnum(AuthMethod.Password)] = 1;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const pkt_len = try buildAuthFailurePacket(&m, "keyboard-interactive", false);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+
+    try expectQueuedAuthMethodStarted(&m, .KeyboardInteractive);
+}
+
+test "auth failure preserves unsupported methods and partial success" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.encrypted = false;
+    m.session.current_auth_method = .KeyboardInteractive;
+    m.session.auth_attempts_total = MaxAuthAttemptsTotal;
+    m.session.auth_stage_attempts_by_method = .{1} ** 4;
+    m.iostate_rd = .Idle;
+    m.iostate_wr = .Idle;
+
+    const methods = "gssapi-with-mic,webauthn@vendor";
+    const pkt_len = try buildAuthFailurePacket(&m, methods, true);
+    try m.session.handlePacket(m.iobuf_rd[0..pkt_len], &m);
+    @memset(&m.iobuf_rd, 0);
+
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .EndSession => |reason| switch (reason) {
+                .AuthFailure => |failure| {
+                    try std.testing.expectEqual(AuthMethod.KeyboardInteractive, failure.attempted_method);
+                    try std.testing.expectEqualStrings(methods, failure.unsupportedMethodNames());
+                    try std.testing.expectEqual(@as(usize, 0), failure.supportedMethods().len);
+                    try std.testing.expect(failure.partial_success);
+                    try std.testing.expectEqual(@as(u8, 0), failure.auth_stage);
+                },
+                else => return error.TestUnexpectedResult,
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "default authentication still starts with credentials" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    m.session.setSessionState(.AuthStart);
+    m.session.setIoSessionState(.Idle);
+    try m.advance();
+    const evt = try m.getNextEvent();
+    switch (evt) {
+        .Event => |code| try std.testing.expect(code == .GetPrivateKey),
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(!m.session.try_none_auth);
+    try std.testing.expectEqual(@as(u8, 0), m.session.auth_attempts_total);
+}
+
+test "rekey hashes retained exact client and server versions" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), "testuser", std.testing.allocator);
+    defer session.deinit();
+
+    session.clearAndFreeOptional(&session.client_version);
+    session.client_version = try std.testing.allocator.dupe(u8, "SSH-2.0-exact_client comment");
+    try session.setPeerProtocolVersion("SSH-1.99-exact_server comment");
+    session.resetKexHasherForRekey();
+
+    var expected_hasher = Hasher(Protocol.hash_algo).init();
+    expected_hasher.writeU32LenString("SSH-2.0-exact_client comment");
+    expected_hasher.writeU32LenString("SSH-1.99-exact_server comment");
+    var expected: [Protocol.hash_algo.digest_length]u8 = undefined;
+    expected_hasher.final(&expected, null);
+    var actual: [Protocol.hash_algo.digest_length]u8 = undefined;
+    session.kex_hasher.final(&actual, null);
+
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+}
+
+test "server initiated client rekey sends and hashes client KEXINIT before server KEXINIT" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+    try m.session.setPeerProtocolVersion("SSH-2.0-test_server");
+
+    var server_payload_buf: [512]u8 = undefined;
+    var server_payload = BufferWriter.init(&server_payload_buf, 0);
+    try writeKexInitPayload(&server_payload);
+    const server_packet_len = buildUnencryptedPacket(&m.iobuf_rd, server_payload.active());
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.ReadPktHdr);
+
+    try m.session.handlePacket(m.iobuf_rd[0..server_packet_len], &m);
+    try std.testing.expect(m.session.is_rekeying);
+    try std.testing.expectEqual(SessionState.KexInitWrite, m.session.sessionState);
+    try std.testing.expectEqual(Protocol.KexHashOrder.V_S, m.session.kex_hash_order);
+    try std.testing.expectEqualStrings(server_payload.active(), m.session.pending_server_kexinit.?);
+
+    try m.session.advanceSession(&m);
+    const client_packet = try m.peek(Protocol.MaxSSHPacket);
+    const client_payload = unencryptedPayload(client_packet);
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT), client_payload[0]);
+    try std.testing.expectEqual(SessionState.EcdhInitWrite, m.session.sessionState);
+    try std.testing.expectEqual(Protocol.KexHashOrder.I_S, m.session.kex_hash_order);
+    try std.testing.expect(m.session.pending_server_kexinit == null);
+
+    var expected_hasher = Hasher(Protocol.hash_algo).init();
+    expected_hasher.writeU32LenString(m.session.client_version.?);
+    expected_hasher.writeU32LenString(m.session.server_version.?);
+    expected_hasher.writeU32LenString(client_payload);
+    expected_hasher.writeU32LenString(server_payload.active());
+    var expected: [Protocol.hash_algo.digest_length]u8 = undefined;
+    expected_hasher.final(&expected, null);
+    var actual: [Protocol.hash_algo.digest_length]u8 = undefined;
+    m.session.kex_hasher.final(&actual, null);
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+
+    try m.consumed(client_packet.len);
+    const ecdh_packet = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_KEX_ECDH_INIT),
+        unencryptedPayload(ecdh_packet)[0],
+    );
+}
+
+test "client rekey preserves initial session id for key derivation" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), "testuser", std.testing.allocator);
+    defer session.deinit();
+
+    const original_session_id: [Protocol.hash_algo.digest_length]u8 = .{0x11} ** Protocol.hash_algo.digest_length;
+    const rekey_hash: [Protocol.hash_algo.digest_length]u8 = .{0x33} ** Protocol.hash_algo.digest_length;
+    const rekey_secret: [Protocol.kex_algo.shared_length]u8 = .{0x22} ** Protocol.kex_algo.shared_length;
+    session.session_id = original_session_id;
+    session.shared_secret_k = rekey_secret;
+    session.is_rekeying = true;
+
+    var expected = Protocol.KeyDataBi.init();
+    defer expected.clear();
+    try expected.genKeys(rekey_hash, rekey_secret, original_session_id);
+    var wrong = Protocol.KeyDataBi.init();
+    defer wrong.clear();
+    try wrong.genKeys(rekey_hash, rekey_secret, rekey_hash);
+
+    try session.installExchangeKeys(rekey_hash);
+
+    const pending_c2s = &session.pending_c2s_keys.?;
+    const pending_s2c = &session.pending_s2c_keys.?;
+    try std.testing.expectEqualSlices(u8, &original_session_id, &session.session_id);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.iv, &pending_c2s.iv);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.key, &pending_c2s.key);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.mackey, &pending_c2s.mackey);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.iv, &pending_s2c.iv);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.key, &pending_s2c.key);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.mackey, &pending_s2c.mackey);
+    try std.testing.expect(!std.mem.eql(u8, &wrong.c2s.key, &pending_c2s.key));
+}
+
+test "client rekey activates inbound and outbound keys at NEWKEYS boundaries" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer m.deinit();
+
+    const session_id: [Protocol.hash_algo.digest_length]u8 = .{0x10} ** Protocol.hash_algo.digest_length;
+    const old_hash: [Protocol.hash_algo.digest_length]u8 = .{0x20} ** Protocol.hash_algo.digest_length;
+    const old_secret: [Protocol.kex_algo.shared_length]u8 = .{0x30} ** Protocol.kex_algo.shared_length;
+    const new_hash: [Protocol.hash_algo.digest_length]u8 = .{0x40} ** Protocol.hash_algo.digest_length;
+    const new_secret: [Protocol.kex_algo.shared_length]u8 = .{0x50} ** Protocol.kex_algo.shared_length;
+    m.session.session_id = session_id;
+    try m.session.keydata.genKeys(old_hash, old_secret, session_id);
+    m.session.encrypted = true;
+    m.session.inbound_encrypted = true;
+    m.session.is_rekeying = true;
+    m.session.shared_secret_k = new_secret;
+    try m.session.installExchangeKeys(new_hash);
+
+    var old_c2s = m.session.keydata.c2s;
+    var old_s2c = m.session.keydata.s2c;
+    defer old_s2c.clear();
+    const new_c2s_key = m.session.pending_c2s_keys.?.key;
+    const new_s2c_key = m.session.pending_s2c_keys.?.key;
+
+    var server_packet_buf: [Protocol.MaxSSHPacket]u8 = undefined;
+    var server_packet = BufferWriter.init(&server_packet_buf, Protocol.sizeof_PktHdr);
+    try server_packet.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
+    var server_prng = std.Random.DefaultPrng.init(99);
+    var server_rand = server_prng.random();
+    const wrapped_server_newkeys = try Protocol.wrapPkt(
+        &server_rand,
+        true,
+        &old_s2c,
+        &server_packet,
+        &server_packet_buf,
+    );
+    @memcpy(m.iobuf_rd[0..wrapped_server_newkeys.len], wrapped_server_newkeys);
+    decryptFirstBlockForTest(m.iobuf_rd[0..wrapped_server_newkeys.len], &m.session.keydata.s2c);
+    m.session.setSessionState(.NewKeysRead);
+    try m.session.handlePacket(m.iobuf_rd[0..wrapped_server_newkeys.len], &m);
+
+    try std.testing.expectEqualSlices(u8, &old_c2s.key, &m.session.keydata.c2s.key);
+    try std.testing.expectEqualSlices(u8, &new_s2c_key, &m.session.keydata.s2c.key);
+    try std.testing.expectEqual(@as(u32, 1), m.session.keydata.s2c.seq);
+    try std.testing.expect(m.session.pending_c2s_keys != null);
+    try std.testing.expect(m.session.pending_s2c_keys == null);
+
+    try m.session.advanceSession(&m);
+    const client_newkeys = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqualSlices(u8, &new_c2s_key, &m.session.keydata.c2s.key);
+    try std.testing.expectEqual(@as(u32, 1), m.session.keydata.c2s.seq);
+    try std.testing.expect(m.session.pending_c2s_keys == null);
+
+    var verifier_prng = std.Random.DefaultPrng.init(7);
+    var verifier = try Misshod.MisshodServer.init(
+        verifier_prng.random(),
+        @import("privkey.zig").testkey_valid,
+        std.testing.allocator,
+    );
+    defer verifier.deinit();
+    verifier.session.keydata.c2s.clear();
+    verifier.session.keydata.c2s = old_c2s;
+    old_c2s = .{ .seq = 0 };
+    verifier.session.inbound_encrypted = true;
+    @memcpy(verifier.iobuf_rd[0..client_newkeys.len], client_newkeys);
+    decryptFirstBlockForTest(verifier.iobuf_rd[0..client_newkeys.len], &verifier.session.keydata.c2s);
+    var rdr = try verifier.getRecvBuffer(
+        verifier.iobuf_rd[0..client_newkeys.len],
+        &verifier.session.keydata.c2s,
+    );
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS), try rdr.readU8());
 }
 
 test "handlePacket: SSH_MSG_IGNORE is silently consumed" {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -9,6 +9,7 @@ const PrivKeyError = @import("privkey.zig").PrivKeyError;
 const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const BufferReader = @import("buffer.zig").BufferReader;
+const Hasher = @import("hasher.zig").Hasher;
 
 pub const MisshodError = std.crypto.errors.Error || std.mem.Allocator.Error || BufferError || IoError || PrivKeyError || Key.KeyError;
 
@@ -33,10 +34,99 @@ pub const DisconnectReason = struct {
     description: []const u8,
 };
 
+pub const AuthMethod = enum {
+    None,
+    PublicKey,
+    Password,
+    KeyboardInteractive,
+
+    pub fn name(self: AuthMethod) []const u8 {
+        return switch (self) {
+            .None => "none",
+            .PublicKey => "publickey",
+            .Password => "password",
+            .KeyboardInteractive => "keyboard-interactive",
+        };
+    }
+
+    pub fn fromName(method_name: []const u8) ?AuthMethod {
+        inline for (std.meta.tags(AuthMethod)) |method| {
+            if (std.mem.eql(u8, method_name, method.name())) return method;
+        }
+        return null;
+    }
+};
+
+pub const AuthFailureInfo = struct {
+    pub const MaxSupportedMethods = std.meta.tags(AuthMethod).len;
+    pub const MaxUnsupportedMethodsLen = 128;
+
+    attempted_method: AuthMethod,
+    supported_methods: [MaxSupportedMethods]AuthMethod = .{.None} ** MaxSupportedMethods,
+    supported_methods_len: u8 = 0,
+    unsupported_methods: [MaxUnsupportedMethodsLen]u8 = .{0} ** MaxUnsupportedMethodsLen,
+    unsupported_methods_len: u8 = 0,
+    partial_success: bool,
+    auth_stage: u8,
+
+    pub fn parse(
+        attempted_method: AuthMethod,
+        method_names: []const u8,
+        partial_success: bool,
+        auth_stage: u8,
+    ) AuthFailureInfo {
+        var info: AuthFailureInfo = .{
+            .attempted_method = attempted_method,
+            .partial_success = partial_success,
+            .auth_stage = auth_stage,
+        };
+        var iter = std.mem.splitSequence(u8, method_names, ",");
+        while (iter.next()) |name| {
+            if (name.len == 0) continue;
+            if (AuthMethod.fromName(name)) |method| {
+                if (!info.hasMethod(method) and info.supported_methods_len < MaxSupportedMethods) {
+                    info.supported_methods[info.supported_methods_len] = method;
+                    info.supported_methods_len += 1;
+                }
+            } else {
+                info.appendUnsupportedMethod(name);
+            }
+        }
+        return info;
+    }
+
+    pub fn supportedMethods(self: *const AuthFailureInfo) []const AuthMethod {
+        return self.supported_methods[0..self.supported_methods_len];
+    }
+
+    pub fn unsupportedMethodNames(self: *const AuthFailureInfo) []const u8 {
+        return self.unsupported_methods[0..self.unsupported_methods_len];
+    }
+
+    pub fn hasMethod(self: *const AuthFailureInfo, method: AuthMethod) bool {
+        for (self.supportedMethods()) |supported| {
+            if (supported == method) return true;
+        }
+        return false;
+    }
+
+    fn appendUnsupportedMethod(self: *AuthFailureInfo, name: []const u8) void {
+        var offset: usize = self.unsupported_methods_len;
+        if (offset != 0) {
+            if (offset + 1 >= self.unsupported_methods.len) return;
+            self.unsupported_methods[offset] = ',';
+            offset += 1;
+        }
+        const copy_len = @min(name.len, self.unsupported_methods.len - offset);
+        @memcpy(self.unsupported_methods[offset .. offset + copy_len], name[0..copy_len]);
+        self.unsupported_methods_len = @intCast(offset + copy_len);
+    }
+};
+
 pub const EndSessionReason = union(enum) {
     Disconnect,
     ServerDisconnect: DisconnectReason,
-    AuthFailure,
+    AuthFailure: AuthFailureInfo,
 };
 
 pub const Role = enum {
@@ -75,7 +165,9 @@ pub const HostKeyInfo = struct {
 };
 
 pub const MisshodClientEventCodes = union(enum) {
+    ServerIdentification: []const u8,
     CheckHostKey: HostKeyInfo,
+    AuthMethodStarted: AuthMethod,
     GetPrivateKey,
     GetKeyPassphrase,
     GetAuthPassphrase,
@@ -534,7 +626,7 @@ pub fn MisshodImpl(role: Role) type {
             if (pkt_len > iobuf.len) return IoError.InvalidPacketSize;
             const payload = iobuf[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
 
-            if (!self.session.encrypted) {
+            if (!self.session.inbound_encrypted) {
                 const decompressed = try inkeys.compression.decompressPayload(payload, &self.iobuf_decompressed);
                 return BufferReader.init(decompressed);
             } else {
@@ -603,40 +695,51 @@ pub fn MisshodImpl(role: Role) type {
                     self.requestRead(0, 1, .{ .VersionReadLineChar = self.iobuf_rd[0..1] });
                 },
                 .VersionReadLineChar => |buf| {
-                    if (buf.len + 1 > self.iobuf_rd.len) {
-                        return IoError.noEOLFound;
-                    } else {
-                        if (buf.len >= 2) {
-                            if (buf[buf.len - 2] == '\r' and buf[buf.len - 1] == '\n') {
-                                self.session.setIoSessionState(.{ .VersionReadLineCompletion = buf });
-                                return;
-                            }
-                        }
-                        // read next char
-                        self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf_rd[0 .. buf.len + 1] });
+                    if (buf.len >= 1 and buf[buf.len - 1] == '\n') {
+                        self.session.setIoSessionState(.{ .VersionReadLineCompletion = buf });
+                        return;
                     }
+                    if (buf.len >= Protocol.MaxIdentificationLineLen) return IoError.noEOLFound;
+                    self.requestRead(buf.len, 1, .{ .VersionReadLineChar = self.iobuf_rd[0 .. buf.len + 1] });
                 },
                 .VersionReadLineCompletion => |buf| {
-                    TRACE(.Debug, "RX: version '{s}'", .{util.chomp(buf)});
+                    const terminator_len: usize = if (buf.len >= 2 and buf[buf.len - 2] == '\r') 2 else 1;
+                    const version = buf[0 .. buf.len - terminator_len];
+                    if (!std.mem.startsWith(u8, version, "SSH-")) {
+                        if (comptime role == .Server) return IoError.UnexpectedResponse;
+                        self.session.pre_identification_lines += 1;
+                        if (self.session.pre_identification_lines > Protocol.MaxPreIdentificationLines) {
+                            return IoError.UnexpectedResponse;
+                        }
+                        self.session.setIoSessionState(.VersionReadLine);
+                        return;
+                    }
+
+                    if (!Protocol.isValidIdentification(version)) return IoError.UnexpectedResponse;
+                    TRACE(.Debug, "RX: version '{s}'", .{version});
+                    try self.session.setPeerProtocolVersion(version);
                     switch (role) {
                         .Client => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_S),
                         .Server => self.session.kex_hash_order = self.session.kex_hash_order.check(.V_C),
                     }
-                    self.session.kex_hasher.writeU32LenString(util.chomp(buf));
+                    self.session.kex_hasher.writeU32LenString(version);
                     switch (role) {
-                        .Client => self.session.setIoSessionState(.Idle),
+                        .Client => {
+                            self.session.setIoSessionState(.Idle);
+                            self.requestEvent(.{ .ServerIdentification = self.session.server_version.? }, .Idle);
+                        },
                         .Server => self.session.setIoSessionState(.VersionWrite),
                     }
                 },
                 .ReadPktHdr => {
-                    if (self.session.encrypted) {
+                    if (self.session.inbound_encrypted) {
                         self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.AesCtrT.block_size] });
                     } else {
                         self.requestRead(0, Protocol.sizeof_PktHdr, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.sizeof_PktHdr] });
                     }
                 },
                 .ReadPktBody => |buf| {
-                    if (self.session.encrypted) {
+                    if (self.session.inbound_encrypted) {
                         // https://datatracker.ietf.org/doc/html/rfc4253#section-6
                         // grab first encrypted block from writebuf
                         var firstblock_encbuf: [Protocol.AesCtrT.block_size]u8 = undefined;
@@ -745,6 +848,13 @@ pub fn MisshodImpl(role: Role) type {
 
         pub fn setAuthPassphrase(self: *Self, data: []const u8) MisshodError!void {
             try self.session.setAuthPassphrase(data);
+        }
+
+        pub fn setTryNoneAuth(self: *Self, enabled: bool) MisshodError!void {
+            return switch (role) {
+                .Client => self.session.setTryNoneAuth(enabled),
+                .Server => IoError.UnimplementedService,
+            };
         }
 
         pub fn isActive(self: *Self) bool {
@@ -1002,9 +1112,37 @@ pub fn MisshodImpl(role: Role) type {
     };
 }
 
+fn feedClientIdentificationBytes(client: *MisshodClient, bytes: []const u8) !void {
+    for (bytes) |byte| {
+        const evt = try client.getNextEvent();
+        const can_consume = switch (evt) {
+            .ReadyToConsume => |n| n,
+            .ReadyToConsumeAndProduce => |sizes| sizes.consume,
+            else => return error.TestUnexpectedResult,
+        };
+        try std.testing.expect(can_consume > 0);
+        try client.write(&.{byte});
+    }
+}
+
+fn startClientIdentificationRead(client: *MisshodClient) !void {
+    const initial = try client.getNextEvent();
+    switch (initial) {
+        .ReadyToProduce => {},
+        else => return error.TestUnexpectedResult,
+    }
+    const client_identification = try client.peek(Protocol.MaxIdentificationLineLen);
+    try client.consumed(client_identification.len);
+}
+
 test "EndSessionReason tagged union" {
     const reason_disconnect: EndSessionReason = .Disconnect;
-    const reason_auth: EndSessionReason = .AuthFailure;
+    const reason_auth: EndSessionReason = .{ .AuthFailure = AuthFailureInfo.parse(
+        .Password,
+        "keyboard-interactive",
+        true,
+        2,
+    ) };
     const reason_server: EndSessionReason = .{ .ServerDisconnect = .{
         .code = 11,
         .description = "test disconnect",
@@ -1016,7 +1154,16 @@ test "EndSessionReason tagged union" {
     }
 
     switch (reason_auth) {
-        .AuthFailure => {},
+        .AuthFailure => |failure| {
+            try std.testing.expectEqual(AuthMethod.Password, failure.attempted_method);
+            try std.testing.expectEqualSlices(
+                AuthMethod,
+                &.{.KeyboardInteractive},
+                failure.supportedMethods(),
+            );
+            try std.testing.expect(failure.partial_success);
+            try std.testing.expectEqual(@as(u8, 2), failure.auth_stage);
+        },
         else => return error.TestUnexpectedResult,
     }
 
@@ -1027,6 +1174,209 @@ test "EndSessionReason tagged union" {
         },
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "AuthFailureInfo public API is value-owned for apk2" {
+    var method_names = "publickey,gssapi-with-mic,password".*;
+    const failure = AuthFailureInfo.parse(.None, &method_names, true, 3);
+    @memset(&method_names, 'x');
+
+    try std.testing.expectEqual(AuthMethod.None, failure.attempted_method);
+    try std.testing.expectEqualSlices(
+        AuthMethod,
+        &.{ .PublicKey, .Password },
+        failure.supportedMethods(),
+    );
+    try std.testing.expectEqual(@as(u8, 2), failure.supported_methods_len);
+    try std.testing.expectEqualStrings("gssapi-with-mic", failure.unsupportedMethodNames());
+    try std.testing.expectEqual(@as(u8, "gssapi-with-mic".len), failure.unsupported_methods_len);
+    try std.testing.expectEqual(@as(usize, 128), failure.unsupported_methods.len);
+    try std.testing.expect(failure.partial_success);
+    try std.testing.expectEqual(@as(u8, 3), failure.auth_stage);
+
+    var long_unsupported: [AuthFailureInfo.MaxUnsupportedMethodsLen + 16]u8 = undefined;
+    @memset(&long_unsupported, 'u');
+    const bounded = AuthFailureInfo.parse(.Password, &long_unsupported, false, 1);
+    try std.testing.expectEqual(
+        @as(usize, AuthFailureInfo.MaxUnsupportedMethodsLen),
+        bounded.unsupportedMethodNames().len,
+    );
+}
+
+test "client retains exact server identification after RFC preamble" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+
+    const initial = try client.getNextEvent();
+    switch (initial) {
+        .ReadyToProduce => {},
+        else => return error.TestUnexpectedResult,
+    }
+    const client_identification = try client.peek(Protocol.MaxIdentificationLineLen);
+    try std.testing.expectEqualStrings(Protocol.version ++ "\r\n", client_identification);
+    try client.consumed(client_identification.len);
+
+    try feedClientIdentificationBytes(&client, "NOTICE exact spaces  \r\n");
+    try feedClientIdentificationBytes(&client, "SSH-2.0-test_server exact café  \r\n");
+
+    const evt = try client.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ServerIdentification => |identification| {
+                try std.testing.expectEqualStrings("SSH-2.0-test_server exact café  ", identification);
+                try std.testing.expectEqualStrings(identification, client.session.server_version.?);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), client.session.pre_identification_lines);
+}
+
+test "client accepts 255 byte pre-identification and identification lines" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    try startClientIdentificationRead(&client);
+
+    var preamble: [Protocol.MaxIdentificationLineLen]u8 = undefined;
+    @memset(&preamble, 'p');
+    preamble[preamble.len - 2] = '\r';
+    preamble[preamble.len - 1] = '\n';
+    try feedClientIdentificationBytes(&client, &preamble);
+
+    var identification: [Protocol.MaxIdentificationLineLen]u8 = undefined;
+    @memset(&identification, 's');
+    const prefix = "SSH-2.0-";
+    @memcpy(identification[0..prefix.len], prefix);
+    identification[identification.len - 2] = '\r';
+    identification[identification.len - 1] = '\n';
+    try feedClientIdentificationBytes(&client, &identification);
+
+    const evt = try client.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ServerIdentification => |server_identification| {
+                try std.testing.expectEqual(
+                    Protocol.MaxIdentificationLineLen - 2,
+                    server_identification.len,
+                );
+                try std.testing.expectEqualStrings(
+                    identification[0 .. identification.len - 2],
+                    server_identification,
+                );
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), client.session.pre_identification_lines);
+}
+
+test "client accepts and hashes exact 255 byte LF-only SSH 1.99 identification" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    try startClientIdentificationRead(&client);
+
+    var identification: [Protocol.MaxIdentificationLineLen]u8 = undefined;
+    @memset(&identification, 's');
+    const prefix = "SSH-1.99-";
+    @memcpy(identification[0..prefix.len], prefix);
+    identification[identification.len - 1] = '\n';
+    try feedClientIdentificationBytes(&client, &identification);
+
+    const exact = identification[0 .. identification.len - 1];
+    const evt = try client.getNextEvent();
+    switch (evt) {
+        .Event => |code| switch (code) {
+            .ServerIdentification => |server_identification| {
+                try std.testing.expectEqualStrings(exact, server_identification);
+                try std.testing.expectEqualStrings(exact, client.session.server_version.?);
+            },
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    var expected_hasher = Hasher(Protocol.hash_algo).init();
+    expected_hasher.writeU32LenString(Protocol.version);
+    expected_hasher.writeU32LenString(exact);
+    var expected: [Protocol.hash_algo.digest_length]u8 = undefined;
+    expected_hasher.final(&expected, null);
+    var actual: [Protocol.hash_algo.digest_length]u8 = undefined;
+    client.session.kex_hasher.final(&actual, null);
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+}
+
+test "client rejects identification line whose CRLF would exceed 255 bytes" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    try startClientIdentificationRead(&client);
+
+    var overlong: [Protocol.MaxIdentificationLineLen + 1]u8 = undefined;
+    @memset(&overlong, 'x');
+    overlong[overlong.len - 2] = '\r';
+    overlong[overlong.len - 1] = '\n';
+    try feedClientIdentificationBytes(&client, overlong[0 .. Protocol.MaxIdentificationLineLen - 1]);
+    try std.testing.expectError(
+        IoError.noEOLFound,
+        client.write(overlong[Protocol.MaxIdentificationLineLen - 1 .. Protocol.MaxIdentificationLineLen]),
+    );
+}
+
+test "client rejects unterminated 255 byte identification line" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+    try startClientIdentificationRead(&client);
+
+    var unterminated: [Protocol.MaxIdentificationLineLen]u8 = undefined;
+    @memset(&unterminated, 'x');
+    try feedClientIdentificationBytes(&client, unterminated[0 .. unterminated.len - 1]);
+    try std.testing.expectError(
+        IoError.noEOLFound,
+        client.write(unterminated[unterminated.len - 1 ..]),
+    );
+}
+
+test "client rejects malformed SSH identification grammar and bytes" {
+    const malformed = [_][]const u8{
+        "SSH-2.0-\r\n",
+        "SSH-2.0- comment-without-software\r\n",
+        "SSH-two.server\r\n",
+        "SSH-2.0-server\x01comment\r\n",
+        "SSH-2.0-server\x7fcomment\r\n",
+        "SSH-2.0-server\x80comment\r\n",
+    };
+
+    for (malformed) |line| {
+        var prng = std.Random.DefaultPrng.init(42);
+        var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+        defer client.deinit();
+        try startClientIdentificationRead(&client);
+        try std.testing.expectError(
+            IoError.UnexpectedResponse,
+            feedClientIdentificationBytes(&client, line),
+        );
+    }
+}
+
+test "client bounds pre-identification lines" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var client = try MisshodClient.init(prng.random(), "testuser", std.testing.allocator);
+    defer client.deinit();
+
+    _ = try client.getNextEvent();
+    const client_identification = try client.peek(Protocol.MaxIdentificationLineLen);
+    try client.consumed(client_identification.len);
+    client.session.pre_identification_lines = Protocol.MaxPreIdentificationLines;
+
+    const line = "one-too-many\r\n";
+    try feedClientIdentificationBytes(&client, line[0 .. line.len - 1]);
+    try std.testing.expectError(IoError.UnexpectedResponse, client.write(line[line.len - 1 ..]));
 }
 
 test "MisshodClientEventCodes Banner variant" {
@@ -1164,6 +1514,7 @@ test "client-server full handshake round-trip" {
 
     var client = try MisshodClient.init(cprng.random(), "testuser", std.testing.allocator);
     defer client.deinit();
+    try client.setTryNoneAuth(true);
     var server = try MisshodServer.init(sprng.random(), privkey.testkey_valid, std.testing.allocator);
     defer server.deinit();
 
@@ -1173,6 +1524,10 @@ test "client-server full handshake round-trip" {
     var s2c_len: usize = 0;
 
     var connected_client = false;
+    var event_order: usize = 0;
+    var identification_order: ?usize = null;
+    var host_key_order: ?usize = null;
+    var auth_order: ?usize = null;
 
     const Endpoint = enum { client_ep, server_ep };
     const endpoints = [_]Endpoint{ .client_ep, .server_ep };
@@ -1214,7 +1569,19 @@ test "client-server full handshake round-trip" {
                         }
                     },
                     .Event => |code| switch (code) {
+                        .ServerIdentification => {
+                            identification_order = event_order;
+                            event_order += 1;
+                            client.clearEvent(code) catch {};
+                        },
+                        .AuthMethodStarted => {
+                            auth_order = event_order;
+                            event_order += 1;
+                            client.clearEvent(code) catch {};
+                        },
                         .CheckHostKey => {
+                            host_key_order = event_order;
+                            event_order += 1;
                             client.clearEvent(.{ .CheckHostKey = .{ .raw_key = null, .fingerprint = .{0} ** 32 } }) catch {};
                         },
                         .GetPrivateKey => {
@@ -1283,6 +1650,8 @@ test "client-server full handshake round-trip" {
     }
 
     try std.testing.expect(connected_client);
+    try std.testing.expect(identification_order.? < host_key_order.?);
+    try std.testing.expect(host_key_order.? < auth_order.?);
 }
 
 test "HostKeyInfo fingerprint computation" {

--- a/src/misshod.zig
+++ b/src/misshod.zig
@@ -606,8 +606,16 @@ pub fn MisshodImpl(role: Role) type {
                 // entire block has been consumed by caller
                 switch (self.iostate_wr) {
                     .Active => |iotype| {
-                        self.session.setIoSessionState(iotype.next_state);
                         self.iostate_wr = .Idle;
+                        switch (iotype.next_state) {
+                            .ChannelWriteComplete => |channel_id| {
+                                try self.session.completeChannelWrite(channel_id, self);
+                            },
+                            .ChannelControlComplete => |channel_id| {
+                                try self.session.completeChannelControl(channel_id, self);
+                            },
+                            else => self.session.setIoSessionState(iotype.next_state),
+                        }
                         try self.advance();
                     },
                     else => unreachable,
@@ -731,7 +739,10 @@ pub fn MisshodImpl(role: Role) type {
                         .Server => self.session.setIoSessionState(.VersionWrite),
                     }
                 },
+                .ChannelWriteComplete => return IoError.UnexpectedResponse,
+                .ChannelControlComplete => return IoError.UnexpectedResponse,
                 .ReadPktHdr => {
+                    _ = try self.session.dispatchDeferredChannelWrite(self);
                     if (self.session.inbound_encrypted) {
                         self.requestRead(0, Protocol.AesCtrT.block_size, .{ .ReadPktBody = self.iobuf_rd[0..Protocol.AesCtrT.block_size] });
                     } else {
@@ -814,6 +825,8 @@ pub fn MisshodImpl(role: Role) type {
                 .ReadPktHdr, .ReadPktBody => self.iostate_rd == .Idle,
                 // Write-requiring states need write side idle
                 .VersionWrite => self.iostate_wr == .Idle,
+                .ChannelWriteComplete => false,
+                .ChannelControlComplete => false,
                 // Processing states
                 .VersionReadLineCompletion => true, // just sets next ioSessionState
                 .ReadPktCompletion => self.iostate_wr == .Idle, // handlePacket may event/write
@@ -866,15 +879,11 @@ pub fn MisshodImpl(role: Role) type {
         }
 
         pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
-            if (self.iostate_wr == .Idle and self.iostate_rd != .Idle) {
+            if (self.iostate_wr != .Idle) return IoError.cannotAcceptWrite;
+            if (self.iostate_rd != .Idle) {
                 try self.session.directChannelWrite(channel_id, nbytes, self);
             } else {
-                self.iostate_rd = .Idle;
-                self.iostate_wr = .Idle;
-                try self.advance();
                 try self.session.channelWriteComplete(channel_id, nbytes);
-                self.iostate_rd = .Idle;
-                self.iostate_wr = .Idle;
                 try self.advance();
             }
         }
@@ -1079,14 +1088,12 @@ pub fn MisshodImpl(role: Role) type {
         }
 
         pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
-            try self.session.sendChannelEof(channel_id);
-            self.iostate_wr = .Idle;
+            try self.session.sendChannelEof(channel_id, self);
             try self.advance();
         }
 
         pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
-            try self.session.sendChannelClose(channel_id);
-            self.iostate_wr = .Idle;
+            try self.session.sendChannelClose(channel_id, self);
             try self.advance();
         }
 
@@ -2039,7 +2046,13 @@ test "ReadyToConsumeAndProduce struct fields" {
     }
 }
 
-test "full handshake round-trip then channel data exchange" {
+fn largeChannelTestByte(packet_index: u8, byte_index: usize) u8 {
+    var value: u32 = @intCast(byte_index);
+    value = value *% 1664525 +% 1013904223 +% packet_index;
+    return @truncate(value >> 24);
+}
+
+test "full handshake round-trip handles multiple large compressed channel packets" {
     const privkey = @import("privkey.zig");
 
     var cprng = std.Random.DefaultPrng.init(10);
@@ -2051,21 +2064,22 @@ test "full handshake round-trip then channel data exchange" {
     defer server.deinit();
 
     var c2s_buf: [16384]u8 = undefined;
-    var s2c_buf: [16384]u8 = undefined;
+    var s2c_buf: [Protocol.MaxSSHPacket]u8 = undefined;
     var c2s_len: usize = 0;
     var s2c_len: usize = 0;
 
     var connected_client = false;
     var connected_server = false;
-    var server_sent_data = false;
-    var client_rx_data: bool = false;
+    var server_packets_sent: u8 = 0;
+    var client_packets_received: u8 = 0;
+    const packet_lengths = [_]usize{ 12_000, 6_000 };
 
     const Endpoint = enum { client_ep, server_ep };
     const endpoints = [_]Endpoint{ .client_ep, .server_ep };
 
     var steps: usize = 0;
     while (steps < 1000) : (steps += 1) {
-        if (client_rx_data) break;
+        if (client_packets_received == packet_lengths.len) break;
 
         for (endpoints) |ep| {
             if (ep == .client_ep) {
@@ -2097,7 +2111,16 @@ test "full handshake round-trip then channel data exchange" {
                             client.clearEvent(.Connected) catch {};
                         },
                         .RxData => |data| {
-                            if (data.len > 0) client_rx_data = true;
+                            const packet_index: usize = client_packets_received;
+                            try std.testing.expect(packet_index < packet_lengths.len);
+                            try std.testing.expectEqual(packet_lengths[packet_index], data.len);
+                            for (data, 0..) |byte, byte_index| {
+                                try std.testing.expectEqual(
+                                    largeChannelTestByte(@intCast(packet_index), byte_index),
+                                    byte,
+                                );
+                            }
+                            client_packets_received += 1;
                             client.clearEvent(.{ .RxData = data }) catch {};
                         },
                         .EndSession => break,
@@ -2139,14 +2162,16 @@ test "full handshake round-trip then channel data exchange" {
                     },
                 }
 
-                // After server connects and event loop is clear, send channel data
-                if (connected_server and !server_sent_data and server.iostate_wr == .Idle) {
+                if (connected_server and server_packets_sent < packet_lengths.len and server.iostate_wr == .Idle and s2c_len == 0) {
                     const buf = server.getChannelWriteBuffer(0) catch continue;
-                    if (buf.len > 0) {
-                        const msg = "hello from server";
-                        @memcpy(buf[0..msg.len], msg);
-                        server.channelWriteComplete(0, msg.len) catch continue;
-                        server_sent_data = true;
+                    const packet_index: usize = server_packets_sent;
+                    const packet_len = packet_lengths[packet_index];
+                    if (buf.len >= packet_len) {
+                        for (buf[0..packet_len], 0..) |*byte, byte_index| {
+                            byte.* = largeChannelTestByte(@intCast(packet_index), byte_index);
+                        }
+                        server.channelWriteComplete(0, packet_len) catch continue;
+                        server_packets_sent += 1;
                     }
                 }
             }
@@ -2155,7 +2180,7 @@ test "full handshake round-trip then channel data exchange" {
 
     try std.testing.expect(connected_client);
     try std.testing.expect(connected_server);
-    try std.testing.expect(client_rx_data);
+    try std.testing.expectEqual(@as(u8, packet_lengths.len), client_packets_received);
     try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, client.session.keydata.c2s.compression.algorithm);
     try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, client.session.keydata.s2c.compression.algorithm);
     try std.testing.expectEqual(Protocol.CompressionAlgorithm.ZlibOpenSsh, server.session.keydata.c2s.compression.algorithm);

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -101,10 +101,33 @@ pub const KexHashOrder = enum { // https://datatracker.ietf.org/doc/html/rfc5656
     }
 };
 
-pub const MaxSSHPacket = 4096; // Can be smaller https://datatracker.ietf.org/doc/html/rfc4253#section-5.3
+// RFC 4253 §6.1 requires support for uncompressed payloads of at least 32768 bytes.
+// This internal bound includes packet framing, maximum padding, and the MAC.
+pub const MaxSSHPacket = 35000;
 pub const MaxPayload = (MaxSSHPacket - (sizeof_PktHdr + 255 + mac_algo.key_length));
-// Max channel data: MaxPayload minus channel data framing (msgid:1 + channel:4 + string_len:4)
-pub const MaxChannelDataLen = MaxPayload - 9;
+pub const ChannelDataFramingLen = 1 + 4 + 4;
+pub const ChannelExtendedDataFramingLen = 1 + 4 + 4 + 4;
+
+// zlib's documented compressBound formula plus conservative Z_SYNC_FLUSH room.
+pub fn zlibSyncFlushBound(input_len: usize) usize {
+    return input_len +
+        (input_len >> 12) +
+        (input_len >> 14) +
+        (input_len >> 25) +
+        32;
+}
+
+fn maxChannelDataLen() usize {
+    var data_len = MaxPayload - ChannelExtendedDataFramingLen;
+    while (zlibSyncFlushBound(data_len + ChannelExtendedDataFramingLen) > MaxPayload) {
+        data_len -= 1;
+    }
+    return data_len;
+}
+
+// Logical/decompressed channel bytes guaranteed to fit both DATA and
+// EXTENDED_DATA after worst-case delayed-zlib expansion.
+pub const MaxChannelDataLen = maxChannelDataLen();
 pub const MaxIVLen = 20; // number of bytes to generate for IVs
 pub const MaxKeyLen = 64; // number of bytes to generate for keys
 pub const MaxIdentificationLineLen = 255;
@@ -178,6 +201,8 @@ pub const IoSessionState = union(enum) {
     VersionReadLine,
     VersionReadLineChar: []const u8,
     VersionReadLineCompletion: []const u8,
+    ChannelWriteComplete: u32,
+    ChannelControlComplete: u32,
     ReadPktHdr,
     ReadPktBody: []const u8,
     ReadPktCompletion: []const u8,
@@ -558,11 +583,15 @@ test "MaxPayload is reasonable" {
     try std.testing.expect(MaxPayload < MaxSSHPacket);
 }
 
-test "MaxChannelDataLen accounts for framing overhead" {
-    // Channel data framing: msgid(1) + channel(4) + string_len(4) = 9 bytes
-    try std.testing.expectEqual(MaxPayload - 9, MaxChannelDataLen);
+test "MaxChannelDataLen accounts for extended framing and zlib expansion" {
+    try std.testing.expect(
+        zlibSyncFlushBound(MaxChannelDataLen + ChannelExtendedDataFramingLen) <= MaxPayload,
+    );
+    try std.testing.expect(
+        zlibSyncFlushBound(MaxChannelDataLen + 1 + ChannelExtendedDataFramingLen) > MaxPayload,
+    );
     try std.testing.expect(MaxChannelDataLen > 0);
-    try std.testing.expect(MaxChannelDataLen > 64); // must be larger than old hardcoded value
+    try std.testing.expect(MaxChannelDataLen >= 32768);
 }
 
 test "agent forwarding channel type aliases" {
@@ -599,6 +628,52 @@ test "zlib openssh compression streams round trip flushed packets" {
     const compressed2 = try compressor.compressPayload(payload2, &compressed);
     const decompressed2 = try decompressor.decompressPayload(compressed2, &decompressed);
     try std.testing.expectEqualStrings(payload2, decompressed2);
+}
+
+fn incompressibleTestByte(index: usize) u8 {
+    var value: u32 = @intCast(index);
+    value = value *% 1664525 +% 1013904223;
+    return @truncate(value >> 24);
+}
+
+fn expectExactBoundCompressedChannelPayload(extended: bool) !void {
+    var logical_data: [MaxChannelDataLen]u8 = undefined;
+    for (&logical_data, 0..) |*byte, index| byte.* = incompressibleTestByte(index);
+
+    var payload_backing: [MaxPayload]u8 = undefined;
+    var payload = BufferWriter.init(&payload_backing, 0);
+    try payload.writeU8(@intFromEnum(if (extended) MsgId.SSH_MSG_CHANNEL_EXTENDED_DATA else MsgId.SSH_MSG_CHANNEL_DATA));
+    try payload.writeU32(7);
+    if (extended) try payload.writeU32(1);
+    try payload.writeU32LenString(&logical_data);
+
+    var sender = KeyDataUni{ .seq = 0, .compression = .{ .algorithm = .ZlibOpenSsh } };
+    defer sender.clear();
+    try sender.compression.activateDeflate();
+    var prng = std.Random.DefaultPrng.init(42);
+    var rand = prng.random();
+    var packet_buf: [MaxSSHPacket]u8 = undefined;
+    const packet = try wrapPayload(&rand, false, &sender, payload.active(), &packet_buf);
+
+    const hdr = readPktHdr(packet[0..sizeof_PktHdr]);
+    const compressed_len: usize = @intCast(hdr.packet_length - hdr.padding_length - 1);
+    var receiver = CompressionState{ .algorithm = .ZlibOpenSsh };
+    defer receiver.deinit();
+    try receiver.activateInflate();
+    var decompressed: [MaxPayload]u8 = undefined;
+    const decoded = try receiver.decompressPayload(
+        packet[sizeof_PktHdr .. sizeof_PktHdr + compressed_len],
+        &decompressed,
+    );
+    try std.testing.expectEqualSlices(u8, payload.active(), decoded);
+}
+
+test "exact advertised DATA bound is encodable with incompressible zlib" {
+    try expectExactBoundCompressedChannelPayload(false);
+}
+
+test "exact advertised EXTENDED_DATA bound is encodable with incompressible zlib" {
+    try expectExactBoundCompressedChannelPayload(true);
 }
 
 test "zlib openssh decompression rejects invalid data" {

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -107,9 +107,38 @@ pub const MaxPayload = (MaxSSHPacket - (sizeof_PktHdr + 255 + mac_algo.key_lengt
 pub const MaxChannelDataLen = MaxPayload - 9;
 pub const MaxIVLen = 20; // number of bytes to generate for IVs
 pub const MaxKeyLen = 64; // number of bytes to generate for keys
+pub const MaxIdentificationLineLen = 255;
+pub const MaxPreIdentificationLines = 50;
 
 // https://datatracker.ietf.org/doc/html/rfc4253#section-4.2
-pub const version = "SSH-2.0-SSH_ZS-0.0.1";
+pub const version = "SSH-2.0-SSH_ZS_0.0.1";
+
+pub fn isValidIdentification(identification: []const u8) bool {
+    const prefix = if (std.mem.startsWith(u8, identification, "SSH-2.0-"))
+        "SSH-2.0-"
+    else if (std.mem.startsWith(u8, identification, "SSH-1.99-"))
+        "SSH-1.99-"
+    else
+        return false;
+
+    const remainder = identification[prefix.len..];
+    const comments_separator = std.mem.indexOfScalar(u8, remainder, ' ');
+    const software_version = if (comments_separator) |index| remainder[0..index] else remainder;
+    if (software_version.len == 0) return false;
+    for (software_version) |byte| {
+        const valid = (byte >= 0x21 and byte <= 0x2c) or (byte >= 0x2e and byte <= 0x7e);
+        if (!valid) return false;
+    }
+
+    if (comments_separator) |index| {
+        const comments = remainder[index + 1 ..];
+        for (comments) |byte| {
+            if (byte == 0 or byte == '\r' or byte == '\n') return false;
+        }
+        if (!std.unicode.utf8ValidateSlice(comments)) return false;
+    }
+    return true;
+}
 
 pub const hash_algo = std.crypto.hash.sha2.Sha256;
 pub const hash_algo_name = "hmac-sha2-256";
@@ -486,6 +515,25 @@ pub fn wrapPayload(rand: *std.Random, encrypted: bool, keysuni: *KeyDataUni, pay
         keysuni.seq +%= 1;
         return iobuf[0..packet_len];
     }
+}
+
+test "identification accepts valid UTF-8 comments" {
+    try std.testing.expect(isValidIdentification("SSH-2.0-server café 🚀"));
+}
+
+test "identification accepts SSH 1.99 compatibility version" {
+    try std.testing.expect(isValidIdentification("SSH-1.99-server compatibility"));
+}
+
+test "identification rejects hyphen in softwareversion" {
+    try std.testing.expect(!isValidIdentification("SSH-2.0-server-name comment"));
+}
+
+test "identification rejects invalid UTF-8 and forbidden comment bytes" {
+    try std.testing.expect(!isValidIdentification("SSH-2.0-server \x80"));
+    try std.testing.expect(!isValidIdentification("SSH-2.0-server comment\x00text"));
+    try std.testing.expect(!isValidIdentification("SSH-2.0-server comment\rtext"));
+    try std.testing.expect(!isValidIdentification("SSH-2.0-server comment\ntext"));
 }
 
 test "MsgId enum values match SSH RFC" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -17,6 +17,8 @@ const PrivKeyError = @import("privkey.zig").PrivKeyError;
 const Key = @import("key.zig");
 const Protocol = @import("protocol.zig");
 const Channel = @import("channel.zig").Channel;
+const ChannelControl = @import("channel.zig").ChannelControl;
+const MaxChannels = @import("channel.zig").MaxChannels;
 const ChannelTable = @import("channel.zig").ChannelTable;
 const ChannelState = @import("channel.zig").ChannelState;
 const ChannelType = @import("channel.zig").ChannelType;
@@ -402,14 +404,32 @@ pub const Session = struct {
         const chan = ch.?;
         self.active_channel_id = chan.local_id;
 
+        if ((chan.close_received or chan.close_pending) and chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+        }
+        const can_send_data = switch (chan.state) {
+            .Data, .DataRx, .DataTx, .DataTxComplete => true,
+            else => false,
+        };
+        if (can_send_data and !chan.eof_sent and !chan.close_sent and !chan.close_pending and !chan.close_received and
+            chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0 and chan.peer_window > 0)
+        {
+            _ = try self.startChannelWrite(chan, misshod, outkeys);
+            return;
+        }
+        if (chan.write_buf_nbytes == 0 and chan.tx_in_flight_len == 0 and chan.control_in_flight == null) {
+            if (try self.startPendingChannelControl(chan, misshod, outkeys)) return;
+        }
+
         switch (chan.state) {
             .OpenWrite => {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
                 try pkt.writeU32LenString(chan.channel_type.name());
                 try pkt.writeU32(chan.local_id);
-                try pkt.writeU32(Protocol.MaxPayload);
-                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
                 if (chan.channel_type.hasTcpipOpenPayload()) {
                     try pkt.writeU32LenString(chan.tcpip_open.host);
                     try pkt.writeU32(chan.tcpip_open.port);
@@ -425,8 +445,8 @@ pub const Session = struct {
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
                 try pkt.writeU32(chan.remote_id);
                 try pkt.writeU32(chan.local_id);
-                try pkt.writeU32(Protocol.MaxPayload);
-                try pkt.writeU32(Protocol.MaxPayload);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
+                try pkt.writeU32(Protocol.MaxChannelDataLen);
                 chan.state = if (chan.channel_type == .Session) .Connected else .Data;
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
             },
@@ -453,9 +473,7 @@ pub const Session = struct {
                 chan.state = .Data;
             },
             .Data => {
-                if (chan.write_buf_nbytes > 0) {
-                    chan.state = .DataTx;
-                } else if (chan.needsWindowAdjust()) {
+                if (chan.needsWindowAdjust()) {
                     // RFC 4254 §5.2 — replenish receive window
                     var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                     try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_WINDOW_ADJUST));
@@ -476,46 +494,28 @@ pub const Session = struct {
             },
             .DataRx => {
                 self.active_channel_id = null;
-                self.setIoSessionState(.ReadPktHdr);
+                if (self.channel_table.findNextRunnable()) |next| {
+                    self.active_channel_id = next.local_id;
+                    try self.advanceChannel(misshod, outkeys);
+                } else {
+                    self.setIoSessionState(.ReadPktHdr);
+                }
             },
             .DataTx => {
-                const max_send = @min(chan.remote_max_packet_size, @as(u32, @intCast(chan.write_buf_nbytes)));
-                const send_len = @min(max_send, chan.peer_window);
-                if (send_len == 0) {
-                    chan.state = .DataRx;
-                    self.active_channel_id = null;
-                    self.setIoSessionState(.ReadPktHdr);
-                    return;
-                }
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
-                try pkt.writeU32(chan.remote_id);
-                try pkt.writeU32LenString(chan.write_buf[0..send_len]);
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
-                chan.peer_window -= @intCast(send_len);
-                chan.state = .DataTxComplete;
+                chan.state = .Data;
             },
             .DataTxComplete => {
-                chan.write_buf_nbytes = 0;
                 chan.state = .Data;
             },
             .EofWrite => {
-                // RFC 4254 §5.3 — send EOF to signal no more data from us
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF));
-                try pkt.writeU32(chan.remote_id);
-                chan.eof_sent = true;
+                chan.eof_pending = true;
                 chan.state = .DataRx;
-                self.active_channel_id = null;
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                _ = try self.startPendingChannelControl(chan, misshod, outkeys);
             },
             .CloseWrite => {
-                var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
-                try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE));
-                try pkt.writeU32(chan.remote_id);
-                chan.close_sent = true;
-                chan.state = .Closed;
-                misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+                chan.close_pending = true;
+                chan.state = .DataRx;
+                _ = try self.startPendingChannelControl(chan, misshod, outkeys);
             },
             .Closed => {
                 const local_id = chan.local_id;
@@ -536,8 +536,8 @@ pub const Session = struct {
                     try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN));
                     try pkt.writeU32LenString(Protocol.channel_type_auth_agent_openssh);
                     try pkt.writeU32(chan.local_id);
-                    try pkt.writeU32(Protocol.MaxPayload);
-                    try pkt.writeU32(Protocol.MaxPayload);
+                    try pkt.writeU32(Protocol.MaxChannelDataLen);
+                    try pkt.writeU32(Protocol.MaxChannelDataLen);
                     chan.state = .OpenSent;
                     misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .ReadPktHdr);
                 } else {
@@ -585,7 +585,7 @@ pub const Session = struct {
             return IoError.NotReady;
         }
 
-        const chan = self.channel_table.allocChannel(0, 0, 0) orelse return IoError.tooManyChannels;
+        const chan = self.channel_table.allocOutboundChannel() orelse return IoError.tooManyChannels;
         chan.channel_type = .ForwardedTcpip;
         chan.tcpip_open = .{
             .host = connected_host,
@@ -603,8 +603,8 @@ pub const Session = struct {
 
     pub fn getChannelWriteBuffer(self: *Self, channel_id: u32) MisshodError![]u8 {
         if (self.channel_table.findByLocalId(channel_id)) |chan| {
-            if (chan.eof_sent) return &.{};
-            if (chan.write_buf_nbytes > 0 and self.ioSessionState == .Idle) {
+            if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return &.{};
+            if (chan.write_buf_nbytes > 0) {
                 return &.{};
             } else {
                 return &chan.write_buf;
@@ -615,13 +615,13 @@ pub const Session = struct {
 
     pub fn channelWriteComplete(self: *Self, channel_id: u32, nbytes: usize) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
+        if (chan.write_buf_nbytes != 0 or chan.tx_in_flight_len != 0) return IoError.UnexpectedResponse;
         chan.write_buf_nbytes = nbytes;
         self.active_channel_id = channel_id;
-        chan.state = .Data;
         self.setSessionState(.ChannelActive);
         self.setIoSessionState(.Idle);
     }
@@ -629,46 +629,186 @@ pub const Session = struct {
     // Full-duplex: build and send channel data packet directly without going through state machine
     pub fn directChannelWrite(self: *Self, channel_id: u32, nbytes: usize, misshod: *MisshodServer) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending or chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
         if (nbytes > chan.write_buf.len) {
             return IoError.tooBig;
         }
+        if (chan.write_buf_nbytes != 0 or chan.tx_in_flight_len != 0) return IoError.UnexpectedResponse;
         chan.write_buf_nbytes = nbytes;
-        const outkeys = &self.keydata.s2c;
+        _ = try self.startChannelWrite(chan, misshod, &self.keydata.s2c);
+    }
+
+    fn startChannelWrite(
+        self: *Self,
+        chan: *Channel,
+        misshod: *MisshodServer,
+        outkeys: *Protocol.KeyDataUni,
+    ) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or !chan.remote_id_known or chan.close_pending or
+            chan.tx_in_flight_len != 0 or chan.write_buf_nbytes == 0)
+        {
+            return false;
+        }
         const max_send = @min(chan.remote_max_packet_size, @as(u32, @intCast(chan.write_buf_nbytes)));
         const send_len = @min(max_send, chan.peer_window);
-        if (send_len == 0) {
-            return;
-        }
+        if (send_len == 0) return false;
         var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
         try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA));
         try pkt.writeU32(chan.remote_id);
         try pkt.writeU32LenString(chan.write_buf[0..send_len]);
-        misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
+        misshod.requestWrite(
+            try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr),
+            .{ .ChannelWriteComplete = chan.local_id },
+        );
         chan.peer_window -= @intCast(send_len);
-        chan.write_buf_nbytes = 0;
+        chan.tx_in_flight_len = send_len;
+        return true;
     }
 
-    pub fn sendChannelEof(self: *Self, channel_id: u32) MisshodError!void {
+    pub fn completeChannelWrite(self: *Self, channel_id: u32, misshod: *MisshodServer) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.eof_sent) return;
-        chan.state = .EofWrite;
-        self.active_channel_id = channel_id;
-        self.setSessionState(.ChannelActive);
-        self.setIoSessionState(.Idle);
+        if (chan.tx_in_flight_len == 0) return IoError.UnexpectedResponse;
+        chan.consumeWriteBuffer(chan.tx_in_flight_len);
+        chan.tx_in_flight_len = 0;
+        if (chan.close_received) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+            _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        const received_packet_pending = switch (self.ioSessionState) {
+            .ReadPktCompletion => true,
+            else => false,
+        };
+        if (received_packet_pending) return;
+        if (chan.close_pending) {
+            chan.discardWriteBuffer();
+            chan.eof_pending = false;
+            const queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c);
+            if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        var queued = false;
+        if (chan.write_buf_nbytes > 0) {
+            queued = try self.startChannelWrite(chan, misshod, &self.keydata.s2c);
+        } else {
+            queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c);
+        }
+        if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
     }
 
-    pub fn sendChannelClose(self: *Self, channel_id: u32) MisshodError!void {
+    fn startPendingChannelControl(
+        self: *Self,
+        chan: *Channel,
+        misshod: *MisshodServer,
+        outkeys: *Protocol.KeyDataUni,
+    ) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or !chan.remote_id_known or
+            misshod.iostate_wr != .Idle or chan.write_buf_nbytes != 0 or
+            chan.tx_in_flight_len != 0 or chan.control_in_flight != null)
+        {
+            return false;
+        }
+        const control: ChannelControl = if (chan.close_received and !chan.close_sent)
+            .Close
+        else if (chan.close_pending and !chan.close_sent)
+            .Close
+        else if (chan.eof_pending and !chan.eof_sent)
+            .Eof
+        else
+            return false;
+
+        var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
+        try pkt.writeU8(@intFromEnum(switch (control) {
+            .Eof => Protocol.MsgId.SSH_MSG_CHANNEL_EOF,
+            .Close => Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE,
+        }));
+        try pkt.writeU32(chan.remote_id);
+        misshod.requestWrite(
+            try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr),
+            .{ .ChannelControlComplete = chan.local_id },
+        );
+        chan.control_in_flight = control;
+        switch (control) {
+            .Eof => {
+                chan.eof_pending = false;
+                chan.eof_sent = true;
+            },
+            .Close => {
+                chan.close_pending = false;
+                chan.close_sent = true;
+                chan.eof_pending = false;
+            },
+        }
+        return true;
+    }
+
+    pub fn dispatchDeferredChannelWrite(self: *Self, misshod: *MisshodServer) MisshodError!bool {
+        if (self.sessionState != .ChannelActive or self.is_rekeying or misshod.iostate_wr != .Idle) return false;
+        for (0..MaxChannels) |_| {
+            const chan = self.channel_table.findNextDeferredWrite() orelse return false;
+            if ((chan.close_received or chan.close_pending) and chan.tx_in_flight_len == 0) {
+                chan.discardWriteBuffer();
+                chan.eof_pending = false;
+            }
+            if (!chan.eof_sent and !chan.close_sent and !chan.close_pending and !chan.close_received and
+                chan.write_buf_nbytes > 0 and chan.tx_in_flight_len == 0 and chan.peer_window > 0)
+            {
+                return try self.startChannelWrite(chan, misshod, &self.keydata.s2c);
+            }
+            if (chan.write_buf_nbytes == 0 and chan.tx_in_flight_len == 0) {
+                if (try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c)) return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn completeChannelControl(self: *Self, channel_id: u32, misshod: *MisshodServer) MisshodError!void {
         const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
-        if (chan.close_sent) return;
-        chan.state = .CloseWrite;
-        self.active_channel_id = channel_id;
-        self.setSessionState(.ChannelActive);
-        self.setIoSessionState(.Idle);
+        const control = chan.control_in_flight orelse return IoError.UnexpectedResponse;
+        chan.control_in_flight = null;
+        if (control == .Close) {
+            if (chan.close_received) {
+                chan.state = .Closed;
+                self.active_channel_id = chan.local_id;
+                self.setSessionState(.ChannelActive);
+            }
+            const received_packet_pending = switch (self.ioSessionState) {
+                .ReadPktCompletion => true,
+                else => false,
+            };
+            if (!received_packet_pending) _ = try self.dispatchDeferredChannelWrite(misshod);
+            return;
+        }
+        const received_packet_pending = switch (self.ioSessionState) {
+            .ReadPktCompletion => true,
+            else => false,
+        };
+        if (!received_packet_pending) {
+            const queued = try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c);
+            if (!queued) _ = try self.dispatchDeferredChannelWrite(misshod);
+        }
+    }
+
+    pub fn sendChannelEof(self: *Self, channel_id: u32, misshod: *MisshodServer) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.eof_sent or chan.eof_pending) return;
+        if (chan.close_sent or chan.close_pending or chan.close_received) return IoError.UnexpectedResponse;
+        chan.eof_pending = true;
+        _ = try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c);
+    }
+
+    pub fn sendChannelClose(self: *Self, channel_id: u32, misshod: *MisshodServer) MisshodError!void {
+        const chan = self.channel_table.findByLocalId(channel_id) orelse return IoError.UnexpectedResponse;
+        if (chan.close_sent or chan.close_pending) return;
+        chan.close_pending = true;
+        chan.eof_pending = false;
+        if (chan.tx_in_flight_len == 0) chan.discardWriteBuffer();
+        _ = try self.startPendingChannelControl(chan, misshod, &self.keydata.s2c);
     }
 
     pub fn openAgentChannel(self: *Self) MisshodError!u32 {
-        const chan = self.channel_table.allocChannelKind(.AgentForward, 0, 0, 0) orelse return IoError.UnexpectedResponse;
+        const chan = self.channel_table.allocOutboundChannelKind(.AgentForward) orelse return IoError.UnexpectedResponse;
         chan.state = .Open;
         self.active_channel_id = chan.local_id;
         self.setSessionState(.ChannelActive);
@@ -935,6 +1075,7 @@ pub const Session = struct {
             if (chan.kind == .AgentForward) {
                 if (chan.state != .OpenSent) return IoError.UnexpectedResponse;
                 chan.remote_id = sender;
+                chan.remote_id_known = true;
                 chan.peer_window = peer_window;
                 chan.remote_max_packet_size = max_packet_size;
                 chan.state = .Data;
@@ -945,6 +1086,7 @@ pub const Session = struct {
             }
 
             chan.remote_id = sender;
+            chan.remote_id_known = true;
             chan.peer_window = peer_window;
             chan.remote_max_packet_size = max_packet_size;
             chan.state = .Data;
@@ -1378,6 +1520,12 @@ pub const Session = struct {
                 const channelnum = try rdr.readU32();
                 if (self.channel_table.findByLocalId(channelnum)) |chan| {
                     chan.eof_received = true;
+                    if (chan.write_buf_nbytes > 0 or chan.eof_pending or chan.close_pending) {
+                        self.active_channel_id = chan.local_id;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
+                        return;
+                    }
                 }
                 self.setIoSessionState(.ReadPktHdr);
             },
@@ -1388,6 +1536,8 @@ pub const Session = struct {
                     return;
                 };
                 chan.close_received = true;
+                chan.discardWriteBuffer();
+                chan.eof_pending = false;
                 if (chan.close_sent) {
                     if (chan.kind == .AgentForward) {
                         self.active_channel_id = chan.local_id;
@@ -1405,7 +1555,8 @@ pub const Session = struct {
                     }
                 } else {
                     self.active_channel_id = chan.local_id;
-                    chan.state = .CloseWrite;
+                    chan.close_pending = true;
+                    chan.state = .DataRx;
                     self.setSessionState(.ChannelActive);
                     self.setIoSessionState(.Idle);
                 }
@@ -1432,6 +1583,12 @@ pub const Session = struct {
                 if (self.channel_table.findByLocalId(channelnum)) |chan| {
                     const bytes_to_add = try rdr.readU32();
                     chan.peer_window +|= bytes_to_add;
+                    if (chan.write_buf_nbytes > 0) {
+                        self.active_channel_id = chan.local_id;
+                        self.setSessionState(.ChannelActive);
+                        self.setIoSessionState(.Idle);
+                        return;
+                    }
                 } else {
                     _ = try rdr.readU32();
                 }
@@ -1479,6 +1636,35 @@ fn decryptFirstBlockForTest(packet: []u8, keys: *Protocol.KeyDataUni) void {
     @memcpy(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
     keys.aesctr.encrypt(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
     keys.seq +%= 1;
+}
+
+fn consumeProducedChannelDataForTest(m: *MisshodServer, destination: []u8, offset: usize) !usize {
+    const packet = try m.peek(Protocol.MaxSSHPacket);
+    var rdr = BufferReader.init(unencryptedPayload(packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_DATA), try rdr.readU8());
+    _ = try rdr.readU32();
+    const data = try rdr.readU32LenString();
+    @memcpy(destination[offset .. offset + data.len], data);
+    try m.consumed(packet.len);
+    return data.len;
+}
+
+fn writeKexInitPayloadForTest(writer: *BufferWriter) !void {
+    try writer.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT));
+    const cookie: [16]u8 = .{0x5a} ** 16;
+    try writer.writeBytes(&cookie);
+    try writer.writeU32LenString(Protocol.kex_algo_name);
+    try writer.writeU32LenString(Protocol.srv_hostkey_algo_name);
+    try writer.writeU32LenString(Protocol.enc_algo_name);
+    try writer.writeU32LenString(Protocol.enc_algo_name);
+    try writer.writeU32LenString(Protocol.mac_algo_name);
+    try writer.writeU32LenString(Protocol.mac_algo_name);
+    try writer.writeU32LenString(Protocol.compression_algorithms);
+    try writer.writeU32LenString(Protocol.compression_algorithms);
+    try writer.writeU32LenString("");
+    try writer.writeU32LenString("");
+    try writer.writeBoolean(false);
+    try writer.writeU32(0);
 }
 
 test "server rekey hashes retained exact client and server versions" {
@@ -1603,6 +1789,217 @@ test "server rekey activates outbound and inbound keys at NEWKEYS boundaries" {
     try std.testing.expectEqualSlices(u8, &new_c2s_key, &m.session.keydata.c2s.key);
     try std.testing.expectEqual(@as(u32, 1), m.session.keydata.c2s.seq);
     try std.testing.expect(m.session.pending_c2s_keys == null);
+}
+
+test "server rekey gates deferred channel traffic until NEWKEYS completes" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+    try m.session.setPeerProtocolVersion("SSH-2.0-test_client");
+
+    const channel_a = m.session.channel_table.allocChannel(10, 2000, 1000).?;
+    channel_a.state = .DataRx;
+    const channel_b = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    channel_b.state = .DataRx;
+    for (channel_a.write_buf[0..2000], 0..) |*byte, index| byte.* = @truncate(index);
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(channel_a.local_id, 2000);
+    try m.sendChannelEof(channel_b.local_id);
+
+    var client_payload_buf: [512]u8 = undefined;
+    var client_payload = BufferWriter.init(&client_payload_buf, 0);
+    try writeKexInitPayloadForTest(&client_payload);
+    const client_packet_len = buildUnencryptedPacket(&m.iobuf_rd, client_payload.active());
+    m.iostate_rd = .Idle;
+    m.session.setIoSessionState(.{ .ReadPktCompletion = m.iobuf_rd[0..client_packet_len] });
+
+    var first_fragment: [1000]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &first_fragment, 0);
+    try std.testing.expect(m.session.is_rekeying);
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_pending);
+
+    const server_kexinit = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_KEXINIT),
+        unencryptedPayload(server_kexinit)[0],
+    );
+    try m.consumed(server_kexinit.len);
+
+    m.iostate_rd = .Idle;
+    m.session.session_id = .{0x11} ** Protocol.hash_algo.digest_length;
+    m.session.shared_secret_k = .{0x22} ** Protocol.kex_algo.shared_length;
+    m.session.negotiated_compression_c2s = .None;
+    m.session.negotiated_compression_s2c = .None;
+    try m.session.installExchangeKeys(.{0x33} ** Protocol.hash_algo.digest_length);
+    const new_s2c_key = m.session.pending_s2c_keys.?.key;
+    m.session.setSessionState(.NewKeysWrite);
+    m.session.setIoSessionState(.Idle);
+    try m.session.advanceSession(&m);
+
+    const newkeys = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqual(
+        @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS),
+        unencryptedPayload(newkeys)[0],
+    );
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_pending);
+    try m.consumed(newkeys.len);
+    try std.testing.expectEqual(SessionState.NewKeysRead, m.session.sessionState);
+    try std.testing.expectEqual(@as(usize, 0), channel_a.tx_in_flight_len);
+
+    try m.session.activatePendingC2sKeys();
+    m.session.is_rekeying = false;
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.Idle);
+    m.iostate_rd = .Idle;
+    try m.advance();
+    try m.advance();
+
+    try std.testing.expectEqualSlices(u8, &new_s2c_key, &m.session.keydata.s2c.key);
+    var resumed_data = try m.peek(Protocol.MaxSSHPacket);
+    if (channel_a.tx_in_flight_len == 0) {
+        try std.testing.expectEqual(ChannelControl.Eof, channel_b.control_in_flight.?);
+        try m.consumed(resumed_data.len);
+        resumed_data = try m.peek(Protocol.MaxSSHPacket);
+    }
+    try std.testing.expectEqual(@as(usize, 1000), channel_a.tx_in_flight_len);
+    try m.consumed(resumed_data.len);
+    try std.testing.expectEqual(@as(usize, 0), channel_a.write_buf_nbytes);
+    try std.testing.expect(channel_b.eof_sent);
+}
+
+test "server channel write retains suffix across peer packet limit" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(77, 2500, 1000).?;
+    chan.state = .DataRx;
+    const total_len: usize = 2500;
+    for (chan.write_buf[0..total_len], 0..) |*byte, index| byte.* = @truncate(index);
+    try m.session.channelWriteComplete(chan.local_id, total_len);
+    try m.advance();
+    try m.advance();
+    try std.testing.expectEqual(ChannelState.DataRx, chan.state);
+    try std.testing.expectEqual(@as(usize, total_len), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(usize, 1000), chan.tx_in_flight_len);
+    try std.testing.expectEqual(@as(usize, 0), (try m.getChannelWriteBuffer(chan.local_id)).len);
+    try std.testing.expectError(IoError.cannotAcceptWrite, m.channelWriteComplete(chan.local_id, 1));
+    try m.sendChannelEof(chan.local_id);
+    try std.testing.expect(chan.eof_pending);
+
+    var received: [total_len]u8 = undefined;
+    var received_len: usize = 0;
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+    try std.testing.expectEqual(@as(usize, 1500), chan.write_buf_nbytes);
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+    try std.testing.expectEqual(@as(usize, 500), chan.write_buf_nbytes);
+    received_len += try consumeProducedChannelDataForTest(&m, &received, received_len);
+
+    try std.testing.expectEqual(total_len, received_len);
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(u32, 0), chan.peer_window);
+    for (received, 0..) |byte, index| try std.testing.expectEqual(@as(u8, @truncate(index)), byte);
+
+    const eof_packet = try m.peek(Protocol.MaxSSHPacket);
+    var eof_reader = BufferReader.init(unencryptedPayload(eof_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF), try eof_reader.readU8());
+    try m.consumed(eof_packet.len);
+    try std.testing.expect(chan.eof_sent);
+    try std.testing.expect(chan.control_in_flight == null);
+    try std.testing.expectEqual(@as(usize, 0), chan.tx_in_flight_len);
+}
+
+test "server local close discards window-blocked suffix after in-flight fragment" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const chan = m.session.channel_table.allocChannel(77, 1000, 1000).?;
+    chan.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    for (chan.write_buf[0..2000], 0..) |*byte, index| byte.* = @truncate(index);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(chan.local_id, 2000);
+    try m.sendChannelClose(chan.local_id);
+    try std.testing.expect(chan.close_pending);
+    try std.testing.expectEqual(@as(u32, 0), chan.peer_window);
+
+    var first_fragment: [1000]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &first_fragment, 0);
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(chan.remote_id, try close_reader.readU32());
+    try std.testing.expectEqual(@as(usize, 0), chan.write_buf_nbytes);
+    try std.testing.expectEqual(@as(usize, 0), chan.tx_in_flight_len);
+    try std.testing.expectEqual(ChannelControl.Close, chan.control_in_flight.?);
+}
+
+test "server completion schedules pending control on another channel" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const channel_a = m.session.channel_table.allocChannel(10, 1000, 1000).?;
+    channel_a.state = .DataRx;
+    const channel_b = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    channel_b.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    const data_len: usize = 100;
+    for (channel_a.write_buf[0..data_len], 0..) |*byte, index| byte.* = @truncate(index);
+
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+    try m.channelWriteComplete(channel_a.local_id, data_len);
+    try m.sendChannelClose(channel_b.local_id);
+    try std.testing.expect(channel_b.close_pending);
+
+    var received: [data_len]u8 = undefined;
+    _ = try consumeProducedChannelDataForTest(&m, &received, 0);
+    try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+    try std.testing.expect(m.iostate_rd != .Idle);
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(channel_b.remote_id, try close_reader.readU32());
+}
+
+test "server close completion dispatches next channel control during active read" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const first = m.session.channel_table.allocChannel(10, 1000, 1000).?;
+    first.state = .DataRx;
+    const second = m.session.channel_table.allocChannel(20, 1000, 1000).?;
+    second.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    m.session.setIoSessionState(.ReadPktHdr);
+    m.requestRead(0, 1, .ReadPktHdr);
+
+    try m.sendChannelClose(first.local_id);
+    try m.sendChannelEof(second.local_id);
+    try std.testing.expectEqual(ChannelControl.Close, first.control_in_flight.?);
+    try std.testing.expect(second.eof_pending);
+
+    const first_close = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(first_close));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try m.consumed(first_close.len);
+
+    try std.testing.expectEqual(Protocol.IoSessionState.ReadPktHdr, m.session.ioSessionState);
+    try std.testing.expect(m.iostate_rd != .Idle);
+    const second_eof = try m.peek(Protocol.MaxSSHPacket);
+    var eof_reader = BufferReader.init(unencryptedPayload(second_eof));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_EOF), try eof_reader.readU8());
+    try std.testing.expectEqual(second.remote_id, try eof_reader.readU32());
 }
 
 test "handlePacket: direct-tcpip open emits request and accept confirms" {
@@ -1840,12 +2237,62 @@ test "openForwardedTcpipChannel writes forwarded-tcpip open payload" {
     try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try rdr.readU8());
     try std.testing.expectEqualStrings("forwarded-tcpip", try rdr.readU32LenString());
     try std.testing.expectEqual(channel_id, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
-    try std.testing.expectEqual(Protocol.MaxPayload, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
+    try std.testing.expectEqual(Protocol.MaxChannelDataLen, try rdr.readU32());
     try std.testing.expectEqualStrings("127.0.0.1", try rdr.readU32LenString());
     try std.testing.expectEqual(@as(u32, 2200), try rdr.readU32());
     try std.testing.expectEqualStrings("203.0.113.10", try rdr.readU32LenString());
     try std.testing.expectEqual(@as(u32, 44444), try rdr.readU32());
+}
+
+test "unconfirmed server channel defers close until remote id is known" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const existing = m.session.channel_table.allocChannel(0, 1000, 1000).?;
+    existing.state = .DataRx;
+    m.session.setSessionState(.ChannelActive);
+    const channel_id = try m.openForwardedTcpipChannel("127.0.0.1", 2200, "203.0.113.10", 44444);
+    const pending = m.session.channel_table.findByLocalId(channel_id).?;
+    try std.testing.expect(!pending.remote_id_known);
+
+    try m.sendChannelClose(channel_id);
+    try std.testing.expect(pending.close_pending);
+    try std.testing.expect(pending.control_in_flight == null);
+
+    const open_packet = try m.peek(Protocol.MaxSSHPacket);
+    var open_reader = BufferReader.init(unencryptedPayload(open_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN), try open_reader.readU8());
+    try m.consumed(open_packet.len);
+    try std.testing.expect(!pending.remote_id_known);
+    try std.testing.expect(pending.control_in_flight == null);
+
+    var confirmation_payload_buf: [32]u8 = undefined;
+    var confirmation = BufferWriter.init(&confirmation_payload_buf, 0);
+    try confirmation.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_OPEN_CONFIRMATION));
+    try confirmation.writeU32(channel_id);
+    try confirmation.writeU32(88);
+    try confirmation.writeU32(1000);
+    try confirmation.writeU32(1000);
+    const confirmation_len = buildUnencryptedPacket(&m.iobuf_rd, confirmation.active());
+    m.iostate_rd = .Idle;
+    try m.session.handlePacket(m.iobuf_rd[0..confirmation_len], &m);
+    const opened = try m.getNextEvent();
+    switch (opened) {
+        .Event => |event| switch (event) {
+            .ChannelOpened => |opened_id| try std.testing.expectEqual(channel_id, opened_id),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try m.clearEvent(.{ .ChannelOpened = channel_id });
+
+    const close_packet = try m.peek(Protocol.MaxSSHPacket);
+    var close_reader = BufferReader.init(unencryptedPayload(close_packet));
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_CHANNEL_CLOSE), try close_reader.readU8());
+    try std.testing.expectEqual(@as(u32, 88), try close_reader.readU32());
+    try std.testing.expect(pending.remote_id_known);
 }
 
 test "handlePacket: auth-agent request surfaces channel request event" {

--- a/src/server_session.zig
+++ b/src/server_session.zig
@@ -68,11 +68,19 @@ pub const Session = struct {
     keydata: Protocol.KeyDataBi,
     rand: std.Random = undefined,
     encrypted: bool,
+    inbound_encrypted: bool,
     channel_table: ChannelTable,
     active_channel_id: ?u32,
     pending_global_request: ?PendingGlobalRequest,
     pending_global_request_bind_address: [Protocol.MaxSSHPacket]u8 = undefined,
     is_rekeying: bool,
+    pending_c2s_keys: ?Protocol.KeyDataUni,
+    pending_s2c_keys: ?Protocol.KeyDataUni,
+    negotiated_compression_c2s: Protocol.CompressionAlgorithm,
+    negotiated_compression_s2c: Protocol.CompressionAlgorithm,
+    client_version: ?[]u8,
+    server_version: ?[]u8,
+    pre_identification_lines: usize,
 
     privkey_ascii: ?[]u8, // allocated
     privkey_passphrase: ?[]u8, //allocated
@@ -91,6 +99,7 @@ pub const Session = struct {
             .rand = rand,
             .allocator = allocator,
             .encrypted = false,
+            .inbound_encrypted = false,
             .keydata = Protocol.KeyDataBi.init(),
             .kex_hasher = Hasher(Protocol.hash_algo).init(), // for hashing H
             .selected_hostkey_algorithm = null,
@@ -104,9 +113,18 @@ pub const Session = struct {
             .active_channel_id = null,
             .pending_global_request = null,
             .is_rekeying = false,
+            .pending_c2s_keys = null,
+            .pending_s2c_keys = null,
+            .negotiated_compression_c2s = .None,
+            .negotiated_compression_s2c = .None,
+            .client_version = null,
+            .server_version = null,
+            .pre_identification_lines = 0,
         };
 
         s.host_private_key = try decodeOpenSshPrivateKey(hostkey_ascii, null);
+        errdefer s.host_private_key.clear();
+        s.server_version = try allocator.dupe(u8, Protocol.version);
 
         return s;
     }
@@ -115,6 +133,9 @@ pub const Session = struct {
         self.clearAndFreeOptional(&self.privkey_ascii);
         self.clearAndFreeOptional(&self.privkey_passphrase);
         self.clearAndFreeOptional(&self.auth_passphrase);
+        self.clearAndFreeOptional(&self.client_version);
+        self.clearAndFreeOptional(&self.server_version);
+        self.clearPendingKeys();
         std.crypto.secureZero(u8, &self.shared_secret_k);
         std.crypto.secureZero(u8, &self.session_id);
         self.host_private_key.clear();
@@ -141,6 +162,63 @@ pub const Session = struct {
     pub fn setSessionState(self: *Self, newState: SessionState) void {
         TRACE(.Debug, "sessionState {any} -> {any}", .{ self.sessionState, newState });
         self.sessionState = newState;
+    }
+
+    pub fn setPeerProtocolVersion(self: *Self, version: []const u8) MisshodError!void {
+        self.clearAndFreeOptional(&self.client_version);
+        self.client_version = try self.allocator.dupe(u8, version);
+    }
+
+    fn resetKexHasherForRekey(self: *Self) void {
+        self.kex_hasher = Hasher(Protocol.hash_algo).init();
+        self.kex_hash_order = .Init;
+        self.kex_hash_order = self.kex_hash_order.check(.V_C);
+        self.kex_hasher.writeU32LenString(self.client_version.?);
+        self.kex_hash_order = self.kex_hash_order.check(.V_S);
+        self.kex_hasher.writeU32LenString(self.server_version.?);
+    }
+
+    fn clearPendingKeys(self: *Self) void {
+        if (self.pending_c2s_keys) |*keys| keys.clear();
+        if (self.pending_s2c_keys) |*keys| keys.clear();
+        self.pending_c2s_keys = null;
+        self.pending_s2c_keys = null;
+    }
+
+    fn installExchangeKeys(self: *Self, kexhash: [Protocol.hash_algo.digest_length]u8) MisshodError!void {
+        if (!self.is_rekeying) @memcpy(&self.session_id, &kexhash);
+        self.clearPendingKeys();
+        var pending = Protocol.KeyDataBi.init();
+        defer pending.clear();
+        try pending.genKeys(kexhash, self.shared_secret_k, self.session_id);
+        pending.c2s.compression.queueAlgorithm(self.negotiated_compression_c2s);
+        pending.s2c.compression.queueAlgorithm(self.negotiated_compression_s2c);
+        self.pending_c2s_keys = pending.c2s;
+        self.pending_s2c_keys = pending.s2c;
+        pending.c2s = .{ .seq = 0 };
+        pending.s2c = .{ .seq = 0 };
+    }
+
+    fn activatePendingC2sKeys(self: *Self) MisshodError!void {
+        var next = self.pending_c2s_keys orelse return IoError.UnexpectedResponse;
+        self.pending_c2s_keys = null;
+        next.seq = self.keydata.c2s.seq;
+        next.compression.applyPendingAlgorithm();
+        if (self.is_rekeying) try next.compression.activateInflate();
+        self.keydata.c2s.clear();
+        self.keydata.c2s = next;
+        self.inbound_encrypted = true;
+    }
+
+    fn activatePendingS2cKeys(self: *Self) MisshodError!void {
+        var next = self.pending_s2c_keys orelse return IoError.UnexpectedResponse;
+        self.pending_s2c_keys = null;
+        next.seq = self.keydata.s2c.seq;
+        next.compression.applyPendingAlgorithm();
+        if (self.is_rekeying) try next.compression.activateDeflate();
+        self.keydata.s2c.clear();
+        self.keydata.s2c = next;
+        self.encrypted = true;
     }
 
     pub fn grantAccess(self: *Self, allow: bool) MisshodError!void {
@@ -240,15 +318,12 @@ pub const Session = struct {
                 self.kex_hasher.final(&kexhash, null);
                 TRACEDUMP(.Debug, "kexhash: (len={d})", .{kexhash.len}, &kexhash);
 
-                @memcpy(&self.session_id, &kexhash); // store as session_id
-
                 const sig_alg = self.selected_hostkey_algorithm orelse self.host_private_key.defaultSignatureAlgorithm();
                 var typed_sig: Key.SignatureBlob = .{};
                 const sig = try self.host_private_key.sign(sig_alg, &kexhash, &typed_sig);
                 try pkt.writeU32LenString(sig);
 
-                // generate keys
-                try self.keydata.genKeys(kexhash, self.shared_secret_k, self.session_id);
+                try self.installExchangeKeys(kexhash);
 
                 misshod.requestWrite(try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr), .Idle);
 
@@ -259,11 +334,8 @@ pub const Session = struct {
                 var pkt = BufferWriter.init(&misshod.iobuf_wr, Protocol.sizeof_PktHdr);
                 try pkt.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
                 const wrapped = try Protocol.wrapPkt(&self.rand, self.encrypted, outkeys, &pkt, &misshod.iobuf_wr);
-                self.keydata.s2c.compression.applyPendingAlgorithm();
-                if (self.is_rekeying) {
-                    try self.keydata.s2c.compression.activateDeflate();
-                }
                 misshod.requestWrite(wrapped, .Idle);
+                try self.activatePendingS2cKeys();
                 self.setSessionState(.NewKeysRead);
             },
             .NewKeysRead => {
@@ -636,10 +708,11 @@ pub const Session = struct {
 
     // special case as we write direct to stream before entering binary pkt mode
     pub fn writeProtocolVersion(self: *Self, buf: []u8) []const u8 {
-        const vers = std.fmt.bufPrint(buf, "{s}\r\n", .{Protocol.version}) catch unreachable;
-        TRACE(.Debug, "TX: version '{s}'", .{Protocol.version});
+        const server_version = self.server_version.?;
+        const vers = std.fmt.bufPrint(buf, "{s}\r\n", .{server_version}) catch unreachable;
+        TRACE(.Debug, "TX: version '{s}'", .{server_version});
         self.kex_hash_order = self.kex_hash_order.check(.V_S);
-        self.kex_hasher.writeU32LenString(Protocol.version);
+        self.kex_hasher.writeU32LenString(server_version);
         return vers;
     }
 
@@ -930,12 +1003,7 @@ pub const Session = struct {
                         return;
                     }
                     TRACE(.Info, "Re-keying initiated by peer", .{});
-                    self.kex_hasher = Hasher(Protocol.hash_algo).init();
-                    self.kex_hash_order = .Init;
-                    self.kex_hash_order = self.kex_hash_order.check(.V_C);
-                    self.kex_hasher.writeU32LenString(Protocol.version);
-                    self.kex_hash_order = self.kex_hash_order.check(.V_S);
-                    self.kex_hasher.writeU32LenString(Protocol.version);
+                    self.resetKexHasherForRekey();
                     self.is_rekeying = true;
                 }
 
@@ -983,8 +1051,8 @@ pub const Session = struct {
                     TRACE(.Info, "No mutual algorithm for compression_algorithms_server_to_client: peer offers '{s}', we can use '{s}'", .{ compression_s2c_namelist, Protocol.compression_algorithms });
                     return IoError.AlgorithmNegotiationFailed;
                 };
-                self.keydata.c2s.compression.queueAlgorithm(compression_c2s);
-                self.keydata.s2c.compression.queueAlgorithm(compression_s2c);
+                self.negotiated_compression_c2s = compression_c2s;
+                self.negotiated_compression_s2c = compression_s2c;
 
                 _ = try rdr.readU32LenString(); // language c2s
                 _ = try rdr.readU32LenString(); // language s2c
@@ -1020,11 +1088,7 @@ pub const Session = struct {
             },
             @intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS) => {
                 if (self.sessionState == .NewKeysRead) {
-                    self.keydata.c2s.compression.applyPendingAlgorithm();
-                    if (self.is_rekeying) {
-                        try self.keydata.c2s.compression.activateInflate();
-                    }
-                    self.encrypted = true;
+                    try self.activatePendingC2sKeys();
                     if (self.is_rekeying) {
                         self.is_rekeying = false;
                         self.setSessionState(.ChannelActive);
@@ -1408,6 +1472,137 @@ fn unencryptedPayload(packet: []const u8) []const u8 {
     const hdr = Protocol.readPktHdr(packet[0..Protocol.sizeof_PktHdr]);
     const payload_len = hdr.packet_length - hdr.padding_length - 1;
     return packet[Protocol.sizeof_PktHdr .. Protocol.sizeof_PktHdr + payload_len];
+}
+
+fn decryptFirstBlockForTest(packet: []u8, keys: *Protocol.KeyDataUni) void {
+    var encrypted_block: [Protocol.AesCtrT.block_size]u8 = undefined;
+    @memcpy(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
+    keys.aesctr.encrypt(&encrypted_block, packet[0..Protocol.AesCtrT.block_size]);
+    keys.seq +%= 1;
+}
+
+test "server rekey hashes retained exact client and server versions" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer session.deinit();
+
+    try session.setPeerProtocolVersion("SSH-2.0-exact_client comment");
+    session.clearAndFreeOptional(&session.server_version);
+    session.server_version = try std.testing.allocator.dupe(u8, "SSH-2.0-exact_server comment");
+    session.resetKexHasherForRekey();
+
+    var expected_hasher = Hasher(Protocol.hash_algo).init();
+    expected_hasher.writeU32LenString("SSH-2.0-exact_client comment");
+    expected_hasher.writeU32LenString("SSH-2.0-exact_server comment");
+    var expected: [Protocol.hash_algo.digest_length]u8 = undefined;
+    expected_hasher.final(&expected, null);
+    var actual: [Protocol.hash_algo.digest_length]u8 = undefined;
+    session.kex_hasher.final(&actual, null);
+
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+}
+
+test "server rekey preserves initial session id for key derivation" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var session = try Session.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer session.deinit();
+
+    const original_session_id: [Protocol.hash_algo.digest_length]u8 = .{0x11} ** Protocol.hash_algo.digest_length;
+    const rekey_hash: [Protocol.hash_algo.digest_length]u8 = .{0x33} ** Protocol.hash_algo.digest_length;
+    const rekey_secret: [Protocol.kex_algo.shared_length]u8 = .{0x22} ** Protocol.kex_algo.shared_length;
+    session.session_id = original_session_id;
+    session.shared_secret_k = rekey_secret;
+    session.is_rekeying = true;
+
+    var expected = Protocol.KeyDataBi.init();
+    defer expected.clear();
+    try expected.genKeys(rekey_hash, rekey_secret, original_session_id);
+    var wrong = Protocol.KeyDataBi.init();
+    defer wrong.clear();
+    try wrong.genKeys(rekey_hash, rekey_secret, rekey_hash);
+
+    try session.installExchangeKeys(rekey_hash);
+
+    const pending_c2s = &session.pending_c2s_keys.?;
+    const pending_s2c = &session.pending_s2c_keys.?;
+    try std.testing.expectEqualSlices(u8, &original_session_id, &session.session_id);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.iv, &pending_c2s.iv);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.key, &pending_c2s.key);
+    try std.testing.expectEqualSlices(u8, &expected.c2s.mackey, &pending_c2s.mackey);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.iv, &pending_s2c.iv);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.key, &pending_s2c.key);
+    try std.testing.expectEqualSlices(u8, &expected.s2c.mackey, &pending_s2c.mackey);
+    try std.testing.expect(!std.mem.eql(u8, &wrong.c2s.key, &pending_c2s.key));
+}
+
+test "server rekey activates outbound and inbound keys at NEWKEYS boundaries" {
+    var prng = std.Random.DefaultPrng.init(42);
+    var m = try MisshodServer.init(prng.random(), @import("privkey.zig").testkey_valid, std.testing.allocator);
+    defer m.deinit();
+
+    const session_id: [Protocol.hash_algo.digest_length]u8 = .{0x10} ** Protocol.hash_algo.digest_length;
+    const old_hash: [Protocol.hash_algo.digest_length]u8 = .{0x20} ** Protocol.hash_algo.digest_length;
+    const old_secret: [Protocol.kex_algo.shared_length]u8 = .{0x30} ** Protocol.kex_algo.shared_length;
+    const new_hash: [Protocol.hash_algo.digest_length]u8 = .{0x40} ** Protocol.hash_algo.digest_length;
+    const new_secret: [Protocol.kex_algo.shared_length]u8 = .{0x50} ** Protocol.kex_algo.shared_length;
+    m.session.session_id = session_id;
+    try m.session.keydata.genKeys(old_hash, old_secret, session_id);
+    m.session.encrypted = true;
+    m.session.inbound_encrypted = true;
+    m.session.is_rekeying = true;
+    m.session.shared_secret_k = new_secret;
+    try m.session.installExchangeKeys(new_hash);
+
+    var old_c2s = m.session.keydata.c2s;
+    defer old_c2s.clear();
+    var old_s2c = m.session.keydata.s2c;
+    const new_c2s_key = m.session.pending_c2s_keys.?.key;
+    const new_s2c_key = m.session.pending_s2c_keys.?.key;
+
+    m.session.setSessionState(.NewKeysWrite);
+    try m.session.advanceSession(&m);
+    const server_newkeys = try m.peek(Protocol.MaxSSHPacket);
+    try std.testing.expectEqualSlices(u8, &new_s2c_key, &m.session.keydata.s2c.key);
+    try std.testing.expectEqual(@as(u32, 1), m.session.keydata.s2c.seq);
+    try std.testing.expectEqualSlices(u8, &old_c2s.key, &m.session.keydata.c2s.key);
+    try std.testing.expect(m.session.pending_s2c_keys == null);
+    try std.testing.expect(m.session.pending_c2s_keys != null);
+
+    var verifier_prng = std.Random.DefaultPrng.init(7);
+    var verifier = try Misshod.MisshodClient.init(verifier_prng.random(), "testuser", std.testing.allocator);
+    defer verifier.deinit();
+    verifier.session.keydata.s2c.clear();
+    verifier.session.keydata.s2c = old_s2c;
+    old_s2c = .{ .seq = 0 };
+    verifier.session.inbound_encrypted = true;
+    @memcpy(verifier.iobuf_rd[0..server_newkeys.len], server_newkeys);
+    decryptFirstBlockForTest(verifier.iobuf_rd[0..server_newkeys.len], &verifier.session.keydata.s2c);
+    var server_rdr = try verifier.getRecvBuffer(
+        verifier.iobuf_rd[0..server_newkeys.len],
+        &verifier.session.keydata.s2c,
+    );
+    try std.testing.expectEqual(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS), try server_rdr.readU8());
+
+    var client_packet_buf: [Protocol.MaxSSHPacket]u8 = undefined;
+    var client_packet = BufferWriter.init(&client_packet_buf, Protocol.sizeof_PktHdr);
+    try client_packet.writeU8(@intFromEnum(Protocol.MsgId.SSH_MSG_NEWKEYS));
+    var client_prng = std.Random.DefaultPrng.init(99);
+    var client_rand = client_prng.random();
+    const wrapped_client_newkeys = try Protocol.wrapPkt(
+        &client_rand,
+        true,
+        &old_c2s,
+        &client_packet,
+        &client_packet_buf,
+    );
+    @memcpy(m.iobuf_rd[0..wrapped_client_newkeys.len], wrapped_client_newkeys);
+    decryptFirstBlockForTest(m.iobuf_rd[0..wrapped_client_newkeys.len], &m.session.keydata.c2s);
+    m.session.setSessionState(.NewKeysRead);
+    try m.session.handlePacket(m.iobuf_rd[0..wrapped_client_newkeys.len], &m);
+
+    try std.testing.expectEqualSlices(u8, &new_c2s_key, &m.session.keydata.c2s.key);
+    try std.testing.expectEqual(@as(u32, 1), m.session.keydata.c2s.seq);
+    try std.testing.expect(m.session.pending_c2s_keys == null);
 }
 
 test "handlePacket: direct-tcpip open emits request and accept confirms" {


### PR DESCRIPTION
## Summary
- add opt-in, initial-only SSH `none` authentication with bounded staged key/password fallback
- expose value-owned authentication diagnostics and ordered authentication/identification events
- validate RFC SSH-2.0/1.99 identification, preserve exact exchange inputs, and make rekey key activation standards-compliant
- keep CLI diagnostics safe from unauthenticated terminal control data

Supports cataggar/droid#119.

## Validation
- `zig build test`
- `zig build mssh`
- `zig build msshd`
- OpenSSH interoperability, including rekey coverage